### PR TITLE
fix: add metadata to Docker image

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -51,6 +51,11 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            DOCKER_META_VERSION=${{ steps.meta.outputs.version }}
+            DOCKER_META_TITLE=${{ steps.meta.outputs.title }}
+            DOCKER_META_VERSION_SEMVER=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+            DOCKER_META_REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,21 @@
 FROM node:21-alpine AS build
 
+# These will be automatically populated by docker/metadata-action
+ARG DOCKER_META_VERSION
+ARG DOCKER_META_TITLE
+ARG DOCKER_META_VERSION_SEMVER
+ARG DOCKER_META_REVISION
+
 WORKDIR /app
 
 COPY package*.json .
 RUN npm ci
 
 COPY . .
+
+# Create version.json that will be copied to the final image
+RUN echo "{\"version\": \"${DOCKER_META_VERSION_SEMVER:-0.0.0}\", \"commitHash\": \"${DOCKER_META_REVISION:-development}\", \"buildTime\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\"}" > public/version.json
+
 RUN npx vite build && npx vite optimize
 
 FROM nginx:1.27


### PR DESCRIPTION
Adds metadata to the Docker image, including version, title, version (semver), and revision.

This information is populated automatically by the docker/metadata-action, and is used to generate a version.json file that is copied to the final image.