### PR TITLE
fix: container build tags

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
     tags:
-      - 'v*.*.*'
+      - 'r4c-cesium-viewer-v*.*.*'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Release-please is configured to create releases of the app and helm chart. This causes the tags to be prepended with the release names.