### PR TITLE
fix(release): semver tags

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
     tags:
-      - 'r4c-cesium-viewer-v*.*.*'
+      - 'v*.*.*'
 
 env:
   REGISTRY: ghcr.io

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,8 @@
   "plugins": ["node-workspace"],
   "packages": {
     ".": {
-      "release-type": "node"
+      "release-type": "node",
+      "include-component-in-tag": false
     },
     "helm":{
       "release-type": "helm"


### PR DESCRIPTION
Configured release-please to tag the application releases with a regular semver tag instead of being prefixed by the component name (r4c-cesium-viewer). This should get the image tags working again.