### PR TITLE
fix(tests): Use dev instead of preview for tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:4173',
+    baseURL: 'http://localhost:5173',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -72,8 +72,8 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run preview',
-    url: 'http://localhost:4173',
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/tests/r4c.spec.ts
+++ b/tests/r4c.spec.ts
@@ -19,16 +19,20 @@ test('Building properties', async ({ page }) => {
   await page.getByRole('button', { name: 'Close' }).click();
   await page.locator('canvas').click({
     position: {
-      x: 659,
-      y: 383
+      x: 690,
+      y: 394
     }
   });
+  // Wait until map transition is complete
+  await page.waitForTimeout(3000);
   await page.locator('canvas').click({
     position: {
-      x: 671,
+      x: 674,
       y: 363
     }
   });
+  // Wait until map transition is complete
+  await page.waitForTimeout(1000);
   await page.getByRole('button', { name: 'Building properties' }).click();
   await expect(page.locator('#printContainer')).toContainText('Talousrakennus');
   await expect(page.locator('canvas')).toBeVisible();


### PR DESCRIPTION
- Preview requires building the dist package, dev doesn't
- Added delays to the tests that click on the canvas because the transition takes a while. There's probably a better way to do this e.g. waiting for an event, but this works for now.