### PR TITLE
fix: Cesium Ion token reminder

### DIFF
--- a/src/pages/CesiumViewer.vue
+++ b/src/pages/CesiumViewer.vue
@@ -59,6 +59,7 @@ export default {
     	});
 		const viewer = ref(null);
 		const view = computed( () => store.view );
+		Cesium.Ion.defaultAccessToken = null;
 
 		const initViewer = () => {
 			viewer.value = new Cesium.Viewer('cesiumContainer', {


### PR DESCRIPTION
Setting the token to null removes the reminder at the bottom of the canvas

fixes: #40