### PR TITLE
feat: add versioning to assets for cache busting

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -57,10 +57,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            DOCKER_META_VERSION=${{ steps.meta.outputs.version }}
-            DOCKER_META_TITLE=${{ steps.meta.outputs.title }}
-            DOCKER_META_VERSION_SEMVER=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
-            DOCKER_META_REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,5 @@
 FROM node:23-alpine AS build
 
-# These will be automatically populated by docker/metadata-action
-ARG DOCKER_META_VERSION
-ARG DOCKER_META_TITLE
-ARG DOCKER_META_VERSION_SEMVER
-ARG DOCKER_META_REVISION
 ARG SENTRY_AUTH_TOKEN
 ARG VITE_SENTRY_DSN
 ENV VITE_SENTRY_DSN=${VITE_SENTRY_DSN}
@@ -15,9 +10,6 @@ COPY package*.json .
 RUN npm ci
 
 COPY . .
-
-# Create version.json that will be copied to the final image
-RUN echo "{\"version\": \"${DOCKER_META_VERSION_SEMVER:-0.0.0}\", \"commitHash\": \"${DOCKER_META_REVISION:-development}\", \"buildTime\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\"}" > public/version.json
 
 RUN npx vite build && npx vite optimize
 

--- a/src/components/CoolingCenter.vue
+++ b/src/components/CoolingCenter.vue
@@ -1,11 +1,16 @@
 <template>
   <v-container class="cooling-center">
-    <v-card elevation="2" class="pa-4">
+    <v-card
+elevation="2"
+class="pa-4"
+>
       <v-card-title>Add Cooling <br> Centers</v-card-title>
 
       <v-card-text>
         <!-- Capacity Slider -->
-        <v-label class="mb-2">Cooling Center Capacity</v-label>
+        <v-label class="mb-2">
+Cooling Center Capacity
+</v-label>
         <br>
         <br>
         <v-slider
@@ -20,12 +25,21 @@
         <!-- Buttons Row: Add & Reset -->
         <v-row class="mt-4">
           <v-col cols="6">
-            <v-btn color="primary" :class="{ 'active-btn': selectingGrid }" block @click="toggleGridSelection">
+            <v-btn
+color="primary"
+:class="{ 'active-btn': selectingGrid }"
+block
+@click="toggleGridSelection"
+>
               {{ selectingGrid ? 'Select' : 'Add' }}
             </v-btn>
           </v-col>
           <v-col cols="6">
-            <v-btn color="error" block @click="resetCoolingCenters">
+            <v-btn
+color="error"
+block
+@click="resetCoolingCenters"
+>
               Reset
             </v-btn>
           </v-col>

--- a/src/components/CoolingCenterOptimiser.vue
+++ b/src/components/CoolingCenterOptimiser.vue
@@ -1,9 +1,14 @@
 <template>
   <v-container class="cooling-center-optimisation">
-    <v-card elevation="2" class="pa-4">
+    <v-card
+elevation="2"
+class="pa-4"
+>
       <v-card-title>  Cooling Center <br> Optimization</v-card-title>
       
-      <v-label class="mb-2">Number of Cooling Centers</v-label>
+      <v-label class="mb-2">
+Number of Cooling Centers
+</v-label>
       <br><br>
       <v-slider 
         v-model="numCoolingCenters"
@@ -15,7 +20,11 @@
       />  
     
         <v-col cols="12">    
-          <v-btn color="success" class="mt-2" @click="findOptimalCoolingCenters">
+          <v-btn
+color="success"
+class="mt-2"
+@click="findOptimalCoolingCenters"
+>
             Optimise Locations
           </v-btn>
         </v-col>

--- a/src/components/EstimatedImpacts.vue
+++ b/src/components/EstimatedImpacts.vue
@@ -1,11 +1,16 @@
 <template>
-  <div v-if="coolingCenters.length" class="mt-4">
+  <div
+v-if="coolingCenters.length"
+class="mt-4"
+>
     <v-divider class="my-4" />
     <h3>Estimated Impacts</h3>
     <p>Total Centers Added: {{ coolingCenters.length }}</p>
     <p>Total Cells Affected: {{ affectedCells.length }}</p>
     <p>Total Heat Vulnerability impact: {{ impact }}</p>
-    <p v-if="optimised">In optimization the minimum distance between two cooling centers is 500m</p>
+    <p v-if="optimised">
+In optimization the minimum distance between two cooling centers is 500m
+</p>
   </div>
 </template>
 

--- a/src/main.js
+++ b/src/main.js
@@ -62,7 +62,7 @@ Sentry.init({
   tracesSampleRate: 1.0,
 
   // Set `tracePropagationTargets` to control for which URLs trace propagation should be enabled
-  tracePropagationTargets: ["localhost", /^https:\/\/r4c\.dataportal\.fi/],
+  tracePropagationTargets: ["localhost", /^https:\/\/r4c\.dataportal\.fi/, /^https:\/\/r4c\.dev\.dataportal\.fi/],
 
 	// Capture Replay for 10% of all sessions,
   // plus for 100% of sessions with an error

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,13 @@ export default defineConfig( () => {
 	return {
 		build: {
 			sourcemap: true, // Source map generation must be turned on
+			rollupOptions: {
+				output: {
+					assetFileNames: `assets/[name].[hash].${version}.[ext]`,
+					chunkFileNames: `assets/[name].[hash].${version}.js`,
+					entryFileNames: `assets/[name].${version}.js`,
+				}
+			}
 		},
 		plugins: [
 			eslint(),
@@ -37,19 +44,19 @@ export default defineConfig( () => {
 		],
 		define: { 'process.env': {} },
 		resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url))
+      },
+      extensions: [
+        '.js',
+        '.json',
+        '.jsx',
+        '.mjs',
+        '.ts',
+        '.tsx',
+        '.vue',
+      ],
     },
-    extensions: [
-      '.js',
-      '.json',
-      '.jsx',
-      '.mjs',
-      '.ts',
-      '.tsx',
-      '.vue',
-    ],
-  },
 		server: {
 			proxy: {
 				'/pygeoapi': {


### PR DESCRIPTION
This commit introduces versioning to asset file names generated during the build process by modifying the rollup options in vite.config.js. The asset, chunk, and entry file names now include a version hash.