### PR TITLE
fix(nginx): set explicit Host header for pygeoapi proxy

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -52,7 +52,7 @@ server {
 
     location /pygeoapi/ {
         proxy_pass https://pygeoapi.dataportal.fi/;
-        proxy_set_header Host $host;
+        proxy_set_header Host pygeoapi.dataportal.fi;
         rewrite ^/pygeoapi/(.*)$ /$1 break;
     }
 


### PR DESCRIPTION
## Summary
- Set Host header to `pygeoapi.dataportal.fi` instead of using `$host` for the pygeoapi proxy
- Ensures proper upstream server routing for the pygeoapi service

## Changes
- Modified `nginx/default.conf.template` to use explicit Host header value

## Test plan
- [ ] Verify nginx configuration syntax is valid
- [ ] Test that pygeoapi proxy requests route correctly to the upstream server
- [ ] Confirm no regression in other proxy configurations

🤖 Generated with [Claude Code](https://claude.ai/code)