### PR TITLE
fix: resolve nginx configuration syntax error in pygeoapi proxy

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -3,3 +3,4 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-configmap
 data:
+  VITE_PYGEOAPI_HOST: {{ .Values.vite.pygeoapi_host | default "pygeoapi.dataportal.fi" }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -13,6 +13,10 @@ secrets:
     dsn: ""
     auth_token: ""
 
+vite:
+  # PygeoAPI host (defaults to production)
+  pygeoapi_host: "pygeoapi.dataportal.fi"
+
 image:
   repository: ghcr.io/forumviriumhelsinki/r4c-cesium-viewer
   pullPolicy: IfNotPresent

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -51,13 +51,16 @@ server {
     }
 
     location /pygeoapi/ {
+        # Store the host in a variable first
+        set $pygeoapi_host "${VITE_PYGEOAPI_HOST}";
+
         # Derive protocol based on port - use http for localhost development ports, https otherwise
         set $pygeoapi_protocol "https";
-        if (${VITE_PYGEOAPI_HOST} ~* "^localhost:[0-9]+$") {
+        if ($pygeoapi_host ~* "^localhost:[0-9]+$") {
             set $pygeoapi_protocol "http";
         }
-        proxy_pass $pygeoapi_protocol://${VITE_PYGEOAPI_HOST}/;
-        proxy_set_header Host ${VITE_PYGEOAPI_HOST};
+        proxy_pass $pygeoapi_protocol://$pygeoapi_host/;
+        proxy_set_header Host $pygeoapi_host;
         rewrite ^/pygeoapi/(.*)$ /$1 break;
     }
 


### PR DESCRIPTION
- Fixed invalid nginx if condition syntax by storing environment variable in local variable first
- Added VITE_PYGEOAPI_HOST to Helm ConfigMap for runtime configuration
- Prevents nginx startup failure due to invalid condition syntax when variable contains hostnames

The issue occurred when ${VITE_PYGEOAPI_HOST} was substituted directly in the if condition,
creating invalid syntax. Now using intermediate variable assignment for proper nginx syntax.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
