### PR TITLE
Fix: Prevent HSY background map clicks from triggering postal code selection

### DIFF
--- a/src/components/HSYWMS.vue
+++ b/src/components/HSYWMS.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="wms-layer-switcher">
+  <div class="wms-layer-switcher" @click.stop>
     <!-- Added upper margin with link to HSY map service -->
 
     <div class="search-and-restore">
@@ -14,11 +14,12 @@ hide-details
 single-line
         @input="onSearch"
 @keyup.enter="onEnter"
-@click:append="onSearchClick"
+@click:append.stop="onSearchClick"
+@click.stop
 />
       <v-btn
 class="restore-btn"
-@click="restoreDefaultLayer"
+@click.stop="restoreDefaultLayer"
 >
         Restore Default
       </v-btn>
@@ -36,7 +37,7 @@ target="_blank"
       <v-list-item
 v-for="(layer, index) in filteredLayers"
 :key="index"
-@click="selectLayer(layer.name)"
+@click.stop="selectLayer(layer.name)"
 >
         {{ layer.title }}
       </v-list-item>


### PR DESCRIPTION
Fixes #102

## Problem
Clicks on HSY background map selection were incorrectly triggering postal code area selection.

## Solution
Added event propagation stopping to all interactive elements in the HSYWMS component to prevent clicks from bubbling up to the map's click handler.

## Changes
- Added `@click.stop` modifier to the main WMS layer switcher container
- Updated all clickable elements to use `.stop` modifier

Generated with [Claude Code](https://claude.ai/code)