### PR TITLE
fix: replace deprecated deps.inline with deps.optimizer.web.include

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -14,7 +14,11 @@ export default defineConfig({
       include: []
     },
     deps: {
-      inline: ['vuetify']
+      optimizer: {
+        web: {
+          include: ['vuetify']
+        }
+      }
     },
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Vitest deprecated `deps.inline` in favor of `deps.optimizer.web.include`. Updated vitest.config.js to use the new configuration format for vuetify.

Fixes #215

Generated with [Claude Code](https://claude.ai/code)