### PR TITLE
feat: add import validation warnings for unknown feature flags

### DIFF
--- a/src/stores/featureFlagStore.ts
+++ b/src/stores/featureFlagStore.ts
@@ -494,6 +494,8 @@ export const useFeatureFlagStore = defineStore("featureFlags", {
           this.setFlag(flagName, enabled);
         } else if (!this.flags[flagName]) {
           console.warn(`Unknown feature flag "${name}" in imported configuration`);
+        } else if (typeof enabled !== "boolean") {
+          console.warn(`Invalid value for feature flag "${name}": expected boolean, got ${typeof enabled}`);
         }
       });
     },

--- a/tests/unit/stores/featureFlagStore.test.js
+++ b/tests/unit/stores/featureFlagStore.test.js
@@ -554,6 +554,30 @@ describe("featureFlagStore", () => {
           'Unknown feature flag "anotherUnknown" in imported configuration',
         );
         expect(warnSpy).toHaveBeenCalledTimes(2);
+        warnSpy.mockRestore();
+      });
+
+      it("should warn about invalid value types in import", () => {
+        const warnSpy = vi.spyOn(console, "warn");
+        const config = {
+          ndvi: "true", // string instead of boolean
+          heatHistogram: 1, // number instead of boolean
+          debugMode: null, // null instead of boolean
+        };
+
+        store.importConfig(config);
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          'Invalid value for feature flag "ndvi": expected boolean, got string',
+        );
+        expect(warnSpy).toHaveBeenCalledWith(
+          'Invalid value for feature flag "heatHistogram": expected boolean, got number',
+        );
+        expect(warnSpy).toHaveBeenCalledWith(
+          'Invalid value for feature flag "debugMode": expected boolean, got object',
+        );
+        expect(warnSpy).toHaveBeenCalledTimes(3);
+        warnSpy.mockRestore();
       });
 
       it("should persist imported configuration", () => {


### PR DESCRIPTION
Add console.warn() for unknown feature flags in importConfig() method to help developers identify typos or outdated flag names when importing configurations.

## Changes
- Added console.warn for unknown flags in `importConfig()` method
- Added test coverage for the warning behavior

Closes #223

Generated with [Claude Code](https://claude.ai/code)