### PR TITLE
fix: remove invalid vite optimize command from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN npm ci
 
 COPY . .
 
-RUN npx vite build && npx vite optimize
+RUN npm run build
 
 FROM nginx:1.27
 


### PR DESCRIPTION
Fixes #249

This PR fixes the container build error by removing the invalid `vite optimize` command and using the proper npm build script instead.

## Changes
- Replace `npx vite build && npx vite optimize` with `npm run build` in Dockerfile

## Why
- `vite optimize` is not a valid Vite command
- Using the npm script ensures proper environment variable handling with dotenvx
- Aligns with the project's standard build process

Generated with [Claude Code](https://claude.ai/code)