### PR TITLE
fix: bypass dotenvx in Docker build to resolve build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN npm ci
 
 COPY . .
 
-RUN npm run build
+RUN ./node_modules/.bin/vite build
 
 FROM nginx:1.27
 


### PR DESCRIPTION
Fixes #252

## Problem
The container build was failing during `npm run build` because the build script uses `dotenvx` to load environment variables, but `.env` files are excluded from the Docker build context via `.dockerignore`.

## Solution
Modified the Dockerfile to run `vite build` directly instead of through the npm script, bypassing the dotenvx wrapper. Environment variables are still properly set via the Dockerfile's `ENV` directives.

## Changes
- Modified `Dockerfile` line 16 to use `./node_modules/.bin/vite build` instead of `npm run build`

---
Generated with [Claude Code](https://claude.ai/code)