### PR TITLE
fix: correct COPY destination path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV VITE_PYGEOAPI_HOST=${VITE_PYGEOAPI_HOST}
 
 WORKDIR /app
 
-COPY package*.json .
+COPY package*.json ./
 RUN npm ci
 
 COPY . .


### PR DESCRIPTION
Fixes #261

The COPY command in the Dockerfile was missing the proper destination path, causing package.json and package-lock.json to not be copied correctly to the /app working directory. This prevented npm ci from finding the required files.

### Changes
- Changed `COPY package*.json .` to `COPY package*.json ./` in Dockerfile line 11

Generated with [Claude Code](https://claude.ai/code)