### PR TITLE
fix: add missing checkout step to container-build workflow

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -15,6 +15,9 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
## Problem
The container build workflow was failing with:
```
ERROR: failed to build: failed to solve: process "/bin/sh -c npm ci" did not complete successfully: exit code: 1
```

## Root Cause
The workflow was missing a `checkout` step, which meant the `docker/build-push-action` had no access to the Dockerfile, package.json, or any source code files. This caused the build to fail when trying to run `npm ci`.

## Solution
Added `actions/checkout@v4` as the first step in the workflow, ensuring all repository files are available for the Docker build process.

## Testing
- The workflow should now successfully build the container image
- Both linux/amd64 and linux/arm64 platforms should build correctly

Fixes #build-failure