### PR TITLE
fix: add optional chaining to prevent TypeError in featurepicker

### DIFF
--- a/src/services/featurepicker.js
+++ b/src/services/featurepicker.js
@@ -87,7 +87,7 @@ export default class FeaturePicker {
     console.log("[FeaturePicker] Picked object:", picked);
 
     if (picked) {
-      let id = Cesium.defaultValue(picked.id, picked.primitive.id);
+      let id = Cesium.defaultValue(picked.id, picked.primitive?.id);
 
       if (picked.id._polygon) {
         if (id instanceof Cesium.Entity) {


### PR DESCRIPTION
Adds optional chaining to `picked.primitive?.id` to prevent TypeError when `picked.primitive` is undefined. This resolves the error reported in Sentry issue REGIONS4CLIMATE-1B.

Fixes #274

Generated with [Claude Code](https://claude.ai/code)