### PR TITLE
fix: optimize Cesium.js loading to prevent render blocking

### DIFF
--- a/src/pages/CesiumViewer.vue
+++ b/src/pages/CesiumViewer.vue
@@ -16,7 +16,6 @@
 
 <script>
 import { ref, onMounted, computed } from 'vue';
-import * as Cesium from 'cesium';
 import 'cesium/Source/Widgets/widgets.css';
 import Datasource from '../services/datasource.js';
 import WMS from '../services/wms.js';
@@ -57,10 +56,17 @@ export default {
       		return store.showBuildingInfo && buildingStore.buildingFeatures && !store.isLoading;
     	});
 		const viewer = ref(null);
-		Cesium.Ion.defaultAccessToken = null;
 		let lastPickTime = 0;
+		let Cesium = null;
 
-		const initViewer = () => {
+		const initViewer = async () => {
+			// Dynamically import Cesium to avoid blocking initial render
+			if (!Cesium) {
+				Cesium = await import('cesium');
+			}
+
+			// Set Ion token after loading
+			Cesium.Ion.defaultAccessToken = null;
 			// Create viewer with enhanced graphics options
 			const viewerOptions = {
 				terrainProvider: new Cesium.EllipsoidTerrainProvider(),
@@ -158,8 +164,8 @@ export default {
   			});
 		};
 
-		onMounted(() => {
-			initViewer();
+		onMounted(async () => {
+			await initViewer();
 			socioEconomicsStore.loadPaavo();
 			heatExposureStore.loadHeatExposure();
 		});

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,6 +19,10 @@ export default defineConfig(() => {
           assetFileNames: `assets/[name].[hash].${version}.[ext]`,
           chunkFileNames: `assets/[name].[hash].${version}.js`,
           entryFileNames: `assets/[name].${version}.js`,
+          manualChunks: {
+            // Split Cesium into its own chunk for better caching and async loading
+            cesium: ['cesium'],
+          },
         },
       },
     },


### PR DESCRIPTION
Convert static Cesium import to dynamic import for better performance:
- Use await import('cesium') in CesiumViewer to load Cesium asynchronously
- Make initViewer() async to handle dynamic import
- Add manual chunking configuration to split Cesium into separate chunk

This resolves the Sentry-reported issue where Cesium.js was blocking initial page render. The main bundle will now load and render faster, with Cesium loading in parallel.

Fixes #275

🤖 Generated with [Claude Code](https://claude.ai/code)