### PR TITLE
fix: replace Cesium.defaultValue with nullish coalescing operator

### DIFF
--- a/src/services/featurepicker.js
+++ b/src/services/featurepicker.js
@@ -103,7 +103,7 @@ export default class FeaturePicker {
     console.log("[FeaturePicker] Picked object:", picked);
 
     if (picked) {
-      let id = Cesium.defaultValue(picked.id, picked.primitive?.id);
+      let id = picked.id ?? picked.primitive?.id;
 
       if (picked.id._polygon) {
         if (id instanceof Cesium.Entity) {


### PR DESCRIPTION
Fixes #291

The Cesium.defaultValue function was causing a TypeError when not available in the loaded CesiumJS version. Replaced it with the standard JavaScript nullish coalescing operator (??) which is more reliable and doesn't depend on CesiumJS utility functions.

Generated with [Claude Code](https://claude.ai/code)