### PR TITLE
fix(ci): replace composite action with inline scripts for containerized jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [24,25]
+        node-version: [24, 25]
 
     steps:
       - name: Checkout code
@@ -85,12 +85,40 @@ jobs:
         run: npm run build
 
       - name: Start frontend server
-        uses: ./.github/actions/start-server-with-healthcheck
-        id: server
-        with:
-          server-command: "npm run preview"
-          server-url: "http://localhost:4173"
-          timeout: "30"
+        run: |
+          # Start the server in background
+          npm run preview &
+          SERVER_PID=$!
+          echo "Server PID: $SERVER_PID"
+          echo "SERVER_PID=$SERVER_PID" >> $GITHUB_ENV
+
+          # Wait for server to be ready with timeout
+          timeout 30 bash -c 'until curl -sf http://localhost:4173 >/dev/null; do
+            echo "Waiting for server to be ready..."
+            sleep 1
+          done'
+
+          # Check if server is actually ready
+          if ! curl -sf http://localhost:4173 >/dev/null; then
+            echo "::error::Server failed to start within 30 seconds"
+            kill $SERVER_PID 2>/dev/null || true
+            exit 1
+          fi
+
+          echo "::notice::Server is ready at http://localhost:4173"
+
+          # Double-check server is still running after initial health check
+          sleep 2
+          if ! kill -0 $SERVER_PID 2>/dev/null; then
+            echo "::error::Server process died after initial startup"
+            exit 1
+          fi
+
+          if ! curl -sf http://localhost:4173 >/dev/null; then
+            echo "::error::Server stopped responding after initial health check"
+            kill $SERVER_PID 2>/dev/null || true
+            exit 1
+          fi
 
       - name: Run Playwright tests
         run: npm run test:e2e
@@ -150,12 +178,40 @@ jobs:
         run: npm run build
 
       - name: Start frontend server
-        uses: ./.github/actions/start-server-with-healthcheck
-        id: server
-        with:
-          server-command: "npm run preview"
-          server-url: "http://localhost:4173"
-          timeout: "30"
+        run: |
+          # Start the server in background
+          npm run preview &
+          SERVER_PID=$!
+          echo "Server PID: $SERVER_PID"
+          echo "SERVER_PID=$SERVER_PID" >> $GITHUB_ENV
+
+          # Wait for server to be ready with timeout
+          timeout 30 bash -c 'until curl -sf http://localhost:4173 >/dev/null; do
+            echo "Waiting for server to be ready..."
+            sleep 1
+          done'
+
+          # Check if server is actually ready
+          if ! curl -sf http://localhost:4173 >/dev/null; then
+            echo "::error::Server failed to start within 30 seconds"
+            kill $SERVER_PID 2>/dev/null || true
+            exit 1
+          fi
+
+          echo "::notice::Server is ready at http://localhost:4173"
+
+          # Double-check server is still running after initial health check
+          sleep 2
+          if ! kill -0 $SERVER_PID 2>/dev/null; then
+            echo "::error::Server process died after initial startup"
+            exit 1
+          fi
+
+          if ! curl -sf http://localhost:4173 >/dev/null; then
+            echo "::error::Server stopped responding after initial health check"
+            kill $SERVER_PID 2>/dev/null || true
+            exit 1
+          fi
 
       - name: Run accessibility tests - Desktop
         run: timeout 600 npm run test:accessibility:desktop -- --reporter=list,json --trace=on-first-retry
@@ -235,12 +291,40 @@ jobs:
         run: npm run build
 
       - name: Start frontend server
-        uses: ./.github/actions/start-server-with-healthcheck
-        id: server
-        with:
-          server-command: "npm run preview"
-          server-url: "http://localhost:4173"
-          timeout: "30"
+        run: |
+          # Start the server in background
+          npm run preview &
+          SERVER_PID=$!
+          echo "Server PID: $SERVER_PID"
+          echo "SERVER_PID=$SERVER_PID" >> $GITHUB_ENV
+
+          # Wait for server to be ready with timeout
+          timeout 30 bash -c 'until curl -sf http://localhost:4173 >/dev/null; do
+            echo "Waiting for server to be ready..."
+            sleep 1
+          done'
+
+          # Check if server is actually ready
+          if ! curl -sf http://localhost:4173 >/dev/null; then
+            echo "::error::Server failed to start within 30 seconds"
+            kill $SERVER_PID 2>/dev/null || true
+            exit 1
+          fi
+
+          echo "::notice::Server is ready at http://localhost:4173"
+
+          # Double-check server is still running after initial health check
+          sleep 2
+          if ! kill -0 $SERVER_PID 2>/dev/null; then
+            echo "::error::Server process died after initial startup"
+            exit 1
+          fi
+
+          if ! curl -sf http://localhost:4173 >/dev/null; then
+            echo "::error::Server stopped responding after initial health check"
+            kill $SERVER_PID 2>/dev/null || true
+            exit 1
+          fi
 
       - name: Run performance tests
         run: npm run test:performance


### PR DESCRIPTION
## Summary
Fixes GitHub Actions Test Suite workflow failures by replacing the composite action with inline server startup scripts.

## Problem
The `start-server-with-healthcheck` composite action was failing in containerized jobs with the error:
```
sh: 0: cannot open /__w/_temp/*.sh: No such file
```

This occurred because composite actions using `shell: bash` don't work properly with containerized GitHub Actions jobs on self-hosted runners - the temp directory isn't properly mounted in the container environment.

## Solution
Replaced the composite action usage with inline scripts directly in the workflow steps for:
- End-to-End Tests
- Accessibility Tests  
- Performance Tests

The server startup and health check logic is now executed directly within each job, avoiding the shell translation issues that composite actions have with containers.

## Testing
- [ ] End-to-End Tests should pass
- [ ] Accessibility Tests should pass
- [ ] Performance Tests should pass (only runs on main branch pushes)

## Related Issues
Fixes the Test Suite workflow failures visible in recent runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)