### PR TITLE
fix: adjust Sentry sample rate to 0.1

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -56,6 +56,9 @@ Sentry.init({
     Sentry.replayCanvasIntegration(),
   ],
 
+  // Sample 10% of error events to reduce quota usage
+  sampleRate: 0.1,
+
   // We recommend adjusting this value in production, or using tracesSampler
   // for finer control
   tracesSampleRate: 1.0,


### PR DESCRIPTION
## Summary

This PR adjusts the Sentry error sampling rate to 0.1 (10%) to reduce quota usage.

## Changes

- Added `sampleRate: 0.1` to the Sentry initialization in `src/main.js`
- This will sample only 10% of error events, helping to manage Sentry quota consumption

Fixes #306

---

Generated with [Claude Code](https://claude.ai/code)