### PR TITLE
fix: resolve WebGL texture errors and Cesium proxy configuration issues

### DIFF
--- a/src/pages/CesiumViewer.vue
+++ b/src/pages/CesiumViewer.vue
@@ -90,6 +90,7 @@ export default {
 			// Create viewer with enhanced graphics options
 			const viewerOptions = {
 				terrainProvider: new Cesium.EllipsoidTerrainProvider(),
+				imageryProvider: false, // Disable default imagery to prevent Ion API calls
 				animation: false,
 				fullscreenButton: false,
 				geocoder: false,

--- a/src/services/floodwms.js
+++ b/src/services/floodwms.js
@@ -41,7 +41,6 @@ export const createFloodImageryLayer = async (url, layerName) => {
     const provider = new Cesium.WebMapServiceImageryProvider({
       url: `${url}&format=image/png&transparent=true`,
       layers: layerName,
-      proxy: new Cesium.DefaultProxy("/proxy/"),
     });
 
     await provider.readyPromise;

--- a/src/services/wms.js
+++ b/src/services/wms.js
@@ -32,7 +32,6 @@ export default class Wms {
     const provider = new Cesium.WebMapServiceImageryProvider({
       url: urlStore.helsinkiWMS,
       layers: layerName,
-      proxy: new Cesium.DefaultProxy("/proxy/"),
     });
 
     return new Cesium.ImageryLayer(provider);

--- a/src/stores/urlStore.js
+++ b/src/stores/urlStore.js
@@ -34,8 +34,7 @@ import { defineStore } from "pinia";
 export const useURLStore = defineStore("url", {
   state: () => ({
     imagesBase: "/ndvi_public",
-    helsinkiWMS:
-      "https://kartta.hel.fi/ws/geoserver/avoindata/ows?SERVICE=WMS&",
+    helsinkiWMS: "/helsinki-wms?SERVICE=WMS&",
     pygeoapiBase: "/pygeoapi/collections", // Base URL for pygeoapi collections (proxied through /pygeoapi)
     wmsProxy: "/wms/proxy",
   }),

--- a/vite.config.js
+++ b/vite.config.js
@@ -111,6 +111,13 @@ export default defineConfig(() => {
           secure: false,
           rewrite: (path) => path.replace(/^\/wms\/proxy/, "/geoserver/wms"),
         },
+        "/helsinki-wms": {
+          target: "https://kartta.hel.fi",
+          changeOrigin: true,
+          secure: false,
+          rewrite: (path) =>
+            path.replace(/^\/helsinki-wms/, "/ws/geoserver/avoindata/ows"),
+        },
         "/ndvi_public": {
           target: "https://storage.googleapis.com",
           changeOrigin: true,


### PR DESCRIPTION
## Summary

Fixes WebGL texture parameter errors and Cesium Ion authentication failures that have been present since initial WMS implementation.

## Root Cause Analysis

Investigation revealed the issues were present from the beginning:

1. **Missing proxy configuration**: `wms.js` used `kartta.hel.fi` but no corresponding proxy route existed in `vite.config.js`
2. **Deprecated Cesium API**: `DefaultProxy("/proxy/")` deprecated in CesiumJS 1.134.1
3. **Unnecessary Ion API calls**: Default imagery provider triggered 401 errors from `api.cesium.com`

These resulted in:
- 56+ repeated `GL_INVALID_VALUE: glTexParameteri: Parameter outside of bounds` errors
- 401 authentication failures from Cesium Ion API
- `RequestErrorEvent` exceptions

## Changes

- ✅ Added `/helsinki-wms` proxy route in `vite.config.js` targeting `kartta.hel.fi`
- ✅ Updated `urlStore.js` to use proxy endpoint instead of direct external URL
- ✅ Removed deprecated `DefaultProxy` usage from `wms.js` and `floodwms.js`
- ✅ Set `imageryProvider: false` in `CesiumViewer.vue` to prevent Ion API calls

## Test Plan

- [ ] Start dev server: `npm run dev`
- [ ] Open browser console and verify:
  - [ ] No `GL_INVALID_VALUE` WebGL errors
  - [ ] No 401 errors from `api.cesium.com`
  - [ ] No `RequestErrorEvent` exceptions
- [ ] Test WMS functionality:
  - [ ] Base maps display correctly
  - [ ] Flood layers work (if used)
  - [ ] Helsinki WMS layers load through proxy

## Files Changed

- `vite.config.js` - Added Helsinki WMS proxy route
- `src/stores/urlStore.js` - Updated to use proxy endpoint
- `src/services/wms.js` - Removed deprecated DefaultProxy
- `src/services/floodwms.js` - Removed deprecated DefaultProxy
- `src/pages/CesiumViewer.vue` - Disabled default imagery provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)