### PR TITLE
chore: apply prettier formatting fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [24,25]
+        node-version: [24, 25]
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,23 @@
 
 ## [1.27.12](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/compare/r4c-cesium-viewer-v1.27.11...r4c-cesium-viewer-v1.27.12) (2025-11-05)
 
-
 ### Bug Fixes
 
-* resolve WebGL texture errors and Cesium proxy configuration issues ([#309](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/309)) ([dfc30c7](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/dfc30c7825c7f56cdf56e4f498088ba4e7bc82bc))
+- resolve WebGL texture errors and Cesium proxy configuration issues ([#309](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/309)) ([dfc30c7](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/dfc30c7825c7f56cdf56e4f498088ba4e7bc82bc))
 
 ## [1.27.11](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/compare/r4c-cesium-viewer-v1.27.10...r4c-cesium-viewer-v1.27.11) (2025-11-05)
 
-
 ### Bug Fixes
 
-* adjust Sentry sample rate to 0.1 to reduce quota usage ([#307](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/307)) ([98c70b2](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/98c70b2c8f2dcfb58338c2d9c37576a45fc34702)), closes [#306](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/306)
-* **ci:** add container configurations for self-hosted runners and fix localStorage mock ([#302](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/302)) ([72b4bd7](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/72b4bd7e1a4eb7839f40ea3bfc1cfa85367aaf73))
+- adjust Sentry sample rate to 0.1 to reduce quota usage ([#307](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/307)) ([98c70b2](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/98c70b2c8f2dcfb58338c2d9c37576a45fc34702)), closes [#306](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/306)
+- **ci:** add container configurations for self-hosted runners and fix localStorage mock ([#302](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/302)) ([72b4bd7](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/72b4bd7e1a4eb7839f40ea3bfc1cfa85367aaf73))
 
 ## [1.27.10](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/compare/r4c-cesium-viewer-v1.27.9...r4c-cesium-viewer-v1.27.10) (2025-11-03)
 
-
 ### Bug Fixes
 
-* add validation checks to prevent drawingBufferWidth error ([#289](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/289)) ([09a5b0c](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/09a5b0c4acf5d192d6f8d5c34c422f436fdd5b61)), closes [#288](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/288)
-* replace Cesium.defaultValue with nullish coalescing operator ([#292](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/292)) ([0d9d8c2](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/0d9d8c231e8d1bc8168a962a75b64b18b2e662f0)), closes [#291](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/291)
+- add validation checks to prevent drawingBufferWidth error ([#289](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/289)) ([09a5b0c](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/09a5b0c4acf5d192d6f8d5c34c422f436fdd5b61)), closes [#288](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/288)
+- replace Cesium.defaultValue with nullish coalescing operator ([#292](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/292)) ([0d9d8c2](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/0d9d8c231e8d1bc8168a962a75b64b18b2e662f0)), closes [#291](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/291)
 
 ## [1.27.9](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/compare/r4c-cesium-viewer-v1.27.8...r4c-cesium-viewer-v1.27.9) (2025-10-30)
 

--- a/tests/unit/services/featurepicker.test.js
+++ b/tests/unit/services/featurepicker.test.js
@@ -457,7 +457,9 @@ describe("FeaturePicker service", () => {
       );
 
       // Verify cleanup
-      expect(featurePicker.removeEntityByName).toHaveBeenCalledWith("coldpoint");
+      expect(featurePicker.removeEntityByName).toHaveBeenCalledWith(
+        "coldpoint",
+      );
       expect(featurePicker.removeEntityByName).toHaveBeenCalledWith(
         "currentLocation",
       );
@@ -478,7 +480,9 @@ describe("FeaturePicker service", () => {
       featurePicker.handleFeatureWithProperties(mockId);
 
       // Verify postal code is set
-      expect(globalStore.setPostalCode).toHaveBeenCalledWith(TEST_POSTAL_CODE_1);
+      expect(globalStore.setPostalCode).toHaveBeenCalledWith(
+        TEST_POSTAL_CODE_1,
+      );
 
       // Verify loadPostalCode is called
       expect(featurePicker.loadPostalCode).toHaveBeenCalled();
@@ -700,7 +704,7 @@ describe("FeaturePicker service", () => {
       const mockCartographics = [
         { longitude: 0.4363, latitude: 1.0472 }, // ~25°E, ~60°N in radians
         { longitude: 0.4538, latitude: 1.0647 }, // Slightly larger
-        { longitude: 0.4450, latitude: 1.0559 }, // In between
+        { longitude: 0.445, latitude: 1.0559 }, // In between
       ];
 
       vi.spyOn(Cesium.Cartographic, "fromCartesian").mockImplementation(


### PR DESCRIPTION
## Summary

Applies automatic prettier formatting fixes from pre-commit hooks:

- Fix array spacing in GitHub workflow configuration
- Improve CHANGELOG.md formatting (consistent list indentation and blank lines)
- Fix line wrapping in featurepicker test file

## Changes

- `.github/workflows/test.yml`: Add spacing in node-version array
- `CHANGELOG.md`: Standardize list formatting and remove extra blank lines
- `tests/unit/services/featurepicker.test.js`: Wrap long lines for better readability

## Type of Change

- [x] Chore (code formatting, no functional changes)