### PR TITLE
fix: update Node.js version to 24 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:23-alpine AS build
+FROM node:24-alpine AS build
 
 ARG SENTRY_AUTH_TOKEN
 ARG VITE_SENTRY_DSN


### PR DESCRIPTION
Fixes #330

Node.js v23 is not supported by jsdom@27.1.0 and vitest@4.0.7.
Updated to Node.js 24 (LTS) which is supported by both packages.

Generated with [Claude Code](https://claude.ai/code)