### PR TITLE
fix: correct nginx proxy_pass path handling for pygeoapi

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -70,9 +70,14 @@ server {
         if ($pygeoapi_host ~* "\.svc\.cluster\.local$") {
             set $pygeoapi_protocol "http";
         }
-        proxy_pass $pygeoapi_protocol://$pygeoapi_host/;
-        proxy_set_header Host $pygeoapi_host;
+
+        # Rewrite must come BEFORE proxy_pass when using variables
+        # Strip /pygeoapi prefix: /pygeoapi/collections/foo -> /collections/foo
         rewrite ^/pygeoapi/(.*)$ /$1 break;
+
+        # proxy_pass without trailing slash preserves the rewritten path
+        proxy_pass $pygeoapi_protocol://$pygeoapi_host;
+        proxy_set_header Host $pygeoapi_host;
     }
 
     location /wms/proxy {


### PR DESCRIPTION
## Summary

Fixes the nginx path rewriting for pygeoapi proxy to ensure requests reach the correct API endpoints instead of the root landing page.

## Problem

The application was requesting `/pygeoapi/collections/heatexposure_optimized/items` but nginx was proxying it to the pygeoapi root (`/`) instead of `/collections/heatexposure_optimized/items`. This caused the "Invalid data structure" error because the application was receiving the pygeoapi landing page JSON instead of the actual heat exposure data.

**Symptom:**
```javascript
Error fetching postal code data: Error: Invalid data structure
```

**Root Cause:**
The `proxy_pass` directive with a trailing `/` and the `rewrite` directive were in the wrong order, causing nginx to:
1. Apply `proxy_pass` with trailing `/` → replace entire path with `/`
2. Then try to apply `rewrite` → but path already replaced

## Solution

Reordered the directives:
1. **Rewrite first** - Strip `/pygeoapi` prefix from the path
2. **Proxy_pass second** - Without trailing slash to preserve the rewritten path

```nginx
# Before (INCORRECT):
proxy_pass $pygeoapi_protocol://$pygeoapi_host/;
rewrite ^/pygeoapi/(.*)$ /$1 break;

# After (CORRECT):
rewrite ^/pygeoapi/(.*)$ /$1 break;
proxy_pass $pygeoapi_protocol://$pygeoapi_host;
```

## Result

| Request | Old Behavior | New Behavior |
|---------|-------------|--------------|
| `/pygeoapi/collections/foo/items` | → `/` (root) | → `/collections/foo/items` ✅ |

## Related

This builds on PR #327 which fixed the HTTP/HTTPS protocol selection for internal Kubernetes services.

## Test Plan

- [ ] Deploy and verify `/pygeoapi/collections/heatexposure_optimized/items?f=json&limit=1` returns heat exposure data
- [ ] Verify heat exposure data loads in the application without errors
- [ ] Check browser console for absence of "Invalid data structure" errors
- [ ] Confirm 3D buildings load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)