### PR TITLE
Fix DataCloneError in Cesium viewer rendering

### DIFF
--- a/src/stores/mitigationStore.js
+++ b/src/stores/mitigationStore.js
@@ -32,6 +32,7 @@
  */
 
 import { defineStore } from "pinia";
+import { markRaw } from "vue";
 
 /**
  * Mitigation Pinia Store
@@ -64,6 +65,12 @@ export const useMitigationStore = defineStore("mitigation", {
     cumulativeHeatReduction: 0,
   }),
   actions: {
+    /**
+     * Sets grid cells with Cesium entity references
+     * @param {Object} datasource - Cesium data source containing grid entities
+     * @note Uses markRaw on entity objects to prevent them from becoming reactive,
+     *       which would cause DataCloneError when Cesium workers process geometry
+     */
     async setGridCells(datasource) {
       this.gridCells = datasource.entities.values
         .filter(
@@ -80,7 +87,7 @@ export const useMitigationStore = defineStore("mitigation", {
             id: gridId,
             x: entity.properties.euref_x.getValue(),
             y: entity.properties.euref_y.getValue(),
-            entity: entity,
+            entity: markRaw(entity),
           };
         });
     },

--- a/src/stores/propsStore.js
+++ b/src/stores/propsStore.js
@@ -14,6 +14,7 @@
  */
 
 import { defineStore } from "pinia";
+import { markRaw } from "vue";
 
 /**
  * Props Pinia Store
@@ -100,16 +101,20 @@ export const usePropsStore = defineStore("props", {
     /**
      * Sets postal code boundary data source reference
      * @param {Object} data - Cesium postal code data source
+     * @note Uses markRaw to prevent Cesium data source from becoming reactive,
+     *       which would cause DataCloneError in Web Workers
      */
     setPostalCodeData(data) {
-      this.postalCodeData = data;
+      this.postalCodeData = markRaw(data);
     },
     /**
      * Sets the selected entity for heat/flood vulnerability analysis
      * @param {Object} entity - Cesium entity with vulnerability properties
+     * @note Uses markRaw to prevent Cesium entity from becoming reactive,
+     *       which would cause DataCloneError in Web Workers
      */
     setHeatFloodVulnerability(entity) {
-      this.heatFloodVulnerabilityEntity = entity;
+      this.heatFloodVulnerabilityEntity = markRaw(entity);
     },
     /**
      * Sets 250m grid cell building aggregation properties
@@ -156,16 +161,20 @@ export const usePropsStore = defineStore("props", {
     /**
      * Sets tree entity references for analysis
      * @param {Array<Object>} entities - Cesium tree canopy entities
+     * @note Uses markRaw to prevent Cesium entities from becoming reactive,
+     *       which would cause DataCloneError in Web Workers
      */
     setTreeEntities(entities) {
-      this.treeEntities = entities;
+      this.treeEntities = markRaw(entities);
     },
     /**
      * Sets buildings data source reference
      * @param {Object} datasource - Cesium buildings data source
+     * @note Uses markRaw to prevent Cesium datasource from becoming reactive,
+     *       which would cause DataCloneError in Web Workers
      */
     setBuildingsDatasource(datasource) {
-      this.buildingsDatasource = datasource;
+      this.buildingsDatasource = markRaw(datasource);
     },
     /**
      * Sets postal code-level heat exposure time-series data


### PR DESCRIPTION
Root cause: Cesium Entity objects and DataSource objects were being stored directly in Pinia stores, making them reactive via Vue's reactivity system. This caused DataCloneError when:
1. Cesium's Web Workers tried to process geometry data (postMessage cloning)
2. Sentry Pinia plugin attempted to serialize store state for error reporting
3. Multiple layers (NDVI + Trees) loaded simultaneously, overwhelming the system

The error manifested as:
"DataCloneError: Failed to execute 'postMessage' on 'Worker': [object Array] could not be cloned."

Technical details:
- Cesium entities contain functions, circular references, and WebGL contexts
- Vue's reactivity wraps these objects with Proxies
- Structured clone algorithm (used by postMessage) cannot clone:
  - Functions
  - DOM nodes
  - Proxied objects with certain internal slots
  - Circular references

Solution:
Use Vue's markRaw() to exclude Cesium objects from reactivity system:
- src/stores/propsStore.js: Mark treeEntities, buildingsDatasource, postalCodeData, and heatFloodVulnerabilityEntity
- src/stores/mitigationStore.js: Mark entity objects in gridCells array

This allows Cesium workers to process geometry without cloning errors while maintaining proper separation between reactive UI state and non-reactive 3D graphics objects.

Performance impact: Positive - reduces memory overhead from unnecessary reactivity tracking on large geometry datasets.

Fixes #[issue-number]
Resolves reported DataCloneError when toggling NDVI and Trees layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)