### PR TITLE
Set up cache busting for app updates

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -45,7 +45,41 @@ server {
     # Debug headers
     add_header X-Cache-Status $upstream_cache_status;
 
+    # Enable gzip compression for static assets
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1000;
+    gzip_proxied any;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/json application/xml+rss application/x-javascript;
+    gzip_disable "MSIE [1-6]\.";
+
+    # Rule 1: NEVER cache index.html (always check for new version)
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
+        try_files $uri =404;
+    }
+
+    # Rule 2: Aggressively cache hashed assets (they're immutable)
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        expires 1y;
+        access_log off;
+        try_files $uri =404;
+    }
+
+    # Rule 3: Don't cache unhashed static assets
+    location ~* \.(svg|png|jpg|jpeg|gif|ico|webp)$ {
+        add_header Cache-Control "no-cache" always;
+        try_files $uri =404;
+    }
+
+    # Rule 4: Default fallback for SPA routing
     location / {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
         try_files $uri $uri/ /index.html;
     }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -18,7 +18,7 @@ export default defineConfig(() => {
         output: {
           assetFileNames: `assets/[name].[hash].${version}.[ext]`,
           chunkFileNames: `assets/[name].[hash].${version}.js`,
-          entryFileNames: `assets/[name].${version}.js`,
+          entryFileNames: `assets/[name].[hash].${version}.js`,
           manualChunks: {
             // Split Cesium into its own chunk for better caching and async loading
             cesium: ["cesium"],


### PR DESCRIPTION
This commit implements production-grade cache busting to ensure users always receive the latest application version without manual cache clearing.

Changes:
- Add content hash to entry files in vite.config.js (was missing [hash])
- Configure nginx Cache-Control headers for optimal caching:
  * index.html: no-cache (always check for updates)
  * /assets/*: 1-year cache with immutable flag (safe due to hashes)
  * Unhashed static files: no-cache
- Enable gzip compression for static assets (JS, CSS, JSON)

Technical details:
- All build outputs now use dual-layer versioning: [name].[hash].[version].[ext]
- Content changes auto-invalidate via hash, version bumps provide extra layer
- Follows Vite best practices for long-term caching strategies

Fixes issue where users needed hard refresh after deployments.