### PR TITLE
ci: enable fail-fast for accessibility tests in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,6 +167,7 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=2048"
 
     strategy:
+      fail-fast: true
       matrix:
         viewport: [desktop, tablet, mobile]
 
@@ -201,7 +202,7 @@ jobs:
           timeout: "30"
 
       - name: Run accessibility tests
-        run: timeout 600 npm run test:accessibility:${{ matrix.viewport }} -- --reporter=list,json --trace=on-first-retry
+        run: timeout 600 npm run test:accessibility:${{ matrix.viewport }} -- -x --reporter=list,json --trace=on-first-retry
         env:
           PLAYWRIGHT_HTML_REPORT: playwright-report-${{ matrix.viewport }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,45 +2,39 @@
 
 ## [1.29.1](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/compare/r4c-cesium-viewer-v1.29.0...r4c-cesium-viewer-v1.29.1) (2025-11-11)
 
-
 ### Performance Improvements
 
-* Optimize WMS tile requests to reduce N+1 API calls by 75% ([#340](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/340)) ([c88c1bf](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/c88c1bfeff569800b535207be920ce023a08a602))
+- Optimize WMS tile requests to reduce N+1 API calls by 75% ([#340](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/340)) ([c88c1bf](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/c88c1bfeff569800b535207be920ce023a08a602))
 
 ## [1.29.0](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/compare/r4c-cesium-viewer-v1.28.4...r4c-cesium-viewer-v1.29.0) (2025-11-11)
 
-
 ### Features
 
-* add bundle size and Web Vitals performance tests ([#315](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/315)) ([5ea658f](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/5ea658f28c8d6e450747e36611b772df024fbeb5))
+- add bundle size and Web Vitals performance tests ([#315](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/315)) ([5ea658f](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/5ea658f28c8d6e450747e36611b772df024fbeb5))
 
 ## [1.28.4](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/compare/r4c-cesium-viewer-v1.28.3...r4c-cesium-viewer-v1.28.4) (2025-11-11)
 
-
 ### Bug Fixes
 
-* prevent DataCloneError by marking Cesium entities as non-reactive ([#336](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/336)) ([46e48f6](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/46e48f67fdce47bf3c54727dfb1d278955aa55f1))
+- prevent DataCloneError by marking Cesium entities as non-reactive ([#336](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/336)) ([46e48f6](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/46e48f67fdce47bf3c54727dfb1d278955aa55f1))
 
 ## [1.28.3](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/compare/r4c-cesium-viewer-v1.28.2...r4c-cesium-viewer-v1.28.3) (2025-11-10)
 
-
 ### Bug Fixes
 
-* correct nginx proxy_pass path handling for pygeoapi ([#333](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/333)) ([fc61f2b](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/fc61f2bc7413600fb55691549c61daabcfa0c30c))
+- correct nginx proxy_pass path handling for pygeoapi ([#333](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/333)) ([fc61f2b](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/fc61f2bc7413600fb55691549c61daabcfa0c30c))
 
 ## [1.28.2](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/compare/r4c-cesium-viewer-v1.28.1...r4c-cesium-viewer-v1.28.2) (2025-11-10)
 
-
 ### Bug Fixes
 
-* update Node.js version to 24 in Dockerfile ([#331](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/331)) ([1ff765d](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/1ff765d7dc28bcf884c186853d18d66b9bd0990a)), closes [#330](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/330)
+- update Node.js version to 24 in Dockerfile ([#331](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/331)) ([1ff765d](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/1ff765d7dc28bcf884c186853d18d66b9bd0990a)), closes [#330](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/330)
 
 ## [1.28.1](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/compare/r4c-cesium-viewer-v1.28.0...r4c-cesium-viewer-v1.28.1) (2025-11-10)
 
-
 ### Bug Fixes
 
-* use HTTP for internal Kubernetes pygeoapi service ([#327](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/327)) ([073f35a](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/073f35ad55644f12b87fb554d45b78b652f0aa07))
+- use HTTP for internal Kubernetes pygeoapi service ([#327](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/327)) ([073f35a](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/commit/073f35ad55644f12b87fb554d45b78b652f0aa07))
 
 ## [1.28.0](https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/compare/r4c-cesium-viewer-v1.27.12...r4c-cesium-viewer-v1.28.0) (2025-11-05)
 

--- a/tests/e2e/accessibility/layer-controls.spec.ts
+++ b/tests/e2e/accessibility/layer-controls.spec.ts
@@ -49,7 +49,9 @@ cesiumDescribe("Layer Controls Accessibility", () => {
         await expect(cesiumPage.getByText("NDVI")).toBeVisible();
 
         // NDVI should be functional in grid view too
-        await helpers.checkWithRetry(ndviToggle, { elementName: "NDVI in grid view" });
+        await helpers.checkWithRetry(ndviToggle, {
+          elementName: "NDVI in grid view",
+        });
         await expect(ndviToggle).toBeChecked();
       },
     );
@@ -114,10 +116,14 @@ cesiumDescribe("Layer Controls Accessibility", () => {
           .locator('input[type="checkbox"]');
 
         // Test toggle functionality
-        await helpers.checkWithRetry(landCoverToggle, { elementName: "Land Cover" });
+        await helpers.checkWithRetry(landCoverToggle, {
+          elementName: "Land Cover",
+        });
         await expect(landCoverToggle).toBeChecked();
 
-        await helpers.uncheckWithRetry(landCoverToggle, { elementName: "Land Cover" });
+        await helpers.uncheckWithRetry(landCoverToggle, {
+          elementName: "Land Cover",
+        });
         await expect(landCoverToggle).not.toBeChecked();
 
         // Should be visible in Grid view too
@@ -161,7 +167,9 @@ cesiumDescribe("Layer Controls Accessibility", () => {
           .locator("..")
           .locator('input[type="checkbox"]');
 
-        await helpers.checkWithRetry(landCoverToggle, { elementName: "Land Cover" });
+        await helpers.checkWithRetry(landCoverToggle, {
+          elementName: "Land Cover",
+        });
         await expect(landCoverToggle).toBeChecked();
 
         // Switch to Grid view - should maintain state
@@ -169,7 +177,9 @@ cesiumDescribe("Layer Controls Accessibility", () => {
         await expect(landCoverToggle).toBeChecked();
 
         // Disable in Grid view
-        await helpers.uncheckWithRetry(landCoverToggle, { elementName: "Land Cover" });
+        await helpers.uncheckWithRetry(landCoverToggle, {
+          elementName: "Land Cover",
+        });
         await expect(landCoverToggle).not.toBeChecked();
 
         // Switch back - state should be maintained
@@ -304,7 +314,9 @@ cesiumDescribe("Layer Controls Accessibility", () => {
           .locator('input[type="checkbox"]');
 
         // Scroll into view once before rapid toggling
-        await helpers.scrollIntoViewportWithRetry(ndviToggle, { elementName: "NDVI" });
+        await helpers.scrollIntoViewportWithRetry(ndviToggle, {
+          elementName: "NDVI",
+        });
         await cesiumPage.waitForTimeout(300);
 
         // Rapidly toggle NDVI multiple times with viewport checks
@@ -314,7 +326,10 @@ cesiumDescribe("Layer Controls Accessibility", () => {
           const isInViewport = box !== null && box.y >= 0 && box.x >= 0;
 
           if (!isInViewport) {
-            await helpers.scrollIntoViewportWithRetry(ndviToggle, { elementName: "NDVI", maxRetries: 2 });
+            await helpers.scrollIntoViewportWithRetry(ndviToggle, {
+              elementName: "NDVI",
+              maxRetries: 2,
+            });
             await cesiumPage.waitForTimeout(200);
           }
 
@@ -363,7 +378,9 @@ cesiumDescribe("Layer Controls Accessibility", () => {
 
         // Enable all available layers
         await helpers.checkWithRetry(ndviToggle, { elementName: "NDVI" });
-        await helpers.checkWithRetry(landCoverToggle, { elementName: "Land Cover" });
+        await helpers.checkWithRetry(landCoverToggle, {
+          elementName: "Land Cover",
+        });
         await helpers.checkWithRetry(treesToggle, { elementName: "Trees" });
 
         // Verify all are checked
@@ -373,7 +390,9 @@ cesiumDescribe("Layer Controls Accessibility", () => {
 
         // Disable all
         await helpers.uncheckWithRetry(ndviToggle, { elementName: "NDVI" });
-        await helpers.uncheckWithRetry(landCoverToggle, { elementName: "Land Cover" });
+        await helpers.uncheckWithRetry(landCoverToggle, {
+          elementName: "Land Cover",
+        });
         await helpers.uncheckWithRetry(treesToggle, { elementName: "Trees" });
 
         // Verify all are unchecked
@@ -397,7 +416,9 @@ cesiumDescribe("Layer Controls Accessibility", () => {
           .locator('input[type="checkbox"]');
 
         await helpers.checkWithRetry(ndviToggle, { elementName: "NDVI" });
-        await helpers.checkWithRetry(landCoverToggle, { elementName: "Land Cover" });
+        await helpers.checkWithRetry(landCoverToggle, {
+          elementName: "Land Cover",
+        });
 
         // Navigate to postal code level
         await helpers.drillToLevel("postalCode");
@@ -559,7 +580,9 @@ cesiumDescribe("Layer Controls Accessibility", () => {
           .locator('input[type="checkbox"]');
 
         // Scroll into view before interaction
-        await helpers.scrollIntoViewportWithRetry(ndviToggle, { elementName: "NDVI" });
+        await helpers.scrollIntoViewportWithRetry(ndviToggle, {
+          elementName: "NDVI",
+        });
         await cesiumPage.waitForTimeout(300);
 
         // Initial state
@@ -659,7 +682,9 @@ cesiumDescribe("Layer Controls Accessibility", () => {
           .locator('input[type="checkbox"]');
 
         await helpers.checkWithRetry(ndviToggle, { elementName: "NDVI" });
-        await helpers.checkWithRetry(landCoverToggle, { elementName: "Land Cover" });
+        await helpers.checkWithRetry(landCoverToggle, {
+          elementName: "Land Cover",
+        });
 
         await expect(ndviToggle).toBeChecked();
         await expect(landCoverToggle).toBeChecked();

--- a/tests/e2e/helpers/test-helpers.ts
+++ b/tests/e2e/helpers/test-helpers.ts
@@ -58,13 +58,15 @@ export class AccessibilityTestHelpers {
    */
   async scrollIntoViewportWithRetry(
     locator: Locator,
-    options: { maxRetries?: number; elementName?: string } = {}
+    options: { maxRetries?: number; elementName?: string } = {},
   ): Promise<void> {
     const { maxRetries = 3, elementName = "element" } = options;
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        await locator.scrollIntoViewIfNeeded({ timeout: TEST_TIMEOUTS.SCROLL_INTO_VIEW });
+        await locator.scrollIntoViewIfNeeded({
+          timeout: TEST_TIMEOUTS.SCROLL_INTO_VIEW,
+        });
         const box = await locator.boundingBox();
         if (box && box.y >= 0 && box.x >= 0) {
           return; // Successfully in viewport
@@ -73,7 +75,9 @@ export class AccessibilityTestHelpers {
         if (attempt === maxRetries) {
           console.warn(`Scroll failed for ${elementName}, continuing anyway`);
         }
-        await this.page.waitForTimeout(TEST_TIMEOUTS.RETRY_BACKOFF_BASE * attempt);
+        await this.page.waitForTimeout(
+          TEST_TIMEOUTS.RETRY_BACKOFF_BASE * attempt,
+        );
       }
     }
   }
@@ -99,7 +103,7 @@ export class AccessibilityTestHelpers {
    */
   async checkWithRetry(
     locator: Locator,
-    options: { maxRetries?: number; elementName?: string } = {}
+    options: { maxRetries?: number; elementName?: string } = {},
   ): Promise<void> {
     await this.scrollIntoViewportWithRetry(locator, options);
     await this.page.waitForTimeout(TEST_TIMEOUTS.RETRY_BACKOFF_INTERACTION);
@@ -116,9 +120,13 @@ export class AccessibilityTestHelpers {
         return;
       } catch {
         if (attempt === maxRetries) {
-          throw new Error(`Failed to check ${elementName} toggle after ${maxRetries} attempts`);
+          throw new Error(
+            `Failed to check ${elementName} toggle after ${maxRetries} attempts`,
+          );
         }
-        await this.page.waitForTimeout(TEST_TIMEOUTS.RETRY_BACKOFF_INTERACTION * attempt);
+        await this.page.waitForTimeout(
+          TEST_TIMEOUTS.RETRY_BACKOFF_INTERACTION * attempt,
+        );
       }
     }
   }
@@ -144,7 +152,7 @@ export class AccessibilityTestHelpers {
    */
   async uncheckWithRetry(
     locator: Locator,
-    options: { maxRetries?: number; elementName?: string } = {}
+    options: { maxRetries?: number; elementName?: string } = {},
   ): Promise<void> {
     await this.scrollIntoViewportWithRetry(locator, options);
     await this.page.waitForTimeout(TEST_TIMEOUTS.RETRY_BACKOFF_INTERACTION);
@@ -161,9 +169,13 @@ export class AccessibilityTestHelpers {
         return;
       } catch {
         if (attempt === maxRetries) {
-          throw new Error(`Failed to uncheck ${elementName} toggle after ${maxRetries} attempts`);
+          throw new Error(
+            `Failed to uncheck ${elementName} toggle after ${maxRetries} attempts`,
+          );
         }
-        await this.page.waitForTimeout(TEST_TIMEOUTS.RETRY_BACKOFF_INTERACTION * attempt);
+        await this.page.waitForTimeout(
+          TEST_TIMEOUTS.RETRY_BACKOFF_INTERACTION * attempt,
+        );
       }
     }
   }
@@ -204,7 +216,9 @@ export class AccessibilityTestHelpers {
         // Wait for page to be stable first
         await this.page
           .waitForLoadState("domcontentloaded", { timeout: 5000 })
-          .catch((e) => console.warn("DOM content load wait failed:", e.message));
+          .catch((e) =>
+            console.warn("DOM content load wait failed:", e.message),
+          );
 
         // Multi-strategy selector detection with fallbacks
         let viewCardFound = false;
@@ -386,9 +400,7 @@ export class AccessibilityTestHelpers {
           // Try to reset page state
           await this.page
             .waitForLoadState("domcontentloaded", { timeout: 5000 })
-            .catch((e) =>
-              console.warn("Page state reset failed:", e.message),
-            );
+            .catch((e) => console.warn("Page state reset failed:", e.message));
         }
       }
     }
@@ -535,7 +547,10 @@ export class AccessibilityTestHelpers {
               await this.page
                 .waitForLoadState("networkidle", { timeout: 5000 })
                 .catch((e) =>
-                  console.warn("Data load network idle wait failed:", e.message),
+                  console.warn(
+                    "Data load network idle wait failed:",
+                    e.message,
+                  ),
                 );
 
               // Wait for timeline component to fully initialize (critical for timeline tests)
@@ -689,7 +704,10 @@ export class AccessibilityTestHelpers {
               await this.page
                 .waitForLoadState("networkidle", { timeout: 5000 })
                 .catch((e) =>
-                  console.warn("Data load network idle wait failed:", e.message),
+                  console.warn(
+                    "Data load network idle wait failed:",
+                    e.message,
+                  ),
                 );
 
               // Wait for timeline component to remain fully interactive (critical for timeline tests)


### PR DESCRIPTION
## Summary

Configures fail-fast behavior for accessibility tests to provide immediate feedback and reduce CI time, especially important given how heavy the Cesium-based tests are.

## Changes

- **Strategy-level fail-fast**: Stops remaining viewport matrix jobs (desktop/tablet/mobile) when any viewport fails
- **Test-level fail-fast**: Added `-x` flag to stop test execution on first failing test within a single viewport run

## Benefits

This two-tier approach provides the fastest possible feedback loop in CI:
- **First failure in any test** → stops that viewport's test run immediately
- **First viewport failure** → cancels remaining viewport jobs

This should significantly reduce feedback time and CI resource usage when tests fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)