### PR TITLE
refactor: apply scroll-before-interact pattern to remaining test files

### DIFF
--- a/tests/e2e/accessibility/comprehensive-walkthrough.spec.ts
+++ b/tests/e2e/accessibility/comprehensive-walkthrough.spec.ts
@@ -205,10 +205,10 @@ cesiumDescribe("Comprehensive Walkthrough Accessibility", () => {
           .locator("..")
           .locator('input[type="checkbox"]');
 
-        await ndviToggle.check();
-        await landCoverToggle.check();
+        await helpers.checkWithRetry(ndviToggle, { elementName: "NDVI" });
+        await helpers.checkWithRetry(landCoverToggle, { elementName: "Land Cover" });
         if (await treesToggle.isVisible()) {
-          await treesToggle.check();
+          await helpers.checkWithRetry(treesToggle, { elementName: "Trees" });
         }
 
         // 3. Enable multiple filters
@@ -221,8 +221,8 @@ cesiumDescribe("Comprehensive Walkthrough Accessibility", () => {
           .locator("..")
           .locator('input[type="checkbox"]');
 
-        await publicBuildingsToggle.check();
-        await tallBuildingsToggle.check();
+        await helpers.checkWithRetry(publicBuildingsToggle, { elementName: "Public Buildings" });
+        await helpers.checkWithRetry(tallBuildingsToggle, { elementName: "Tall Buildings" });
 
         // 4. Use timeline
         const slider = cesiumPage.locator(".timeline-slider input");
@@ -265,8 +265,8 @@ cesiumDescribe("Comprehensive Walkthrough Accessibility", () => {
           .locator("..")
           .locator('input[type="checkbox"]');
 
-        await ndviToggle.check();
-        await tallBuildingsToggle.check();
+        await helpers.checkWithRetry(ndviToggle, { elementName: "NDVI" });
+        await helpers.checkWithRetry(tallBuildingsToggle, { elementName: "Tall Buildings" });
 
         // 2. Switch to Grid view
         await helpers.navigateToView("gridView");
@@ -491,7 +491,7 @@ cesiumDescribe("Comprehensive Walkthrough Accessibility", () => {
           .getByText("NDVI")
           .locator("..")
           .locator('input[type="checkbox"]');
-        await ndviToggle.check();
+        await helpers.checkWithRetry(ndviToggle, { elementName: "NDVI" });
 
         await helpers.drillToLevel("building");
         // Wait for building level under load

--- a/tests/e2e/accessibility/expansion-panels.spec.ts
+++ b/tests/e2e/accessibility/expansion-panels.spec.ts
@@ -35,6 +35,7 @@ cesiumDescribe("Expansion Panels Accessibility", () => {
 
         // Test expansion
         const hsyPanel = cesiumPage.getByText("HSY Background maps");
+        await helpers.scrollIntoViewportWithRetry(hsyPanel, { elementName: "HSY Background maps" });
         await hsyPanel.click();
 
         // Should reveal background map options
@@ -42,6 +43,7 @@ cesiumDescribe("Expansion Panels Accessibility", () => {
         await expect(cesiumPage.getByText("Map")).toBeVisible();
 
         // Collapse again
+        await helpers.scrollIntoViewportWithRetry(hsyPanel, { elementName: "HSY Background maps" });
         await hsyPanel.click();
         await expect(cesiumPage.getByText("Orthophoto")).toBeHidden();
       },
@@ -55,6 +57,7 @@ cesiumDescribe("Expansion Panels Accessibility", () => {
         ).toBeVisible();
 
         const sykePanel = cesiumPage.getByText("Syke Flood Background Maps");
+        await helpers.scrollIntoViewportWithRetry(sykePanel, { elementName: "Syke Flood Background Maps" });
         await sykePanel.click();
 
         // Should show flood scenario options
@@ -62,6 +65,7 @@ cesiumDescribe("Expansion Panels Accessibility", () => {
         await expect(cesiumPage.getByText("Flood: 1/20a, Sea")).toBeVisible();
         await expect(cesiumPage.getByText("Flood: 1/50a, Sea")).toBeVisible();
 
+        await helpers.scrollIntoViewportWithRetry(sykePanel, { elementName: "Syke Flood Background Maps" });
         await sykePanel.click();
         await expect(cesiumPage.getByText("Flood: 1/5a, Sea")).toBeHidden();
       },
@@ -73,6 +77,7 @@ cesiumDescribe("Expansion Panels Accessibility", () => {
         await expect(cesiumPage.getByText("Geocoding")).toBeVisible();
 
         const geocodingPanel = cesiumPage.getByText("Geocoding");
+        await helpers.scrollIntoViewportWithRetry(geocodingPanel, { elementName: "Geocoding" });
         await geocodingPanel.click();
 
         // Should show search input
@@ -85,6 +90,7 @@ cesiumDescribe("Expansion Panels Accessibility", () => {
         await searchInput.fill("Helsinki");
         await cesiumPage.keyboard.press("Enter");
 
+        await helpers.scrollIntoViewportWithRetry(geocodingPanel, { elementName: "Geocoding" });
         await geocodingPanel.click();
         await expect(searchInput).toBeHidden();
       },
@@ -112,11 +118,13 @@ cesiumDescribe("Expansion Panels Accessibility", () => {
         const gridOptionsPanel = cesiumPage.getByText(
           "Statistical grid options",
         );
+        await helpers.scrollIntoViewportWithRetry(gridOptionsPanel, { elementName: "Statistical grid options" });
         await gridOptionsPanel.click();
 
         // Should show grid configuration options
         await expect(cesiumPage.getByText("250m x 250m")).toBeVisible();
 
+        await helpers.scrollIntoViewportWithRetry(gridOptionsPanel, { elementName: "Statistical grid options" });
         await gridOptionsPanel.click();
         await expect(cesiumPage.getByText("250m x 250m")).toBeHidden();
       },
@@ -157,12 +165,14 @@ cesiumDescribe("Expansion Panels Accessibility", () => {
         await expect(cesiumPage.getByText("NDVI")).toBeVisible();
 
         const ndviPanel = cesiumPage.getByText("NDVI");
+        await helpers.scrollIntoViewportWithRetry(ndviPanel, { elementName: "NDVI panel" });
         await ndviPanel.click();
 
         // Should show NDVI options
         const ndviSlider = cesiumPage.locator(".ndvi-threshold-slider");
         await expect(ndviSlider).toBeVisible();
 
+        await helpers.scrollIntoViewportWithRetry(ndviPanel, { elementName: "NDVI panel" });
         await ndviPanel.click();
         await expect(ndviSlider).toBeHidden();
 
@@ -212,11 +222,13 @@ cesiumDescribe("Expansion Panels Accessibility", () => {
         // Should be visible
         const socioPanel = cesiumPage.getByText("Socioeconomics");
         if (await socioPanel.isVisible()) {
+          await helpers.scrollIntoViewportWithRetry(socioPanel, { elementName: "Socioeconomics panel" });
           await socioPanel.click();
 
           // Should show socioeconomic data
           await expect(cesiumPage.getByText("Population")).toBeVisible();
 
+          await helpers.scrollIntoViewportWithRetry(socioPanel, { elementName: "Socioeconomics panel" });
           await socioPanel.click();
           await expect(cesiumPage.getByText("Population")).toBeHidden();
         }
@@ -232,12 +244,14 @@ cesiumDescribe("Expansion Panels Accessibility", () => {
         // Land cover visibility depends on location
         const landCoverPanel = cesiumPage.getByText("Land cover");
         if (await landCoverPanel.isVisible()) {
+          await helpers.scrollIntoViewportWithRetry(landCoverPanel, { elementName: "Land Cover panel" });
           await landCoverPanel.click();
 
           // Should show land cover data
           const landCoverChart = cesiumPage.locator(".land-cover-chart");
           await expect(landCoverChart).toBeVisible();
 
+          await helpers.scrollIntoViewportWithRetry(landCoverPanel, { elementName: "Land Cover panel" });
           await landCoverPanel.click();
           await expect(landCoverChart).toBeHidden();
         }
@@ -261,12 +275,14 @@ cesiumDescribe("Expansion Panels Accessibility", () => {
         ).toBeVisible();
 
         const scatterPanel = cesiumPage.getByText("Building Scatter Plot");
+        await helpers.scrollIntoViewportWithRetry(scatterPanel, { elementName: "Building Scatter Plot panel" });
         await scatterPanel.click();
 
         // Should show scatter plot
         const scatterChart = cesiumPage.locator(".building-scatter-chart");
         await expect(scatterChart).toBeVisible();
 
+        await helpers.scrollIntoViewportWithRetry(scatterPanel, { elementName: "Building Scatter Plot panel" });
         await scatterPanel.click();
         await expect(scatterChart).toBeHidden();
       },
@@ -281,11 +297,13 @@ cesiumDescribe("Expansion Panels Accessibility", () => {
         // Should show area properties
         const areaProps = cesiumPage.getByText("Area properties");
         if (await areaProps.isVisible()) {
+          await helpers.scrollIntoViewportWithRetry(areaProps, { elementName: "Area properties panel" });
           await areaProps.click();
 
           // Should show property details
           await expect(cesiumPage.getByText("Total area")).toBeVisible();
 
+          await helpers.scrollIntoViewportWithRetry(areaProps, { elementName: "Area properties panel" });
           await areaProps.click();
           await expect(cesiumPage.getByText("Total area")).toBeHidden();
         }
@@ -301,11 +319,13 @@ cesiumDescribe("Expansion Panels Accessibility", () => {
         // Should show building properties
         const buildingProps = cesiumPage.getByText("Building properties");
         if (await buildingProps.isVisible()) {
+          await helpers.scrollIntoViewportWithRetry(buildingProps, { elementName: "Building properties panel" });
           await buildingProps.click();
 
           // Should show property details
           await expect(cesiumPage.getByText("Building type")).toBeVisible();
 
+          await helpers.scrollIntoViewportWithRetry(buildingProps, { elementName: "Building properties panel" });
           await buildingProps.click();
           await expect(cesiumPage.getByText("Building type")).toBeHidden();
         }
@@ -349,6 +369,7 @@ cesiumDescribe("Expansion Panels Accessibility", () => {
       async ({ cesiumPage }) => {
         // Expand HSY panel
         const hsyPanel = cesiumPage.getByText("HSY Background maps");
+        await helpers.scrollIntoViewportWithRetry(hsyPanel, { elementName: "HSY Background maps" });
         await hsyPanel.click();
         await expect(cesiumPage.getByText("Orthophoto")).toBeVisible();
 
@@ -374,8 +395,11 @@ cesiumDescribe("Expansion Panels Accessibility", () => {
         const sykePanel = cesiumPage.getByText("Syke Flood Background Maps");
         const geocodingPanel = cesiumPage.getByText("Geocoding");
 
+        await helpers.scrollIntoViewportWithRetry(hsyPanel, { elementName: "HSY Background maps" });
         await hsyPanel.click();
+        await helpers.scrollIntoViewportWithRetry(sykePanel, { elementName: "Syke Flood Background Maps" });
         await sykePanel.click();
+        await helpers.scrollIntoViewportWithRetry(geocodingPanel, { elementName: "Geocoding" });
         await geocodingPanel.click();
 
         // All should be expanded
@@ -386,6 +410,7 @@ cesiumDescribe("Expansion Panels Accessibility", () => {
         ).toBeVisible();
 
         // Collapse one shouldn't affect others
+        await helpers.scrollIntoViewportWithRetry(hsyPanel, { elementName: "HSY Background maps" });
         await hsyPanel.click();
         await expect(cesiumPage.getByText("Orthophoto")).toBeHidden();
         await expect(cesiumPage.getByText("Flood: 1/5a, Sea")).toBeVisible();
@@ -409,11 +434,13 @@ cesiumDescribe("Expansion Panels Accessibility", () => {
         expect(ariaExpanded).toBeDefined();
 
         // Expand and check state change
+        await helpers.scrollIntoViewportWithRetry(hsyPanel, { elementName: "HSY Background maps" });
         await hsyPanel.click();
         const expandedState = await hsyButton.getAttribute("aria-expanded");
         expect(expandedState).toBe("true");
 
         // Collapse and check
+        await helpers.scrollIntoViewportWithRetry(hsyPanel, { elementName: "HSY Background maps" });
         await hsyPanel.click();
         const collapsedState = await hsyButton.getAttribute("aria-expanded");
         expect(collapsedState).toBe("false");

--- a/tests/e2e/accessibility/navigation-levels.spec.ts
+++ b/tests/e2e/accessibility/navigation-levels.spec.ts
@@ -516,7 +516,7 @@ cesiumDescribe("Navigation Levels Accessibility", () => {
             .getByText("Trees")
             .locator("..")
             .locator('input[type="checkbox"]');
-          await treesToggle.check();
+          await helpers.checkWithRetry(treesToggle, { elementName: "Trees" });
           await expect(treesToggle).toBeChecked();
         }
       },

--- a/tests/e2e/accessibility/view-modes.spec.ts
+++ b/tests/e2e/accessibility/view-modes.spec.ts
@@ -265,6 +265,7 @@ cesiumDescribe("View Modes Accessibility", () => {
         const resetButton = cesiumPage
           .getByRole("button")
           .filter({ has: cesiumPage.locator(".mdi-refresh") });
+        await helpers.scrollIntoViewportWithRetry(resetButton, { elementName: "Reset button" });
         await resetButton.click();
 
         // Wait for reset to complete


### PR DESCRIPTION
## Summary

Applies the scroll-before-interact helper methods established in PR #350 to the remaining accessibility test files to improve test reliability and reduce viewport-related flakiness.

## Changes

- **comprehensive-walkthrough.spec.ts**: Replace 8 direct `.check()` calls with `helpers.checkWithRetry()` for toggle interactions
- **navigation-levels.spec.ts**: Replace 1 direct `.check()` call with `helpers.checkWithRetry()` for Trees toggle
- **expansion-panels.spec.ts**: Add `helpers.scrollIntoViewportWithRetry()` before 20+ expansion panel click interactions
- **view-modes.spec.ts**: Add `helpers.scrollIntoViewportWithRetry()` before reset button click
- **timeline-controls.spec.ts**: No changes needed - already using helpers appropriately

## Benefits

- Improved reliability: Elements are properly scrolled into viewport before interaction
- Consistent pattern: All test files now use the same helper methods
- Reduced flakiness: Viewport-related test failures should be significantly reduced
- Better maintainability: Centralized scroll-before-interact logic in helper methods

## Related

Closes #351
Follows pattern from PR #350

----

Generated with [Claude Code](https://claude.ai/code)