### PR TITLE
fix(dev): resolve port conflicts for local Skaffold development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@
 # ==============================================================================
 #
 # 1. LOCAL FRONTEND + LOCAL SERVICES (Recommended - fast iteration)
-#    a. Set VITE_PYGEOAPI_HOST=localhost:5000
+#    a. Set VITE_PYGEOAPI_HOST=localhost:5001
 #    b. Run: make dev
 #    Services persist on Ctrl+C, only frontend stops.
 #
@@ -35,7 +35,7 @@
 
 # PygeoAPI Host (controls where building/geo data comes from)
 # Default: pygeoapi.dataportal.fi (production)
-# For local services: localhost:5000
+# For local services: localhost:5001 (port 5000 conflicts with macOS AirPlay)
 VITE_PYGEOAPI_HOST=pygeoapi.dataportal.fi
 
 # Digitransit API Key (optional - for public transport routing features)
@@ -58,7 +58,8 @@ SENTRY_AUTH_TOKEN=
 
 # PostgreSQL connection string for dbmate migrations
 # Default values work with local Skaffold setup
-DATABASE_URL=postgres://regions4climate_user:regions4climate_pass@localhost:5432/regions4climate
+# Port 5434 avoids conflicts with local PostgreSQL installations
+DATABASE_URL=postgres://regions4climate_user:regions4climate_pass@localhost:5434/regions4climate
 
 # Database passwords (used by Skaffold to create secrets)
 DB_PASSWORD=regions4climate_pass

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -84,12 +84,12 @@ profiles:
       - resourceType: service
         resourceName: postgresql
         port: 5432
-        localPort: 5432
+        localPort: 5434
         address: 127.0.0.1
       - resourceType: service
         resourceName: pygeoapi
         port: 80
-        localPort: 5000
+        localPort: 5001
         address: 127.0.0.1
 
   # Frontend only - assumes services-only is already running


### PR DESCRIPTION
## Summary

- Change PyGeoAPI port from 5000 → 5001 (avoids macOS AirPlay Receiver conflict)
- Change PostgreSQL port from 5432 → 5434 (avoids local PostgreSQL installations)
- Update `.env.example` with new ports and document the reasoning
- Add port-forward import method to `DATABASE_IMPORT.md` for faster restores

## Problem

On macOS Monterey+, port 5000 is used by AirPlay Receiver (ControlCenter), causing Skaffold to auto-assign a different port. This led to configuration mismatches where `.env` expected port 5000 but Skaffold was actually forwarding to a different port.

Similarly, port 5432 often conflicts with local PostgreSQL installations.

## Solution

Use non-conflicting ports by default:
- **5001** for PyGeoAPI (avoids AirPlay)
- **5434** for PostgreSQL (avoids local PG)

## Test plan

- [ ] Run `make dev` and verify services start on expected ports
- [ ] Verify frontend successfully connects to local PyGeoAPI
- [ ] Verify database connections work via port-forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)