### PR TITLE
feat(viewport): add fade-in animation and fix cache status warnings

### DIFF
--- a/src/services/viewportBuildingLoader.js
+++ b/src/services/viewportBuildingLoader.js
@@ -395,6 +395,15 @@ export default class ViewportBuildingLoader {
 				.then(() => {
 					this.activeLoads--;
 					this.loadingTiles.delete(tileKey);
+
+					// Show the newly loaded tile with fade-in animation
+					const viewPrefix = this.toggleStore.helsinkiView ? 'Helsinki' : 'HSY';
+					const datasourceName = `Buildings Viewport ${viewPrefix} ${tileKey}`;
+					const datasource = this.datasourceService.getDataSourceByName(datasourceName);
+					if (datasource) {
+						void this.fadeInDatasource(datasource);
+					}
+
 					// Continue processing queue
 					void this.processLoadingQueue();
 				})

--- a/src/stores/loadingStore.js
+++ b/src/stores/loadingStore.js
@@ -331,6 +331,26 @@ export const useLoadingStore = defineStore('loading', {
 			}
 		},
 
+		/**
+		 * Update cache status for a layer (called by unifiedLoader after caching)
+		 * @param {string} layerId - Layer identifier
+		 * @param {boolean} cached - Whether data is cached
+		 * @param {number} timestamp - Cache timestamp
+		 */
+		updateCacheStatus(layerId, cached, timestamp = null) {
+			// Extract base layer name from layerId (e.g., "viewport_buildings_hsy_2499_6025" -> dynamic)
+			// For dynamic layer IDs, we just acknowledge the cache update without state tracking
+			// This prevents warnings while maintaining compatibility with unifiedLoader
+			if (this.cacheStatus[layerId]) {
+				this.cacheStatus[layerId] = {
+					cached,
+					age: timestamp ? Date.now() - timestamp : 0,
+					timestamp,
+				};
+			}
+			// For dynamic layer IDs not in predefined cacheStatus, silently succeed
+		},
+
 		// Data source health management
 		updateDataSourceHealth(sourceName, status, responseTime = null, error = null) {
 			if (this.dataSourceHealth[sourceName]) {


### PR DESCRIPTION
## Summary
- Add fade-in animation trigger when viewport tiles complete loading for smoother visual transitions
- Add `updateCacheStatus` action to loadingStore that handles dynamic layer IDs (viewport tiles) without logging warnings

## Test plan
- [ ] Verify viewport building tiles fade in smoothly when loaded
- [ ] Confirm no console warnings appear for cache status updates during viewport tile loading
- [ ] Test both Helsinki and Capital Region view modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)