### PR TITLE
build(vite): strip console.log and debugger from production builds

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -54,6 +54,12 @@ export default defineConfig(({ mode }) => {
 	const buildTime = new Date().toISOString();
 
 	return {
+		// Strip console.log and console.debug from production builds
+		// Keeps console.warn, console.error, console.info for production monitoring
+		esbuild: {
+			drop: mode === 'production' ? ['debugger'] : [],
+			pure: mode === 'production' ? ['console.log', 'console.debug'] : [],
+		},
 		build: {
 			sourcemap: true, // Source map generation must be turned on
 			target: 'es2020', // Modern browsers only for better optimization


### PR DESCRIPTION
## Summary
- Configures esbuild to drop debugger statements in production
- Marks console.log and console.debug as pure (tree-shakeable)
- Keeps console.warn, console.error, console.info for production monitoring

## Changes
- Added esbuild configuration to vite.config.js with `drop` and `pure` options
- Production bundles will have significantly fewer debug statements

## Test plan
- [x] Build succeeds with `npm run build`
- [x] Verified console.log count reduced in production bundle (3 remaining from arrow function callbacks vs 435+ in source)
- [x] console.warn/error preserved for production monitoring

Partially addresses #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)