### PR TITLE
fix: update Dockerfile to use bun.lock instead of bun.lockb

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,7 @@
 !eslint.config.js
 !public
 !package.json
-!package-lock.json
+!bun.lock
 !index.html
 !db
 !scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV VITE_PYGEOAPI_HOST=${VITE_PYGEOAPI_HOST}
 
 WORKDIR /app
 
-COPY package.json bun.lockb ./
+COPY package.json bun.lock ./
 # Cache bun packages across builds for faster installs
 RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

- Updates Dockerfile to reference `bun.lock` instead of `bun.lockb`
- Updates `.dockerignore` to allow `bun.lock` instead of `package-lock.json`

The migration from npm to bun updated the lockfile to `bun.lock` (text-based JSON format) but the Dockerfile and .dockerignore were still referencing the old formats.

Fixes #439

## Test plan

- [ ] Container build succeeds in CI
- [ ] Docker image builds correctly locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)