### PR TITLE
refactor: replace direct DOM manipulation with Vue refs and events

### DIFF
--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -205,14 +205,8 @@ export default {
 				eventBus.emit('create250mGrid') // Trigger the simulation to start
 			} else {
 				this.datasourceService.removeDataSourcesByNamePrefix('250m_grid')
-				// Use refs for child component visibility control
-				if (this.$refs.buildingGridChart?.$el) {
-					const barChartContainer =
-						this.$refs.buildingGridChart.$el.querySelector('#bar-chart-container')
-					const legend = this.$refs.buildingGridChart.$el.querySelector('#legend')
-					if (barChartContainer) barChartContainer.style.visibility = 'hidden'
-					if (legend) legend.style.visibility = 'hidden'
-				}
+				// Hide building grid chart via event bus (maintains component encapsulation)
+				eventBus.emit('hideBuildingGridChart')
 				this.datasourceService.changeDataSourceShowByName('PopulationGrid', true)
 			}
 		},
@@ -226,11 +220,8 @@ export default {
 				void espooSurveyService.loadSurveyFeatures('places_in_everyday_life')
 			} else {
 				this.datasourceService.removeDataSourcesByNamePrefix('Survey ')
-				// Use refs for child component visibility control
-				if (this.$refs.surveyScatterPlot?.$el) {
-					const scatterPlot = this.$refs.surveyScatterPlot.$el.querySelector('#surveyScatterPlot')
-					if (scatterPlot) scatterPlot.style.visibility = 'hidden'
-				}
+				// Hide survey scatter plot via event bus (maintains component encapsulation)
+				eventBus.emit('hideSurveyScatterPlot')
 			}
 		},
 

--- a/src/components/PostalCodeView.vue
+++ b/src/components/PostalCodeView.vue
@@ -376,11 +376,11 @@ export default {
 			const camera = new Camera()
 			camera.init()
 
-			// Hide tooltip
-			const tooltip = document.querySelector('.tooltip')
-			if (tooltip) {
-				tooltip.style.display = 'none'
-			}
+			// Hide all D3.js tooltips via D3 selection (maintains D3.js consistency)
+			// D3 creates tooltips dynamically, so we use D3 selection to hide them
+			void import('d3').then(({ selectAll }) => {
+				selectAll('.tooltip').style('opacity', 0).style('display', 'none')
+			})
 		},
 		returnToPostalCode() {
 			const featurepicker = new Featurepicker()

--- a/src/components/Scatterplot.vue
+++ b/src/components/Scatterplot.vue
@@ -1,5 +1,8 @@
 <template>
-	<div id="scatterPlotContainer" />
+	<div
+		id="scatterPlotContainer"
+		ref="containerRef"
+	/>
 
 	<select
 		ref="numericalSelect"
@@ -287,12 +290,12 @@ export default {
 		},
 
 		/**
-		 * Initialize plot container using D3.js selector
-		 * Note: D3.js requires DOM access for SVG manipulation - this is legitimate usage
+		 * Initialize plot container using Vue ref (proper Vue pattern)
+		 * Note: D3.js requires DOM access for SVG manipulation - using ref maintains Vue encapsulation
 		 */
-		initializePlotContainer(containerId) {
-			// Use D3.js selector for consistency with other D3.js operations
-			const container = d3.select(`#${containerId}`).node()
+		initializePlotContainer() {
+			// Use Vue ref for direct DOM access (maintains component encapsulation)
+			const container = this.$refs.containerRef
 			if (container) {
 				// Use textContent for safe clearing (prevents potential XSS)
 				container.textContent = ''
@@ -472,9 +475,11 @@ export default {
 		},
 
 		clearScatterPlot() {
-			// Remove or clear the D3.js visualization
-			// Example:
-			d3.select('#scatterPlotContainer').select('svg').remove()
+			// Remove or clear the D3.js visualization using Vue ref
+			// Using D3.js on the ref value maintains Vue encapsulation
+			if (this.$refs.containerRef) {
+				d3.select(this.$refs.containerRef).select('svg').remove()
+			}
 		},
 	},
 }


### PR DESCRIPTION
## Summary
- Replace `document.getElementById` and `document.querySelector` with Vue refs
- Use event bus for parent-child component communication instead of querying child DOM internals
- Maintain proper Vue component encapsulation and follow Vue best practices

## Changes
| File | Change |
|------|--------|
| PostalCodeView.vue | Use D3 selection for tooltip hiding instead of `document.querySelector` |
| GridView.vue | Emit events (`hideBuildingGridChart`, `hideSurveyScatterPlot`) instead of querying child DOM |
| BuildingGridChart.vue | Listen for hide event, use Vue ref for container |
| SurveyScatterPlot.vue | Listen for hide event, use Vue ref instead of `document.getElementById` |
| Scatterplot.vue | Use Vue ref for container instead of `d3.select('#id')` |

## Test plan
- [ ] Build succeeds (`npm run build` ✓)
- [ ] Linting passes (`npm run lint` ✓)
- [ ] Grid view toggle shows/hides correctly
- [ ] Survey scatter plot visibility works
- [ ] Scatter plot in postal code view works
- [ ] Tooltips hide on reset

Fixes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)