### PR TITLE
refactor: add Vue watcher cleanup handlers

### DIFF
--- a/src/components/FloodBackgroundSyke.vue
+++ b/src/components/FloodBackgroundSyke.vue
@@ -73,7 +73,7 @@
 </template>
 
 <script setup>
-import { computed, nextTick, ref, watch } from 'vue'
+import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
 import { createFloodImageryLayer, removeFloodLayers } from '../services/floodwms'
 import { useURLStore } from '../stores/urlStore'
 
@@ -139,9 +139,15 @@ const updateWMS = async (config) => {
 	}
 }
 
-watch(selectedScenario, async () => {
+// Capture stop handler for explicit cleanup on unmount
+const stopWatchScenario = watch(selectedScenario, async () => {
 	await nextTick() // Ensure updates propagate before modifying layers
 	updateWMS(wmsConfig.value).catch(console.error)
+})
+
+// Cleanup on unmount
+onUnmounted(() => {
+	stopWatchScenario()
 })
 </script>
 

--- a/src/components/GraphicsQuality.vue
+++ b/src/components/GraphicsQuality.vue
@@ -267,7 +267,7 @@
 </template>
 
 <script>
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { useGraphicsStore } from '../stores/graphicsStore.js'
 
 export default {
@@ -364,7 +364,8 @@ export default {
 		}
 
 		// Watch for external changes to update preset selection
-		watch(
+		// Capture stop handler for explicit cleanup on unmount
+		const stopWatchGraphicsSettings = watch(
 			() => [
 				graphicsStore.msaaEnabled,
 				graphicsStore.msaaSamples,
@@ -379,6 +380,11 @@ export default {
 			},
 			{ deep: true }
 		)
+
+		onBeforeUnmount(() => {
+			// Stop watcher to prevent stale callbacks
+			stopWatchGraphicsSettings()
+		})
 
 		const detectCurrentPreset = () => {
 			const state = graphicsStore

--- a/src/components/UnifiedSearch.vue
+++ b/src/components/UnifiedSearch.vue
@@ -234,7 +234,7 @@
  * <UnifiedSearch />
  */
 
-import { computed, ref, watch } from 'vue'
+import { computed, onUnmounted, ref, watch } from 'vue'
 import Camera from '../services/camera'
 import { eventBus } from '../services/eventEmitter'
 import FeaturePicker from '../services/featurepicker'
@@ -597,8 +597,9 @@ const handleClickOutside = () => {
  * Watches for view changes and refreshes search results
  *
  * Re-executes search when view changes to apply new filtering context.
+ * Capture stop handler for explicit cleanup on unmount.
  */
-watch(
+const stopWatchView = watch(
 	() => globalStore.view,
 	() => {
 		if (searchQuery.value) {
@@ -606,6 +607,11 @@ watch(
 		}
 	}
 )
+
+// Cleanup on unmount
+onUnmounted(() => {
+	stopWatchView()
+})
 </script>
 
 <style scoped>

--- a/src/components/ViewportLoadingIndicator.vue
+++ b/src/components/ViewportLoadingIndicator.vue
@@ -222,7 +222,8 @@ const handleRetry = () => {
 }
 
 // Watch for loading state changes to show completion
-watch(isLoading, (newValue, oldValue) => {
+// Capture stop handlers for explicit cleanup on unmount
+const stopWatchIsLoading = watch(isLoading, (newValue, oldValue) => {
 	// Detect transition from loading to not loading
 	if (oldValue && !newValue && !hasError.value) {
 		// Clear any pending timeout
@@ -250,7 +251,7 @@ watch(isLoading, (newValue, oldValue) => {
 })
 
 // Announce errors to screen readers
-watch(hasError, (newValue) => {
+const stopWatchHasError = watch(hasError, (newValue) => {
 	if (newValue) {
 		screenReaderAnnouncement.value = `Error: ${errorMessage.value}`
 	}
@@ -261,6 +262,9 @@ onUnmounted(() => {
 	if (completeTimeout) {
 		clearTimeout(completeTimeout)
 	}
+	// Stop watchers to prevent stale callbacks
+	stopWatchIsLoading()
+	stopWatchHasError()
 })
 </script>
 

--- a/src/pages/CapitalRegion.vue
+++ b/src/pages/CapitalRegion.vue
@@ -106,13 +106,9 @@ export default {
 			})
 		})
 
-		onBeforeUnmount(() => {
-			eventBus.off('showCapitalRegion')
-			eventBus.off('hideCapitalRegion')
-		})
-
 		// Watch landCover toggle to control mutual exclusivity
-		watch(
+		// Capture stop handlers for explicit cleanup on unmount
+		const stopWatchLandCover = watch(
 			() => toggleStore.landCover,
 			(newValue) => {
 				showLandcover.value = toggleStore.helsinkiView ? showLandcover.value : !!newValue
@@ -121,7 +117,7 @@ export default {
 		)
 
 		// Separate control for HSYWMS based on postalcode and landcover visibility
-		watch(
+		const stopWatchPostalCode = watch(
 			() => store.postalcode,
 			(newPostalCode) => {
 				if (!showLandcover.value && newPostalCode) {
@@ -129,6 +125,14 @@ export default {
 				}
 			}
 		)
+
+		onBeforeUnmount(() => {
+			eventBus.off('showCapitalRegion')
+			eventBus.off('hideCapitalRegion')
+			// Stop watchers to prevent stale callbacks
+			stopWatchLandCover()
+			stopWatchPostalCode()
+		})
 
 		return {
 			showComponents,


### PR DESCRIPTION
## Summary

Add explicit stop handlers for watchers in Composition API components to prevent potential memory leaks and stale callbacks.

## Changes

### Watcher Cleanup Added

| File | Watchers | Cleanup Hook |
|------|----------|--------------|
| `ViewportLoadingIndicator.vue` | `isLoading`, `hasError` | `onUnmounted` |
| `FloodBackgroundSyke.vue` | `selectedScenario` | `onUnmounted` (new) |
| `CapitalRegion.vue` | `landCover`, `postalcode` | `onBeforeUnmount` |
| `GraphicsQuality.vue` | graphics settings array | `onBeforeUnmount` (new) |
| `UnifiedSearch.vue` | `view` | `onUnmounted` (new) |

### Pattern Applied

```javascript
// Before
watch(() => store.value, (newValue) => { /* ... */ })

// After
const stopWatcher = watch(() => store.value, (newValue) => { /* ... */ })

onUnmounted(() => {
    stopWatcher()
})
```

## PostalCodeView.vue Migration Deferred

The issue describes `PostalCodeView.vue` as mixing Options API with Composition API, but upon inspection:

- The component is **pure Options API** (not mixed)
- Options API `watch:` watchers **auto-cleanup on unmount**
- The component already has proper `beforeUnmount()` for event cleanup
- A full migration to Composition API would be a larger, separate effort

## Acceptance Criteria

- [x] `ViewportLoadingIndicator.vue` - Capture `watch(isLoading)` stop handler ✓
- [x] `FloodBackgroundSyke.vue` - Capture `watch(selectedScenario)` stop handler ✓
- [x] `CapitalRegion.vue` - Capture both watcher stop handlers ✓
- [x] `GraphicsQuality.vue` - Capture complex watcher stop handler ✓
- [x] `UnifiedSearch.vue` - Capture search watcher stop handlers ✓
- [ ] `PostalCodeView.vue` fully migrated to Composition API - **Deferred** (pure Options API, auto-cleans)
- [x] All affected components pass existing tests ✓
- [x] No Vue warnings about unmounted component state updates ✓

Partial fix for #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)