### PR TITLE
fix(viewport): pass viewer.value instead of ref to ViewportBuildingLoader

### DIFF
--- a/src/composables/useViewportLoading.js
+++ b/src/composables/useViewportLoading.js
@@ -193,7 +193,7 @@ export function useViewportLoading(viewer, Camera, Featurepicker) {
 	 * @returns {Promise<void>}
 	 */
 	const initViewportStreaming = async () => {
-		if (!viewer) {
+		if (!viewer?.value) {
 			logger.warn('[useViewportLoading] Cannot init viewport streaming - viewer not ready')
 			return
 		}
@@ -201,7 +201,7 @@ export function useViewportLoading(viewer, Camera, Featurepicker) {
 		if (featureFlagStore.isEnabled('viewportStreaming')) {
 			viewportBuildingLoader = new ViewportBuildingLoader()
 			// Await initialization - includes retry logic for globe readiness
-			await viewportBuildingLoader.initialize(viewer)
+			await viewportBuildingLoader.initialize(viewer.value)
 			logger.debug('[useViewportLoading] ✅ ViewportBuildingLoader initialized (tile-based mode)')
 		}
 	}
@@ -213,7 +213,7 @@ export function useViewportLoading(viewer, Camera, Featurepicker) {
 	watch(
 		() => featureFlagStore.isEnabled('viewportStreaming'),
 		async (newValue, _oldValue) => {
-			if (!viewer) {
+			if (!viewer?.value) {
 				logger.warn('[useViewportLoading] Viewer not initialized, cannot toggle viewport streaming')
 				return
 			}
@@ -222,7 +222,7 @@ export function useViewportLoading(viewer, Camera, Featurepicker) {
 				// Enable viewport streaming
 				logger.debug('[useViewportLoading] Enabling viewport streaming (tile-based loading)')
 				viewportBuildingLoader = new ViewportBuildingLoader()
-				await viewportBuildingLoader.initialize(viewer)
+				await viewportBuildingLoader.initialize(viewer.value)
 			} else if (!newValue && viewportBuildingLoader) {
 				// Disable viewport streaming
 				logger.debug('[useViewportLoading] Disabling viewport streaming')


### PR DESCRIPTION
## Summary

- Fix TypeError when initializing ViewportBuildingLoader with viewport streaming enabled
- The `useViewportLoading` composable receives `viewer` as a Vue ref but was passing the ref object directly instead of `viewer.value`
- This caused "Cannot read properties of undefined (reading 'moveEnd')" when accessing `viewer.camera.moveEnd`

## Changes

- Change guard checks from `if (!viewer)` to `if (!viewer?.value)` to properly check the unwrapped value
- Pass `viewer.value` to `initialize()` in both `initViewportStreaming` and the feature flag watcher

## Test plan

- [ ] Enable viewport streaming feature flag
- [ ] Verify no console errors on page load
- [ ] Verify buildings load correctly when navigating to postal code level

🤖 Generated with [Claude Code](https://claude.com/claude-code)