### PR TITLE
feat: add mock PyGeoAPI server for database-free development

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,23 @@ VITE_PYGEOAPI_HOST=localhost:5000
 
 ## Quick Start
 
+Choose your development mode:
+
+### Fastest: Mock API (No Database Required)
+
+Perfect for frontend development. No Kubernetes or PostgreSQL needed.
+
+```bash
+npm install
+make dev-mock
+```
+
+**Available at:** http://localhost:5173 (frontend) | http://localhost:5050 (mock API)
+
+### Full Stack: With Database
+
+For testing with real database queries or production data.
+
 ```bash
 # First time setup
 cp .env.example .env
@@ -33,19 +50,40 @@ make setup
 
 # Start development (services persist, frontend iterates)
 make dev
+
+# Seed with test data (recommended)
+make db-seed
 ```
 
 **Available at:** http://localhost:5173 (frontend) | http://localhost:5000 (pygeoapi)
 
 ## Development Modes
 
-| Command         | Description                   | Frontend       | Services              |
+| Command         | Description                   | Frontend       | Backend               |
 | --------------- | ----------------------------- | -------------- | --------------------- |
+| `make dev-mock` | Mock API (no database)        | localhost:5173 | Mock server on :5050  |
 | `make dev`      | Local frontend + K8s services | localhost:5173 | Persist on Ctrl+C     |
 | `make dev-full` | All in containers             | localhost:4173 | Persist on Ctrl+C     |
 | `make stop`     | Stop everything               | -              | Data preserved in PVC |
 
-### make dev (Recommended)
+### make dev-mock (Fastest)
+
+Uses a lightweight Bun server with synthetic GeoJSON data. No containers, no database:
+
+```bash
+make dev-mock
+# Ctrl+C stops both mock server and frontend
+```
+
+The mock API:
+
+- Serves all 11 PyGeoAPI collections
+- Supports query parameters (`postinumero`, `bbox`, `limit`, etc.)
+- Auto-detected by Vite (no configuration needed)
+
+See [mock-api/README.md](./mock-api/README.md) for details.
+
+### make dev (Recommended for Full Stack)
 
 Backend services run in Kubernetes, frontend runs locally with Vite for fast hot-reload:
 
@@ -72,6 +110,9 @@ make stop
 
 # Stop only frontend (keep services)
 make stop-frontend
+
+# Stop mock API
+make mock-stop
 
 # View all commands
 make help
@@ -149,6 +190,8 @@ docker system --prune --all
 
 ## Project Documentation
 
+- [Getting Started Guide](./docs/GETTING_STARTED.md) - Complete setup with all options
+- [Mock API Documentation](./mock-api/README.md) - Lightweight development without database
 - [Local Development Guide](./docs/LOCAL_DEVELOPMENT.md) - Complete setup with PostgreSQL + pygeoapi
 - [Database Migrations](./db/README.md) - Schema management with dbmate
 - [Database Seeding](./docs/DATABASE_SEEDING.md) - Mock data for testing

--- a/mock-api/.gitignore
+++ b/mock-api/.gitignore
@@ -1,0 +1,6 @@
+# Generated fixtures - regenerate with: bun run generate
+fixtures/
+
+# Bun dependencies
+node_modules/
+bun.lockb

--- a/mock-api/README.md
+++ b/mock-api/README.md
@@ -1,0 +1,200 @@
+# Mock PyGeoAPI Server
+
+Lightweight Bun server that mimics PyGeoAPI endpoints for local development.
+No database required - uses generated GeoJSON fixtures.
+
+## Quick Start
+
+```bash
+# Generate fixtures (one time)
+bun run generate
+
+# Start mock server
+bun run dev
+```
+
+The server runs on `http://localhost:5050` (port 5000 is often used by AirPlay on macOS).
+
+## Usage with Frontend
+
+### Recommended: Use Makefile
+
+```bash
+# Start mock API + frontend together
+make dev-mock
+```
+
+This automatically:
+
+1. Generates fixtures if needed
+2. Starts the mock server on port 5050
+3. Starts Vite dev server
+4. Cleans up on Ctrl+C
+
+### Manual Start (Two Terminals)
+
+```bash
+# Terminal 1: Start mock API
+cd mock-api && bun run dev
+
+# Terminal 2: Start frontend (auto-detects mock server)
+npm run dev
+```
+
+### Vite Auto-Detection
+
+Vite automatically detects running backends in this priority order:
+
+1. **Mock API** (localhost:5050) - If running, uses mock server
+2. **kubectl port-forward** - If pygeoapi port-forward is running
+3. **Production** (pygeoapi.dataportal.fi) - Fallback
+
+No configuration needed. Just start the mock server and Vite finds it.
+
+## Customizing Data Density
+
+```bash
+# Default: 50 buildings per postal code
+bun run generate
+
+# More data (load testing)
+bun run generate --density 100
+
+# Less data (faster startup)
+bun run generate --density 20
+
+# Limit postal codes (faster generation)
+bun run generate --postal-codes 10
+```
+
+Via Makefile:
+
+```bash
+# Default density
+make mock-generate
+
+# Custom density
+MOCK_DENSITY=100 make mock-generate
+
+# Force regeneration
+rm -rf mock-api/fixtures && make mock-generate
+```
+
+## Supported Collections
+
+| Collection                 | Query Parameters                |
+| -------------------------- | ------------------------------- |
+| `hsy_buildings_optimized`  | `postinumero`, `bbox`, `limit`  |
+| `heatexposure_optimized`   | `postinumero`, `limit`          |
+| `urban_heat_building`      | `postinumero`, `limit`          |
+| `tree`                     | `postinumero`, `koodi`, `limit` |
+| `coldarea`                 | `posno`, `limit`                |
+| `adaptation_landcover`     | `grid_id`, `bbox`, `limit`      |
+| `tree_building_distance`   | `postinumero`, `limit`          |
+| `othernature`              | `postinumero`, `limit`          |
+| `hki_travel_time`          | `from_id`, `limit`              |
+| `populationgrid`           | `limit`                         |
+| `capitalregion_postalcode` | `limit`                         |
+
+## Example Requests
+
+```bash
+# Health check
+curl http://localhost:5050/health
+
+# List all collections
+curl http://localhost:5050/collections
+
+# Get buildings in postal code 00100
+curl "http://localhost:5050/collections/hsy_buildings_optimized/items?postinumero=00100&limit=50"
+
+# Get heat exposure data
+curl "http://localhost:5050/collections/heatexposure_optimized/items?limit=100"
+
+# Get trees by height category
+curl "http://localhost:5050/collections/tree/items?postinumero=00100&koodi=T510"
+
+# Bounding box query
+curl "http://localhost:5050/collections/hsy_buildings_optimized/items?bbox=24.9,60.16,25.0,60.18"
+```
+
+## Differences from Real PyGeoAPI
+
+| Aspect          | Mock API              | Real PyGeoAPI              |
+| --------------- | --------------------- | -------------------------- |
+| Data source     | Generated JSON files  | PostgreSQL + PostGIS       |
+| Data accuracy   | Synthetic values      | Real Helsinki data         |
+| Geometry        | Simplified rectangles | Actual building footprints |
+| Response time   | Instant               | Database query time        |
+| WFS integration | None                  | External WFS sources       |
+
+The mock API is sufficient for:
+
+- Frontend UI development
+- Component styling
+- Data visualization testing
+- Rapid iteration
+
+Use the real PyGeoAPI for:
+
+- Database query testing
+- Production bug reproduction
+- Data accuracy verification
+
+## Files
+
+```
+mock-api/
+├── server.ts       # Bun HTTP server with routing and filtering
+├── generate.ts     # Fixture generator with realistic Helsinki data
+├── package.json    # Dependencies (@types/bun)
+├── README.md       # This file
+└── fixtures/       # Generated GeoJSON files (gitignored)
+    ├── buildings.json
+    ├── heatexposure.json
+    ├── trees.json
+    ├── coldarea.json
+    ├── urban_heat_building.json
+    ├── adaptation_landcover.json
+    ├── tree_building_distance.json
+    ├── othernature.json
+    ├── travel_time.json
+    ├── populationgrid.json
+    └── capitalregion_postalcode.json
+```
+
+## Server Architecture
+
+The server (`server.ts`) is a single-file Bun HTTP server that:
+
+1. **Loads fixtures on demand** - Cached in memory after first request
+2. **Filters by query parameters** - Implements `postinumero`, `bbox`, `limit`, etc.
+3. **Returns GeoJSON** - Standard FeatureCollection format matching PyGeoAPI
+4. **CORS enabled** - Works with any frontend origin
+
+## Data Generation
+
+The generator (`generate.ts`) creates realistic Helsinki-area data:
+
+- **100+ postal codes** from Helsinki, Espoo, and Vantaa
+- **Building properties** matching real schema (vtj_prt, postinumero, kayttarks, etc.)
+- **Heat exposure values** with realistic temperature ranges
+- **Tree data** with height categories (T510-T550)
+- **Land cover** types (FOREST, WATER, URBAN, etc.)
+
+## Requirements
+
+- [Bun](https://bun.sh/) runtime (replaces Node.js for this server)
+- No other dependencies (Bun has built-in TypeScript and HTTP server)
+
+Install Bun:
+
+```bash
+curl -fsSL https://bun.sh/install | bash
+```
+
+## Related Documentation
+
+- [Getting Started Guide](../docs/GETTING_STARTED.md) - Full development setup options
+- [Makefile targets](../Makefile) - `mock-api`, `mock-generate`, `dev-mock`, `mock-stop`
+- [Vite configuration](../vite.config.js) - `detectPygeoApiPort()` function

--- a/mock-api/bun.lock
+++ b/mock-api/bun.lock
@@ -1,0 +1,21 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "r4c-mock-api",
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
+
+    "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
+
+    "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
+
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+  }
+}

--- a/mock-api/generate.ts
+++ b/mock-api/generate.ts
@@ -1,0 +1,590 @@
+/**
+ * Mock Data Generator
+ *
+ * Generates realistic GeoJSON fixtures for all PyGeoAPI collections.
+ * Uses real Helsinki postal codes and coordinate bounds.
+ *
+ * Usage:
+ *   bun run generate                    # Default: 50 buildings per postal code
+ *   bun run generate --density 100      # 100 buildings per postal code
+ *   bun run generate --postal-codes 10  # Only generate for 10 postal codes
+ */
+
+import { writeFileSync, mkdirSync, existsSync } from 'fs'
+import { join } from 'path'
+
+const FIXTURES_DIR = join(import.meta.dir, 'fixtures')
+
+// Parse CLI args
+const args = process.argv.slice(2)
+const densityIdx = args.indexOf('--density')
+const postalCodesIdx = args.indexOf('--postal-codes')
+
+const BUILDINGS_PER_POSTAL = densityIdx !== -1 ? Number(args[densityIdx + 1]) : 50
+const MAX_POSTAL_CODES = postalCodesIdx !== -1 ? Number(args[postalCodesIdx + 1]) : null
+
+// Helsinki region postal codes with approximate center coordinates
+// Based on real postal code areas in Capital Region
+const POSTAL_CODES: Record<string, { lat: number; lon: number; name: string }> = {
+	'00100': { lat: 60.1699, lon: 24.9384, name: 'Helsinki keskusta' },
+	'00120': { lat: 60.1633, lon: 24.9296, name: 'Punavuori' },
+	'00130': { lat: 60.1653, lon: 24.9458, name: 'Kaartinkaupunki' },
+	'00140': { lat: 60.1555, lon: 24.9516, name: 'Kaivopuisto' },
+	'00150': { lat: 60.1608, lon: 24.9231, name: 'Eira' },
+	'00160': { lat: 60.1629, lon: 24.9098, name: 'Katajanokka' },
+	'00170': { lat: 60.1773, lon: 24.9527, name: 'Kruununhaka' },
+	'00180': { lat: 60.1687, lon: 24.9656, name: 'Kluuvi' },
+	'00200': { lat: 60.1848, lon: 24.9116, name: 'Kallio' },
+	'00210': { lat: 60.1901, lon: 24.9301, name: 'Vallila' },
+	'00220': { lat: 60.1881, lon: 24.9554, name: 'Sörnäinen' },
+	'00240': { lat: 60.1838, lon: 24.9777, name: 'Käpylä' },
+	'00250': { lat: 60.2008, lon: 24.9586, name: 'Toukola' },
+	'00260': { lat: 60.2019, lon: 24.9301, name: 'Koskela' },
+	'00270': { lat: 60.2081, lon: 24.9654, name: 'Vanhakaupunki' },
+	'00280': { lat: 60.2173, lon: 24.9776, name: 'Viikki' },
+	'00300': { lat: 60.1765, lon: 24.8886, name: 'Pikku Huopalahti' },
+	'00310': { lat: 60.1852, lon: 24.8716, name: 'Kivihaka' },
+	'00320': { lat: 60.1926, lon: 24.8819, name: 'Etelä-Haaga' },
+	'00330': { lat: 60.2042, lon: 24.8811, name: 'Munkkiniemi' },
+	'00340': { lat: 60.2175, lon: 24.8706, name: 'Kuusisaari' },
+	'00350': { lat: 60.1992, lon: 24.8562, name: 'Munkkivuori' },
+	'00360': { lat: 60.2122, lon: 24.8529, name: 'Pajamäki' },
+	'00370': { lat: 60.2251, lon: 24.8629, name: 'Reimarla' },
+	'00380': { lat: 60.2341, lon: 24.8507, name: 'Pitäjänmäki' },
+	'00400': { lat: 60.2295, lon: 24.9152, name: 'Oulunkylä' },
+	'00410': { lat: 60.2376, lon: 24.9016, name: 'Maunula' },
+	'00420': { lat: 60.2248, lon: 24.8887, name: 'Pirkkola' },
+	'00430': { lat: 60.2419, lon: 24.9301, name: 'Patola' },
+	'00440': { lat: 60.2495, lon: 24.9086, name: 'Metsälä' },
+	'00500': { lat: 60.1886, lon: 24.9747, name: 'Sörnäinen itä' },
+	'00510': { lat: 60.1983, lon: 24.9861, name: 'Alppila' },
+	'00520': { lat: 60.1866, lon: 24.9987, name: 'Itäkeskus' },
+	'00530': { lat: 60.1948, lon: 25.0134, name: 'Kalasatama' },
+	'00540': { lat: 60.2012, lon: 25.0289, name: 'Kulosaari' },
+	'00550': { lat: 60.1884, lon: 25.0467, name: 'Herttoniemi' },
+	'00560': { lat: 60.2011, lon: 25.0648, name: 'Roihuvuori' },
+	'00570': { lat: 60.2139, lon: 25.0798, name: 'Laajasalo' },
+	'00580': { lat: 60.1962, lon: 25.0932, name: 'Verkkosaari' },
+	'00600': { lat: 60.2412, lon: 24.8762, name: 'Kaarela' },
+	'00610': { lat: 60.2536, lon: 24.8619, name: 'Kannelmäki' },
+	'00620': { lat: 60.2629, lon: 24.8753, name: 'Malminkartano' },
+	'00630': { lat: 60.2388, lon: 24.8416, name: 'Myyrmäki' },
+	'00640': { lat: 60.2295, lon: 24.8204, name: 'Martinlaakso' },
+	'00650': { lat: 60.2182, lon: 24.8051, name: 'Vantaa' },
+	'00660': { lat: 60.2488, lon: 24.7984, name: 'Hämevaara' },
+	'00670': { lat: 60.2591, lon: 24.8201, name: 'Vantaanlaakso' },
+	'00680': { lat: 60.2456, lon: 24.9441, name: 'Pakila' },
+	'00690': { lat: 60.2513, lon: 24.9662, name: 'Pukinmäki' },
+	'00700': { lat: 60.2619, lon: 24.9498, name: 'Malmi' },
+	'00710': { lat: 60.2412, lon: 24.9896, name: 'Pihlajamäki' },
+	'00720': { lat: 60.2501, lon: 25.0141, name: 'Puistola' },
+	'00730': { lat: 60.2627, lon: 25.0367, name: 'Tapanila' },
+	'00740': { lat: 60.2789, lon: 25.0512, name: 'Suutarila' },
+	'00750': { lat: 60.2892, lon: 25.0159, name: 'Puistola pohj.' },
+	'00760': { lat: 60.2745, lon: 24.9876, name: 'Suurmetsä' },
+	'00770': { lat: 60.2888, lon: 24.9698, name: 'Jakomäki' },
+	'00780': { lat: 60.2991, lon: 24.9429, name: 'Tapaninvainio' },
+	'00790': { lat: 60.3081, lon: 24.9187, name: 'Viikki pohj.' },
+	'00800': { lat: 60.2182, lon: 25.0987, name: 'Laajasalo' },
+	'00810': { lat: 60.2096, lon: 25.1234, name: 'Herttoniemenranta' },
+	'00820': { lat: 60.2189, lon: 25.1412, name: 'Roihupelto' },
+	'00830': { lat: 60.2288, lon: 25.0823, name: 'Tammisalo' },
+	'00840': { lat: 60.2129, lon: 25.1098, name: 'Laajasalo itä' },
+	'00850': { lat: 60.2401, lon: 25.0456, name: 'Jollas' },
+	'00860': { lat: 60.2187, lon: 25.0652, name: 'Santahamina' },
+	'00870': { lat: 60.2341, lon: 25.1287, name: 'Vartiokylä' },
+	'00880': { lat: 60.2433, lon: 25.1098, name: 'Roihupelto' },
+	'00890': { lat: 60.2512, lon: 25.0876, name: 'Mellunmäki' },
+	'00900': { lat: 60.1987, lon: 25.1623, name: 'Vuosaari' },
+	'00910': { lat: 60.2102, lon: 25.1876, name: 'Vuosaari itä' },
+	'00920': { lat: 60.2233, lon: 25.1512, name: 'Meri-Rastila' },
+	'00930': { lat: 60.1889, lon: 25.1234, name: 'Aurinkolahti' },
+	'00940': { lat: 60.1756, lon: 25.0987, name: 'Kontula' },
+	'00950': { lat: 60.2412, lon: 25.1654, name: 'Vartiosaari' },
+	'00960': { lat: 60.2112, lon: 25.2012, name: 'Östersundom' },
+	'00970': { lat: 60.2245, lon: 25.1876, name: 'Mellunmäki itä' },
+	'00980': { lat: 60.2401, lon: 25.2123, name: 'Vuosaari pohj.' },
+	'00990': { lat: 60.2534, lon: 25.1234, name: 'Vuosaari lounais' },
+	// Espoo
+	'02100': { lat: 60.2048, lon: 24.6559, name: 'Espoon keskus' },
+	'02150': { lat: 60.1614, lon: 24.7389, name: 'Otaniemi' },
+	'02200': { lat: 60.1689, lon: 24.7123, name: 'Tapiola' },
+	'02230': { lat: 60.1752, lon: 24.8012, name: 'Matinkylä' },
+	'02320': { lat: 60.1598, lon: 24.7667, name: 'Haukilahti' },
+	'02600': { lat: 60.2089, lon: 24.6234, name: 'Leppävaara' },
+	'02700': { lat: 60.1889, lon: 24.6512, name: 'Kauniainen' },
+	// Vantaa
+	'01200': { lat: 60.2912, lon: 24.9512, name: 'Hakunila' },
+	'01300': { lat: 60.2912, lon: 25.0412, name: 'Tikkurila' },
+	'01350': { lat: 60.3145, lon: 25.0234, name: 'Hiekkaharju' },
+	'01400': { lat: 60.2734, lon: 24.8512, name: 'Vantaa keskus' },
+	'01450': { lat: 60.3012, lon: 24.8912, name: 'Korso' },
+	'01510': { lat: 60.3189, lon: 24.9612, name: 'Vantaankoski' },
+	'01600': { lat: 60.3312, lon: 24.8712, name: 'Martinlaakso' },
+	'01620': { lat: 60.2789, lon: 24.8334, name: 'Myyrmäki' },
+}
+
+// Building types and characteristics
+const BUILDING_TYPES = ['RESIDENTIAL', 'COMMERCIAL', 'INDUSTRIAL', 'PUBLIC', 'OFFICE']
+const HEATING_TYPES = ['DISTRICT_HEATING', 'ELECTRIC', 'OIL', 'GAS', 'GEOTHERMAL']
+const TREE_TYPES = ['DECIDUOUS', 'CONIFEROUS', 'MIXED']
+const TREE_CODES = ['T510', 'T520', 'T530', 'T540', 'T550'] // Height categories
+const LANDCOVER_TYPES = ['FOREST', 'WATER', 'URBAN', 'GRASS', 'AGRICULTURAL', 'BARE']
+
+// Utility functions
+function randomInRange(min: number, max: number): number {
+	return Math.random() * (max - min) + min
+}
+
+function randomChoice<T>(arr: T[]): T {
+	return arr[Math.floor(Math.random() * arr.length)]
+}
+
+function generateBuildingId(): string {
+	const num = Math.floor(Math.random() * 900000000) + 100000000
+	const letter = String.fromCharCode(65 + Math.floor(Math.random() * 26))
+	return `${num}${letter}`
+}
+
+function generatePolygon(centerLon: number, centerLat: number, size = 0.0003): number[][][] {
+	// Generate a simple rectangular building footprint
+	const halfSize = size / 2
+	const rotation = Math.random() * Math.PI / 4 // Random rotation up to 45 degrees
+
+	const corners = [
+		[-halfSize, -halfSize],
+		[halfSize, -halfSize],
+		[halfSize, halfSize],
+		[-halfSize, halfSize],
+		[-halfSize, -halfSize], // Close the polygon
+	]
+
+	// Apply rotation and translate to center
+	const rotatedCorners = corners.map(([x, y]) => {
+		const rx = x * Math.cos(rotation) - y * Math.sin(rotation)
+		const ry = x * Math.sin(rotation) + y * Math.cos(rotation)
+		return [centerLon + rx, centerLat + ry]
+	})
+
+	return [rotatedCorners]
+}
+
+// Feature generators
+function generateBuilding(postalCode: string, center: { lat: number; lon: number }, index: number) {
+	const offset = 0.008 // ~800m spread around center
+	const lon = center.lon + randomInRange(-offset, offset)
+	const lat = center.lat + randomInRange(-offset, offset)
+
+	const buildingId = generateBuildingId()
+	const heatExposure = randomInRange(0.2, 0.8)
+	const floors = Math.floor(randomInRange(1, 15))
+	const area = randomInRange(50, 2000)
+
+	return {
+		type: 'Feature',
+		id: buildingId,
+		geometry: {
+			type: 'Polygon',
+			coordinates: generatePolygon(lon, lat, 0.0002 + Math.random() * 0.0003),
+		},
+		properties: {
+			vtj_prt: buildingId,
+			postinumero: postalCode,
+			posno: postalCode,
+			kunta: postalCode.startsWith('02') ? 'Espoo' : postalCode.startsWith('01') ? 'Vantaa' : 'Helsinki',
+			kayttarks: randomChoice(BUILDING_TYPES),
+			lammitystapa_s: randomChoice(HEATING_TYPES),
+			kerrosten_lkm: floors,
+			area_m2: Math.round(area),
+			kavu: Math.round(area * floors * 3), // Volume estimate
+			avgheatexposure: heatExposure,
+			avg_temp_c: 20 + heatExposure * 15,
+		},
+	}
+}
+
+function generateHeatExposureArea(postalCode: string, center: { lat: number; lon: number }, index: number) {
+	const offset = 0.006
+	const lon = center.lon + randomInRange(-offset, offset)
+	const lat = center.lat + randomInRange(-offset, offset)
+
+	const heatExposure = randomInRange(0.3, 0.9)
+
+	return {
+		type: 'Feature',
+		id: `HE_${postalCode}_${index}`,
+		geometry: {
+			type: 'Polygon',
+			coordinates: generatePolygon(lon, lat, 0.001 + Math.random() * 0.002),
+		},
+		properties: {
+			id: `HE_${postalCode}_${index}`,
+			postinumero: postalCode,
+			heatexposure: heatExposure,
+			temp_c: 20 + heatExposure * 15,
+			date: '2023-07-15',
+		},
+	}
+}
+
+function generateTree(postalCode: string, center: { lat: number; lon: number }, index: number) {
+	const offset = 0.008
+	const lon = center.lon + randomInRange(-offset, offset)
+	const lat = center.lat + randomInRange(-offset, offset)
+
+	const koodi = randomChoice(TREE_CODES)
+	const height = 5 + Math.random() * 20
+
+	return {
+		type: 'Feature',
+		id: `TREE_${postalCode}_${index}`,
+		geometry: {
+			type: 'Polygon',
+			coordinates: generatePolygon(lon, lat, 0.00005 + Math.random() * 0.0001),
+		},
+		properties: {
+			id: `TREE_${postalCode}_${index}`,
+			kohde_id: `TREE_${postalCode}_${index}`,
+			postinumero: postalCode,
+			koodi,
+			kuvaus: randomChoice(TREE_TYPES),
+			p_ala_m2: Math.round(randomInRange(10, 200)),
+			korkeus_ka_m: Math.round(height * 10) / 10,
+			kunta: 'Helsinki',
+		},
+	}
+}
+
+function generateColdArea(postalCode: string, center: { lat: number; lon: number }, index: number) {
+	const offset = 0.005
+	const lon = center.lon + randomInRange(-offset, offset)
+	const lat = center.lat + randomInRange(-offset, offset)
+
+	return {
+		type: 'Feature',
+		id: `COLD_${postalCode}_${index}`,
+		geometry: {
+			type: 'Point',
+			coordinates: [lon, lat],
+		},
+		properties: {
+			id: `COLD_${postalCode}_${index}`,
+			posno: postalCode,
+			heatexposure: randomInRange(0.0, 0.4), // Cold spots have low heat exposure
+			temp_c: randomInRange(15, 22),
+			date: '2023-07-15',
+		},
+	}
+}
+
+function generateUrbanHeatBuilding(postalCode: string, center: { lat: number; lon: number }, index: number) {
+	const offset = 0.008
+	const lon = center.lon + randomInRange(-offset, offset)
+	const lat = center.lat + randomInRange(-offset, offset)
+
+	const heatExposure = randomInRange(0.2, 0.9)
+
+	return {
+		type: 'Feature',
+		id: `UHB_${postalCode}_${index}`,
+		geometry: {
+			type: 'Polygon',
+			coordinates: generatePolygon(lon, lat, 0.0002 + Math.random() * 0.0002),
+		},
+		properties: {
+			id: `UHB_${postalCode}_${index}`,
+			ratu: Math.floor(Math.random() * 900000) + 100000,
+			postinumero: postalCode,
+			c_kayttark: randomChoice(BUILDING_TYPES),
+			katunimi_suomi: `Testikatu ${Math.floor(Math.random() * 100)}`,
+			osoitenumero: String(Math.floor(Math.random() * 200)),
+			year_of_construction: String(Math.floor(randomInRange(1950, 2024))),
+			measured_height: randomInRange(5, 50),
+			avgheatexposuretobuilding: heatExposure,
+			distancetounder40: Math.floor(randomInRange(50, 2000)),
+			area_m2: Math.round(randomInRange(50, 2000)),
+		},
+	}
+}
+
+function generateAdaptationLandcover(index: number) {
+	// Generate across entire Helsinki region
+	const lon = randomInRange(24.5, 25.3)
+	const lat = randomInRange(60.1, 60.35)
+
+	return {
+		type: 'Feature',
+		id: `GRID_${String(index).padStart(6, '0')}`,
+		geometry: {
+			type: 'Polygon',
+			coordinates: generatePolygon(lon, lat, 0.002),
+		},
+		properties: {
+			id: `GRID_${String(index).padStart(6, '0')}`,
+			grid_id: `GRID_${String(index).padStart(6, '0')}`,
+			area_m2: Math.round(randomInRange(1000, 50000)),
+			year: randomChoice([2020, 2021, 2022, 2023, 2024]),
+			koodi: randomChoice(LANDCOVER_TYPES),
+		},
+	}
+}
+
+function generateTreeBuildingDistance(postalCode: string, center: { lat: number; lon: number }, index: number) {
+	return {
+		type: 'Feature',
+		id: `TBD_${postalCode}_${index}`,
+		geometry: {
+			type: 'Point',
+			coordinates: [
+				center.lon + randomInRange(-0.008, 0.008),
+				center.lat + randomInRange(-0.008, 0.008),
+			],
+		},
+		properties: {
+			id: `TBD_${postalCode}_${index}`,
+			postinumero: postalCode,
+			distance: Math.round(randomInRange(1, 100)),
+			building_id: generateBuildingId(),
+			tree_id: `TREE_${postalCode}_${Math.floor(Math.random() * 100)}`,
+		},
+	}
+}
+
+function generateOtherNature(postalCode: string, center: { lat: number; lon: number }, index: number) {
+	return {
+		type: 'Feature',
+		id: `NAT_${postalCode}_${index}`,
+		geometry: {
+			type: 'Polygon',
+			coordinates: generatePolygon(
+				center.lon + randomInRange(-0.008, 0.008),
+				center.lat + randomInRange(-0.008, 0.008),
+				0.0005 + Math.random() * 0.001
+			),
+		},
+		properties: {
+			id: `NAT_${postalCode}_${index}`,
+			kohde_id: `NAT_${postalCode}_${index}`,
+			postinumero: postalCode,
+			koodi: randomChoice(['ROCK', 'SAND', 'BARE_SOIL', 'WETLAND']),
+			kuvaus: 'Other nature surface',
+			p_ala_m2: Math.round(randomInRange(50, 500)),
+			kunta: 'Helsinki',
+		},
+	}
+}
+
+function generateTravelTime(index: number) {
+	const fromId = 5970000 + index * 100
+	const lon = randomInRange(24.8, 25.1)
+	const lat = randomInRange(60.15, 60.3)
+
+	return {
+		type: 'Feature',
+		id: `TT_${fromId}`,
+		geometry: {
+			type: 'Point',
+			coordinates: [lon, lat],
+		},
+		properties: {
+			id: `TT_${fromId}`,
+			from_id: fromId,
+			travel_data: JSON.stringify({
+				walk: Math.floor(randomInRange(5, 60)),
+				bike: Math.floor(randomInRange(3, 40)),
+				public_transport: Math.floor(randomInRange(10, 90)),
+				car: Math.floor(randomInRange(5, 45)),
+			}),
+		},
+	}
+}
+
+// Main generation function
+function generate() {
+	console.log('\n  Mock Data Generator')
+	console.log('  ===================\n')
+	console.log(`  Buildings per postal code: ${BUILDINGS_PER_POSTAL}`)
+	console.log(`  Postal codes: ${MAX_POSTAL_CODES || 'all'}\n`)
+
+	if (!existsSync(FIXTURES_DIR)) {
+		mkdirSync(FIXTURES_DIR, { recursive: true })
+	}
+
+	const postalCodes = Object.entries(POSTAL_CODES).slice(0, MAX_POSTAL_CODES || undefined)
+
+	// Buildings
+	console.log('  Generating buildings...')
+	const buildings: ReturnType<typeof generateBuilding>[] = []
+	for (const [code, center] of postalCodes) {
+		for (let i = 0; i < BUILDINGS_PER_POSTAL; i++) {
+			buildings.push(generateBuilding(code, center, i))
+		}
+	}
+	writeFileSync(
+		join(FIXTURES_DIR, 'buildings.json'),
+		JSON.stringify({ type: 'FeatureCollection', features: buildings }, null, 2)
+	)
+	console.log(`    Created ${buildings.length} buildings`)
+
+	// Heat exposure
+	console.log('  Generating heat exposure areas...')
+	const heatAreas: ReturnType<typeof generateHeatExposureArea>[] = []
+	for (const [code, center] of postalCodes) {
+		for (let i = 0; i < Math.ceil(BUILDINGS_PER_POSTAL / 5); i++) {
+			heatAreas.push(generateHeatExposureArea(code, center, i))
+		}
+	}
+	writeFileSync(
+		join(FIXTURES_DIR, 'heatexposure.json'),
+		JSON.stringify({ type: 'FeatureCollection', features: heatAreas }, null, 2)
+	)
+	console.log(`    Created ${heatAreas.length} heat exposure areas`)
+
+	// Trees
+	console.log('  Generating trees...')
+	const trees: ReturnType<typeof generateTree>[] = []
+	for (const [code, center] of postalCodes) {
+		for (let i = 0; i < BUILDINGS_PER_POSTAL * 2; i++) {
+			trees.push(generateTree(code, center, i))
+		}
+	}
+	writeFileSync(
+		join(FIXTURES_DIR, 'trees.json'),
+		JSON.stringify({ type: 'FeatureCollection', features: trees }, null, 2)
+	)
+	console.log(`    Created ${trees.length} trees`)
+
+	// Cold areas
+	console.log('  Generating cold areas...')
+	const coldAreas: ReturnType<typeof generateColdArea>[] = []
+	for (const [code, center] of postalCodes) {
+		for (let i = 0; i < Math.ceil(BUILDINGS_PER_POSTAL / 10); i++) {
+			coldAreas.push(generateColdArea(code, center, i))
+		}
+	}
+	writeFileSync(
+		join(FIXTURES_DIR, 'coldarea.json'),
+		JSON.stringify({ type: 'FeatureCollection', features: coldAreas }, null, 2)
+	)
+	console.log(`    Created ${coldAreas.length} cold areas`)
+
+	// Urban heat buildings
+	console.log('  Generating urban heat buildings...')
+	const urbanHeatBuildings: ReturnType<typeof generateUrbanHeatBuilding>[] = []
+	for (const [code, center] of postalCodes) {
+		for (let i = 0; i < Math.ceil(BUILDINGS_PER_POSTAL / 2); i++) {
+			urbanHeatBuildings.push(generateUrbanHeatBuilding(code, center, i))
+		}
+	}
+	writeFileSync(
+		join(FIXTURES_DIR, 'urban_heat_building.json'),
+		JSON.stringify({ type: 'FeatureCollection', features: urbanHeatBuildings }, null, 2)
+	)
+	console.log(`    Created ${urbanHeatBuildings.length} urban heat buildings`)
+
+	// Adaptation landcover
+	console.log('  Generating adaptation landcover...')
+	const landcover: ReturnType<typeof generateAdaptationLandcover>[] = []
+	for (let i = 0; i < 500; i++) {
+		landcover.push(generateAdaptationLandcover(i))
+	}
+	writeFileSync(
+		join(FIXTURES_DIR, 'adaptation_landcover.json'),
+		JSON.stringify({ type: 'FeatureCollection', features: landcover }, null, 2)
+	)
+	console.log(`    Created ${landcover.length} landcover areas`)
+
+	// Tree building distance
+	console.log('  Generating tree-building distances...')
+	const treeBuildingDist: ReturnType<typeof generateTreeBuildingDistance>[] = []
+	for (const [code, center] of postalCodes) {
+		for (let i = 0; i < Math.ceil(BUILDINGS_PER_POSTAL / 2); i++) {
+			treeBuildingDist.push(generateTreeBuildingDistance(code, center, i))
+		}
+	}
+	writeFileSync(
+		join(FIXTURES_DIR, 'tree_building_distance.json'),
+		JSON.stringify({ type: 'FeatureCollection', features: treeBuildingDist }, null, 2)
+	)
+	console.log(`    Created ${treeBuildingDist.length} tree-building distances`)
+
+	// Other nature
+	console.log('  Generating other nature areas...')
+	const otherNature: ReturnType<typeof generateOtherNature>[] = []
+	for (const [code, center] of postalCodes) {
+		for (let i = 0; i < Math.ceil(BUILDINGS_PER_POSTAL / 5); i++) {
+			otherNature.push(generateOtherNature(code, center, i))
+		}
+	}
+	writeFileSync(
+		join(FIXTURES_DIR, 'othernature.json'),
+		JSON.stringify({ type: 'FeatureCollection', features: otherNature }, null, 2)
+	)
+	console.log(`    Created ${otherNature.length} other nature areas`)
+
+	// Travel time
+	console.log('  Generating travel time data...')
+	const travelTime: ReturnType<typeof generateTravelTime>[] = []
+	for (let i = 0; i < 200; i++) {
+		travelTime.push(generateTravelTime(i))
+	}
+	writeFileSync(
+		join(FIXTURES_DIR, 'travel_time.json'),
+		JSON.stringify({ type: 'FeatureCollection', features: travelTime }, null, 2)
+	)
+	console.log(`    Created ${travelTime.length} travel time entries`)
+
+	// Population grid (simplified)
+	console.log('  Generating population grid...')
+	const popGrid: { type: string; id: string; geometry: object; properties: object }[] = []
+	for (let i = 0; i < 100; i++) {
+		popGrid.push({
+			type: 'Feature',
+			id: `POP_${i}`,
+			geometry: {
+				type: 'Polygon',
+				coordinates: generatePolygon(
+					randomInRange(24.7, 25.2),
+					randomInRange(60.1, 60.35),
+					0.005
+				),
+			},
+			properties: {
+				id: `POP_${i}`,
+				population: Math.floor(randomInRange(100, 5000)),
+				density: Math.floor(randomInRange(500, 10000)),
+			},
+		})
+	}
+	writeFileSync(
+		join(FIXTURES_DIR, 'populationgrid.json'),
+		JSON.stringify({ type: 'FeatureCollection', features: popGrid }, null, 2)
+	)
+	console.log(`    Created ${popGrid.length} population grid cells`)
+
+	// Capital region postal codes
+	console.log('  Generating capital region postal codes...')
+	const postalCodeFeatures = Object.entries(POSTAL_CODES).map(([code, data]) => ({
+		type: 'Feature',
+		id: code,
+		geometry: {
+			type: 'Polygon',
+			coordinates: generatePolygon(data.lon, data.lat, 0.015),
+		},
+		properties: {
+			postinumero: code,
+			nimi: data.name,
+			kunta: code.startsWith('02') ? 'Espoo' : code.startsWith('01') ? 'Vantaa' : 'Helsinki',
+		},
+	}))
+	writeFileSync(
+		join(FIXTURES_DIR, 'capitalregion_postalcode.json'),
+		JSON.stringify({ type: 'FeatureCollection', features: postalCodeFeatures }, null, 2)
+	)
+	console.log(`    Created ${postalCodeFeatures.length} postal code areas`)
+
+	console.log('\n  Done! Fixtures saved to mock-api/fixtures/')
+	console.log('  Start mock server with: cd mock-api && bun run dev\n')
+}
+
+generate()

--- a/mock-api/package.json
+++ b/mock-api/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "r4c-mock-api",
+  "version": "1.0.0",
+  "description": "Mock PyGeoAPI server for local development",
+  "type": "module",
+  "scripts": {
+    "start": "bun run server.ts",
+    "dev": "bun run --watch server.ts",
+    "generate": "bun run generate.ts"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  }
+}

--- a/mock-api/server.ts
+++ b/mock-api/server.ts
@@ -1,0 +1,371 @@
+/**
+ * Mock PyGeoAPI Server
+ *
+ * Lightweight Bun server that mimics PyGeoAPI endpoints for local development.
+ * Supports query parameter filtering (postinumero, bbox, limit) for realistic testing.
+ *
+ * Usage:
+ *   bun run dev     # Start with hot reload
+ *   bun run start   # Production start
+ */
+
+import { readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+
+const PORT = Number(process.env.PORT) || 5050
+const FIXTURES_DIR = join(import.meta.dir, 'fixtures')
+
+// Collection configurations
+interface CollectionConfig {
+	file: string
+	idField: string
+	postalCodeField?: string // Field name for postal code filtering
+	supportsPostalCode: boolean
+	supportsBbox: boolean
+}
+
+const COLLECTIONS: Record<string, CollectionConfig> = {
+	hsy_buildings_optimized: {
+		file: 'buildings.json',
+		idField: 'vtj_prt',
+		postalCodeField: 'postinumero',
+		supportsPostalCode: true,
+		supportsBbox: true,
+	},
+	heatexposure_optimized: {
+		file: 'heatexposure.json',
+		idField: 'id',
+		postalCodeField: 'postinumero',
+		supportsPostalCode: true,
+		supportsBbox: false,
+	},
+	urban_heat_building: {
+		file: 'urban_heat_building.json',
+		idField: 'id',
+		postalCodeField: 'postinumero',
+		supportsPostalCode: true,
+		supportsBbox: false,
+	},
+	tree: {
+		file: 'trees.json',
+		idField: 'id',
+		postalCodeField: 'postinumero',
+		supportsPostalCode: true,
+		supportsBbox: false,
+	},
+	coldarea: {
+		file: 'coldarea.json',
+		idField: 'id',
+		postalCodeField: 'posno',
+		supportsPostalCode: true,
+		supportsBbox: false,
+	},
+	adaptation_landcover: {
+		file: 'adaptation_landcover.json',
+		idField: 'id',
+		supportsPostalCode: false,
+		supportsBbox: true,
+	},
+	tree_building_distance: {
+		file: 'tree_building_distance.json',
+		idField: 'id',
+		postalCodeField: 'postinumero',
+		supportsPostalCode: true,
+		supportsBbox: false,
+	},
+	othernature: {
+		file: 'othernature.json',
+		idField: 'id',
+		postalCodeField: 'postinumero',
+		supportsPostalCode: true,
+		supportsBbox: false,
+	},
+	hki_travel_time: {
+		file: 'travel_time.json',
+		idField: 'id',
+		supportsPostalCode: false,
+		supportsBbox: false,
+	},
+	// GeoJSON file collections (pass-through)
+	populationgrid: {
+		file: 'populationgrid.json',
+		idField: 'id',
+		supportsPostalCode: false,
+		supportsBbox: false,
+	},
+	capitalregion_postalcode: {
+		file: 'capitalregion_postalcode.json',
+		idField: 'id',
+		supportsPostalCode: false,
+		supportsBbox: false,
+	},
+}
+
+// Cache loaded fixtures
+const fixtureCache = new Map<string, GeoJSON.FeatureCollection>()
+
+interface GeoJSONFeature {
+	type: 'Feature'
+	id?: string | number
+	geometry: {
+		type: string
+		coordinates: number[] | number[][] | number[][][]
+	}
+	properties: Record<string, unknown>
+}
+
+function loadFixture(filename: string): GeoJSON.FeatureCollection | null {
+	if (fixtureCache.has(filename)) {
+		return fixtureCache.get(filename)!
+	}
+
+	const filepath = join(FIXTURES_DIR, filename)
+	if (!existsSync(filepath)) {
+		console.warn(`Fixture not found: ${filepath}`)
+		return null
+	}
+
+	try {
+		const data = JSON.parse(readFileSync(filepath, 'utf-8'))
+		fixtureCache.set(filename, data)
+		return data
+	} catch (error) {
+		console.error(`Error loading fixture ${filename}:`, error)
+		return null
+	}
+}
+
+function filterByPostalCode(
+	features: GeoJSONFeature[],
+	postalCode: string,
+	field: string
+): GeoJSONFeature[] {
+	return features.filter((f) => f.properties[field] === postalCode)
+}
+
+function filterByBbox(
+	features: GeoJSONFeature[],
+	bbox: string
+): GeoJSONFeature[] {
+	const [west, south, east, north] = bbox.split(',').map(Number)
+
+	return features.filter((f) => {
+		const geom = f.geometry
+		if (!geom || !geom.coordinates) return false
+
+		// Get centroid for filtering (simplified - works for points and polygons)
+		let lon: number, lat: number
+
+		if (geom.type === 'Point') {
+			;[lon, lat] = geom.coordinates as number[]
+		} else if (geom.type === 'Polygon') {
+			// Use first coordinate of first ring as approximation
+			const coords = geom.coordinates as number[][][]
+			;[lon, lat] = coords[0][0]
+		} else if (geom.type === 'MultiPolygon') {
+			const coords = geom.coordinates as number[][][][]
+			;[lon, lat] = coords[0][0][0]
+		} else {
+			return true // Include if we can't determine bbox intersection
+		}
+
+		return lon >= west && lon <= east && lat >= south && lat <= north
+	})
+}
+
+function handleCollectionItems(
+	collection: string,
+	url: URL
+): Response | null {
+	const config = COLLECTIONS[collection]
+	if (!config) {
+		return null
+	}
+
+	const data = loadFixture(config.file)
+	if (!data) {
+		return Response.json(
+			{ type: 'FeatureCollection', features: [] },
+			{
+				headers: {
+					'Content-Type': 'application/json',
+					'Access-Control-Allow-Origin': '*',
+				},
+			}
+		)
+	}
+
+	let features = [...data.features] as GeoJSONFeature[]
+
+	// Filter by postal code
+	const postalCode =
+		url.searchParams.get('postinumero') || url.searchParams.get('posno')
+	if (postalCode && config.supportsPostalCode && config.postalCodeField) {
+		features = filterByPostalCode(features, postalCode, config.postalCodeField)
+	}
+
+	// Filter by bbox
+	const bbox = url.searchParams.get('bbox')
+	if (bbox && config.supportsBbox) {
+		features = filterByBbox(features, bbox)
+	}
+
+	// Filter by koodi (for tree collection)
+	const koodi = url.searchParams.get('koodi')
+	if (koodi && collection === 'tree') {
+		features = features.filter((f) => f.properties.koodi === koodi)
+	}
+
+	// Filter by grid_id (for adaptation_landcover)
+	const gridId = url.searchParams.get('grid_id')
+	if (gridId && collection === 'adaptation_landcover') {
+		features = features.filter((f) => f.properties.grid_id === gridId)
+	}
+
+	// Filter by from_id (for travel_time)
+	const fromId = url.searchParams.get('from_id')
+	if (fromId && collection === 'hki_travel_time') {
+		features = features.filter(
+			(f) => f.properties.from_id === Number(fromId)
+		)
+	}
+
+	// Apply limit
+	const limit = Number(url.searchParams.get('limit')) || 1000
+	features = features.slice(0, limit)
+
+	const response = {
+		type: 'FeatureCollection',
+		numberMatched: features.length,
+		numberReturned: features.length,
+		features,
+	}
+
+	return Response.json(response, {
+		headers: {
+			'Content-Type': 'application/json',
+			'Access-Control-Allow-Origin': '*',
+		},
+	})
+}
+
+function handleCollections(): Response {
+	const collections = Object.entries(COLLECTIONS).map(([id, config]) => ({
+		id,
+		title: id.replace(/_/g, ' '),
+		description: `Mock ${id} collection`,
+		links: [
+			{
+				rel: 'items',
+				href: `/collections/${id}/items`,
+				type: 'application/geo+json',
+			},
+		],
+	}))
+
+	return Response.json(
+		{ collections },
+		{
+			headers: {
+				'Content-Type': 'application/json',
+				'Access-Control-Allow-Origin': '*',
+			},
+		}
+	)
+}
+
+const server = Bun.serve({
+	port: PORT,
+	fetch(req) {
+		const url = new URL(req.url)
+		const path = url.pathname
+
+		// CORS preflight
+		if (req.method === 'OPTIONS') {
+			return new Response(null, {
+				headers: {
+					'Access-Control-Allow-Origin': '*',
+					'Access-Control-Allow-Methods': 'GET, OPTIONS',
+					'Access-Control-Allow-Headers': 'Content-Type',
+				},
+			})
+		}
+
+		// Root / health check
+		if (path === '/' || path === '/health') {
+			return Response.json({
+				status: 'ok',
+				server: 'r4c-mock-api',
+				collections: Object.keys(COLLECTIONS).length,
+			})
+		}
+
+		// List collections
+		if (path === '/collections' || path === '/collections/') {
+			return handleCollections()
+		}
+
+		// Collection items: /collections/{collection}/items
+		const itemsMatch = path.match(/^\/collections\/([^/]+)\/items\/?$/)
+		if (itemsMatch) {
+			const collection = itemsMatch[1]
+			const response = handleCollectionItems(collection, url)
+			if (response) return response
+		}
+
+		// Single collection metadata: /collections/{collection}
+		const collectionMatch = path.match(/^\/collections\/([^/]+)\/?$/)
+		if (collectionMatch) {
+			const collection = collectionMatch[1]
+			const config = COLLECTIONS[collection]
+			if (config) {
+				return Response.json(
+					{
+						id: collection,
+						title: collection.replace(/_/g, ' '),
+						description: `Mock ${collection} collection`,
+					},
+					{
+						headers: {
+							'Content-Type': 'application/json',
+							'Access-Control-Allow-Origin': '*',
+						},
+					}
+				)
+			}
+		}
+
+		// 404 for unmatched routes
+		return Response.json(
+			{ error: 'Not found', path },
+			{
+				status: 404,
+				headers: {
+					'Content-Type': 'application/json',
+					'Access-Control-Allow-Origin': '*',
+				},
+			}
+		)
+	},
+})
+
+console.log(`
+  Mock PyGeoAPI Server
+  ====================
+
+  Running on: http://localhost:${PORT}
+
+  Collections:
+${Object.keys(COLLECTIONS)
+	.map((c) => `    - /collections/${c}/items`)
+	.join('\n')}
+
+  Query parameters:
+    ?postinumero=00100  Filter by postal code
+    ?bbox=w,s,e,n       Filter by bounding box
+    ?limit=100          Limit results
+    ?koodi=T510         Filter trees by height code
+    ?grid_id=GRID_001   Filter landcover by grid
+
+  Press Ctrl+C to stop
+`)

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,11 +12,25 @@ import { fileURLToPath, URL } from 'node:url';
 import { version } from './package.json';
 import { execSync } from 'child_process';
 
-// Auto-detect pygeoapi port from kubectl port-forward
+// Auto-detect pygeoapi: mock server > kubectl port-forward > production
 const detectPygeoApiPort = () => {
 	// If explicitly set in env, use that
 	if (process.env.VITE_PYGEOAPI_HOST) {
 		return process.env.VITE_PYGEOAPI_HOST;
+	}
+
+	// Check if mock API server is running on port 5050
+	try {
+		const psOutput = execSync('ps aux | grep -E "bun.*server\\.ts" | grep -v grep', {
+			encoding: 'utf-8',
+			stdio: ['pipe', 'pipe', 'pipe'],
+		});
+		if (psOutput.trim()) {
+			console.log('🎭 Using mock PyGeoAPI server (localhost:5050)');
+			return 'localhost:5050';
+		}
+	} catch {
+		// Mock server not running
 	}
 
 	// Try to detect from running kubectl port-forwards
@@ -37,8 +51,8 @@ const detectPygeoApiPort = () => {
 		// No kubectl port-forward running, fall back to production
 	}
 
-	// Default to production if no local port-forward found
-	console.log('ℹ️  Using production pygeoapi (no local port-forward detected)');
+	// Default to production if no local server found
+	console.log('ℹ️  Using production pygeoapi (no local server detected)');
 	return 'pygeoapi.dataportal.fi';
 };
 


### PR DESCRIPTION
## Summary

- Add lightweight Bun-based mock PyGeoAPI server for frontend-only development
- Enables development without Kubernetes or PostgreSQL
- Auto-detected by Vite when running on localhost:5050
- Supports all 11 PyGeoAPI collections with query parameters

## Changes

### New: mock-api/ server
- `server.ts` - HTTP server serving synthetic GeoJSON
- `generate.ts` - Fixture generator with configurable density
- Supports query parameters: `postinumero`, `bbox`, `limit`, `koodi`, etc.

### Makefile enhancements
- `make dev-mock` - Start frontend with mock API (fastest)
- `make mock-api` - Start mock server standalone
- `make mock-generate` - Generate/regenerate fixtures
- `make db-seed` - Seed database (promoted as recommended approach)

### Documentation
- Updated README with three development modes
- Expanded GETTING_STARTED with mock API section
- Revised SEEDING.md to promote seeding over production import

## Development Modes

| Mode | Command | Backend | Use Case |
|------|---------|---------|----------|
| Mock API | `make dev-mock` | Synthetic data (5050) | Frontend dev |
| Full Stack | `make dev` + `make db-seed` | PostgreSQL (5000) | Full testing |
| Production Data | `make dev` + `make db-import` | 18GB dump | Bug repro |

## Test plan

- [ ] Run `make dev-mock` and verify frontend loads
- [ ] Verify mock API responds: `curl http://localhost:5050/collections`
- [ ] Navigate to postal code and verify buildings render
- [ ] Run `make mock-stop` and verify cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)