### PR TITLE
fix(ci): fix Lighthouse CI failing silently without results

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -312,12 +312,34 @@ jobs:
               });
             }
 
-      - name: Check Lighthouse assertions
-        if: steps.lighthouse.outputs.exit_code != '0'
+      - name: Check Lighthouse results
         run: |
-          echo "Lighthouse CI assertions failed with exit code ${{ steps.lighthouse.outputs.exit_code }}"
-          echo "Review the lighthouse-output.txt artifact for details"
+          EXIT_CODE="${{ steps.lighthouse.outputs.exit_code }}"
+          ERROR_MESSAGE="${{ steps.parse-results.outputs.error_message }}"
+          PERFORMANCE="${{ steps.parse-results.outputs.performance }}"
 
-          # For now, don't fail the workflow - just warn
-          # exit ${{ steps.lighthouse.outputs.exit_code }}
-          exit 0
+          echo "Lighthouse exit code: $EXIT_CODE"
+          echo "Error message: $ERROR_MESSAGE"
+          echo "Performance score: $PERFORMANCE"
+
+          # Fail if Lighthouse didn't produce any results
+          if [ -n "$ERROR_MESSAGE" ]; then
+            echo "::error::Lighthouse CI failed: $ERROR_MESSAGE"
+            echo "Review the lighthouse-output.txt artifact for details"
+            exit 1
+          fi
+
+          # Fail if performance score is empty (no results)
+          if [ -z "$PERFORMANCE" ] || [ "$PERFORMANCE" = "error" ]; then
+            echo "::error::Lighthouse CI did not produce valid results"
+            exit 1
+          fi
+
+          # Warn about assertion failures but don't fail the workflow
+          # (assertions may fail for expected reasons like CesiumJS performance)
+          if [ "$EXIT_CODE" != "0" ]; then
+            echo "::warning::Lighthouse CI assertions had warnings (exit code: $EXIT_CODE)"
+            echo "This is expected for CesiumJS applications with heavy initial load"
+          fi
+
+          echo "Lighthouse CI completed successfully with Performance score: $PERFORMANCE"

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -14,16 +14,31 @@ module.exports = {
 			// Build the production bundle and start preview server
 			startServerCommand: 'bun run preview',
 
+			// Pattern to detect when server is ready
+			// Vite outputs: "➜  Local:   http://localhost:4173/"
+			// Default pattern is /listen|ready/i which doesn't match Vite's output
+			startServerReadyPattern: 'Local:',
+
+			// Timeout for server startup (ms) - allow extra time for CI
+			startServerReadyTimeout: 30000,
+
 			// Test URL - preview server runs on port 4173 by default
 			url: ['http://localhost:4173/'],
 
 			// Number of runs for each URL to get median values
 			numberOfRuns: 3,
 
+			// Max wait time for page load (ms) - CesiumJS is heavy
+			maxWaitForLoad: 90000,
+
 			// Additional settings for more accurate measurements
 			settings: {
 				// Lighthouse preset
 				preset: 'desktop',
+
+				// Increase max wait time for page to load (CesiumJS is heavy)
+				maxWaitForFcp: 60000,
+				maxWaitForLoad: 90000,
 
 				// Disable throttling for CI environment
 				// (GitHub Actions runners are already slower than local dev)
@@ -32,6 +47,16 @@ module.exports = {
 					throughputKbps: 10240,
 					cpuSlowdownMultiplier: 1,
 				},
+
+				// Chrome flags for better CI performance
+				chromeFlags: [
+					'--disable-gpu',
+					'--no-sandbox',
+					'--disable-dev-shm-usage',
+					'--disable-background-timer-throttling',
+					'--disable-backgrounding-occluded-windows',
+					'--disable-renderer-backgrounding',
+				],
 
 				// Skip PWA and some unused audits to speed up CI
 				skipAudits: [


### PR DESCRIPTION
Address three issues causing Lighthouse CI to fail without proper status:

1. Server ready pattern mismatch: Lighthouse CI was looking for
   /listen|ready/i but Vite outputs "Local: http://localhost:4173/"
   - Added startServerReadyPattern: 'Local:'

2. PROTOCOL_TIMEOUT: CesiumJS heavy load caused Chrome DevTools timeout
   - Added maxWaitForLoad: 90000ms at collect and settings level
   - Added maxWaitForFcp: 60000ms
   - Added Chrome flags for better CI performance (disable-gpu, etc.)
   - Increased startServerReadyTimeout to 30000ms

3. Workflow always succeeded even on failure:
   - Replaced "Check Lighthouse assertions" step with proper failure logic
   - Now fails workflow when no results are produced
   - Distinguishes between missing results (fail) vs assertion warnings (warn)