### PR TITLE
claude/fix-docker-entrypoint-GDClN

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -66,7 +66,15 @@ server {
     location = /status {
         access_log off;
         add_header Content-Type application/json;
-        return 200 '{"status":"healthy","server":"r4c-frontend","nginx_version":"$nginx_version","timestamp":"$time_iso8601","config":{"pygeoapi":"${VITE_PYGEOAPI_HOST}","digitransit_key_set":"${VITE_DIGITRANSIT_KEY:+true}"},"checks":["/status/pygeoapi","/status/hsy-wms","/status/stat-fi","/status/digitransit","/status/helsinki-wms"]}';
+
+        # Check if digitransit key is configured (nginx variable logic)
+        set $digitransit_configured "false";
+        set $digitransit_key_check "${VITE_DIGITRANSIT_KEY}";
+        if ($digitransit_key_check != "") {
+            set $digitransit_configured "true";
+        }
+
+        return 200 '{"status":"healthy","server":"r4c-frontend","nginx_version":"$nginx_version","timestamp":"$time_iso8601","config":{"pygeoapi":"${VITE_PYGEOAPI_HOST}","digitransit_key_set":$digitransit_configured},"checks":["/status/pygeoapi","/status/hsy-wms","/status/stat-fi","/status/digitransit","/status/helsinki-wms"]}';
     }
 
     # -------------------------------------------


### PR DESCRIPTION
The /status endpoint was using `${VITE_DIGITRANSIT_KEY:+true}` which is bash-style parameter expansion syntax. nginx's envsubst only supports simple ${VAR} substitution, causing the error:

  nginx: [emerg] the closing bracket in "VITE_DIGITRANSIT_KEY" variable
  is missing in /etc/nginx/conf.d/default.conf:69

This fix uses nginx's native `set` directive with `if` condition to check if the digitransit key is configured, avoiding the unsupported bash syntax while achieving the same result.