### PR TITLE
claude/optimize-container-build-ci-PALOe

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -38,8 +38,7 @@ jobs:
             type=match,pattern=.*-v(\d+.\d+),group=1
             type=match,pattern=.*-v(\d+),group=1
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      # QEMU removed - only building for amd64 (no emulation needed)
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -56,7 +55,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -64,5 +63,6 @@ jobs:
             VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          provenance: mode=max
-          sbom: true
+          # SBOM and provenance only for release tags (saves ~30s on regular builds)
+          provenance: ${{ startsWith(github.ref, 'refs/tags/') && 'mode=max' || 'false' }}
+          sbom: ${{ startsWith(github.ref, 'refs/tags/') }}


### PR DESCRIPTION
- Remove ARM64 platform build (amd64-only reduces build time by ~50%)
- Remove QEMU setup step (no longer needed without cross-platform builds)
- Make SBOM and provenance conditional (only for release tags)

Expected improvement: ~8min → ~4min for regular main branch builds. ARM64 was only used for Mac development which can use Rosetta 2.