### PR TITLE
fix(ci): add outputDir to Lighthouse CI config

### DIFF
--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -31,6 +31,9 @@ module.exports = {
 			// Max wait time for page load (ms) - CesiumJS is heavy
 			maxWaitForLoad: 90000,
 
+			// Output directory for results (required for CI workflow parsing)
+			outputDir: '.lighthouseci',
+
 			// Additional settings for more accurate measurements
 			settings: {
 				// Lighthouse preset
@@ -136,9 +139,6 @@ module.exports = {
 			// Use temporary public storage (free, no setup required)
 			// Results are available for 7 days via a public URL
 			target: 'temporary-public-storage',
-
-			// Optionally store results in filesystem for archival
-			// outputDir: '.lighthouseci',
 		},
 
 		// Server configuration (optional - for Lighthouse CI server)


### PR DESCRIPTION
Fixes #521

The Lighthouse CI workflow was failing with "manifest.json not found" because the `collect.outputDir` setting was commented out.

## Changes
- Added `outputDir: '.lighthouseci'` to the collect section
- Removed duplicate commented-out line from the upload section
- Added clear comment explaining the requirement

This ensures the workflow's parse step can find the required manifest.json file.

Generated with [Claude Code](https://claude.ai/code)