### PR TITLE
feat(ux): add altitude-based fog overlay for zoom indication

### DIFF
--- a/docs/adr/ADR-004-altitude-visual-indicator.md
+++ b/docs/adr/ADR-004-altitude-visual-indicator.md
@@ -1,0 +1,116 @@
+# ADR-004: CSS Overlay for Altitude-Based Visual Indicators
+
+## Status
+
+Accepted
+
+## Date
+
+2026-01-14
+
+## Context
+
+Users need a visual indication when the camera is zoomed out beyond the building loading threshold (3000m altitude). Without this feedback, users see an empty map with no explanation of why buildings aren't visible.
+
+The indicator should:
+
+- Feel natural and non-intrusive (not text-based)
+- Appear gradually as users zoom out
+- Clear smoothly as users zoom in
+- Not interfere with map interactions
+
+## Decision
+
+Use a CSS overlay element instead of CesiumJS's built-in fog system.
+
+The overlay:
+
+- Is a semi-transparent gradient (atmospheric haze appearance)
+- Positioned absolutely within `#cesiumContainer`
+- Opacity controlled by camera altitude (0% at ≤3000m, 40% at ≥10000m)
+- Uses quadratic easing for natural appearance
+- Has `pointer-events: none` to allow map interaction through it
+
+Additionally, the default camera height was lowered from 4000m to 2800m so buildings load immediately on app start.
+
+## Consequences
+
+### Positive
+
+- Reliable, predictable visual effect across all browsers
+- Full control over appearance (color, gradient, opacity curve)
+- Simple implementation with no CesiumJS API complexity
+- Smooth CSS transitions built-in
+- No performance impact on 3D rendering
+
+### Negative
+
+- Not integrated with CesiumJS scene (doesn't affect 3D depth perception)
+- Requires manual z-index management relative to other UI elements
+
+### Neutral
+
+- Overlay element added to DOM (minimal overhead)
+
+## Alternatives Considered
+
+### CesiumJS Built-in Fog (`viewer.scene.fog`)
+
+CesiumJS provides fog with properties like `density`, `visualDensityScalar`, `heightScalar`, and `heightFalloff`.
+
+**Why not chosen:**
+
+- CesiumJS fog is designed for **distance-based atmospheric scattering** (making distant objects fade toward the horizon)
+- At typical map viewing altitudes (3000-10000m), the fog effect is imperceptible because it's calculated based on distance to terrain, not camera altitude
+- The fog parameters don't provide direct altitude-based control
+- Testing confirmed the effect was invisible even with aggressive density settings
+
+### Desaturation Effect
+
+Reduce color saturation when zoomed out, making colors vivid as you zoom in.
+
+**Why not chosen:**
+
+- Would require post-processing shader modifications
+- Less intuitive visual metaphor than "haze clearing"
+- More complex to implement
+
+### Zoom Icon Indicator
+
+Display a small animated "zoom in" icon when above threshold.
+
+**Why not chosen:**
+
+- Text/icon-based approach (user preference was for something more natural)
+- Doesn't provide graduated feedback as altitude changes
+- More abrupt visual change
+
+### Ground Atmosphere Glow
+
+Adjust `globe.showGroundAtmosphere` to create a glowing effect.
+
+**Why not chosen:**
+
+- Limited control over the effect
+- Designed for global atmosphere visualization, not altitude feedback
+
+## Implementation Notes
+
+Key files:
+
+- `src/composables/useFogEffect.js` - Core overlay logic
+- `src/constants/viewport.js` - `FOG_START_HEIGHT` (3000m), `FOG_FULL_HEIGHT` (10000m)
+- `src/services/camera.js` - Default camera height (2800m)
+- `src/pages/CesiumViewer.vue` - Initialization
+
+The composable:
+
+1. Creates overlay element on init
+2. Listens to `camera.changed` events (debounced 50ms)
+3. Calculates opacity using quadratic easing based on altitude
+4. Cleans up event listeners and DOM element on unmount
+
+## References
+
+- CesiumJS Fog API: https://cesium.com/learn/cesiumjs/ref-doc/Fog.html
+- CesiumJS Fog Sandcastle: https://sandcastle.cesium.com/?src=Fog.html

--- a/src/composables/useFogEffect.js
+++ b/src/composables/useFogEffect.js
@@ -1,0 +1,189 @@
+/**
+ * @module composables/useFogEffect
+ * Manages a CSS overlay effect based on camera altitude.
+ * Overlay appears above 3000m (building loading threshold) and fades as you zoom in,
+ * providing a natural visual indicator that buildings won't load until zoomed in.
+ */
+
+import { VIEWPORT } from '../constants/viewport.js'
+import logger from '../utils/logger.js'
+
+/**
+ * Configuration for altitude-based overlay effect
+ */
+const OVERLAY_CONFIG = {
+	/** Altitude where overlay starts appearing (meters) - matches building loading threshold */
+	START_HEIGHT: VIEWPORT.FOG_START_HEIGHT,
+	/** Altitude where overlay reaches maximum opacity (meters) */
+	FULL_HEIGHT: VIEWPORT.FOG_FULL_HEIGHT,
+	/** Maximum overlay opacity (0-1) */
+	MAX_OPACITY: 0.4,
+	/** Minimum overlay opacity (no overlay below threshold) */
+	MIN_OPACITY: 0,
+	/** Debounce delay for overlay updates (ms) */
+	UPDATE_DEBOUNCE_MS: 50,
+	/** Transition duration for smooth opacity changes (ms) */
+	TRANSITION_MS: 300,
+}
+
+/**
+ * Calculate overlay opacity based on camera altitude.
+ * Uses quadratic easing for natural appearance.
+ *
+ * @param {number} altitude - Camera altitude in meters
+ * @returns {number} Overlay opacity value (0-1)
+ */
+const calculateOverlayOpacity = (altitude) => {
+	if (altitude <= OVERLAY_CONFIG.START_HEIGHT) {
+		return OVERLAY_CONFIG.MIN_OPACITY
+	}
+
+	if (altitude >= OVERLAY_CONFIG.FULL_HEIGHT) {
+		return OVERLAY_CONFIG.MAX_OPACITY
+	}
+
+	// Linear interpolation between start and full height
+	const t =
+		(altitude - OVERLAY_CONFIG.START_HEIGHT) /
+		(OVERLAY_CONFIG.FULL_HEIGHT - OVERLAY_CONFIG.START_HEIGHT)
+
+	// Use easeInQuad for gradual appearance
+	const easedT = t * t
+
+	return (
+		OVERLAY_CONFIG.MIN_OPACITY + (OVERLAY_CONFIG.MAX_OPACITY - OVERLAY_CONFIG.MIN_OPACITY) * easedT
+	)
+}
+
+/**
+ * Vue 3 composable for altitude-based CSS overlay effect
+ *
+ * @param {any} viewer - Cesium viewer instance
+ * @returns {{
+ *   initFog: () => void,
+ *   cleanup: () => void
+ * }}
+ *
+ * @example
+ * import { useFogEffect } from '@/composables/useFogEffect';
+ * const { initFog, cleanup } = useFogEffect(viewer.value);
+ * initFog();
+ * // Later: cleanup() in onBeforeUnmount
+ */
+export function useFogEffect(viewer) {
+	let cameraChangedHandler = null
+	let updateDebounceTimeout = null
+	let overlayElement = null
+
+	/**
+	 * Create and inject the overlay element into the Cesium container
+	 */
+	const createOverlayElement = () => {
+		const cesiumContainer = document.getElementById('cesiumContainer')
+		if (!cesiumContainer) {
+			logger.warn('[useFogEffect] Cannot create overlay - cesiumContainer not found')
+			return null
+		}
+
+		// Create overlay element
+		const overlay = document.createElement('div')
+		overlay.id = 'altitude-fog-overlay'
+		overlay.style.cssText = `
+			position: absolute;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			background: linear-gradient(
+				to bottom,
+				rgba(180, 195, 210, 0.7) 0%,
+				rgba(200, 210, 220, 0.4) 50%,
+				rgba(220, 225, 230, 0.2) 100%
+			);
+			pointer-events: none;
+			opacity: 0;
+			transition: opacity ${OVERLAY_CONFIG.TRANSITION_MS}ms ease-out;
+			z-index: 10;
+		`
+
+		cesiumContainer.appendChild(overlay)
+		return overlay
+	}
+
+	/**
+	 * Update overlay opacity based on current camera altitude.
+	 * Called on camera change events with debouncing.
+	 */
+	const updateOverlayFromAltitude = () => {
+		if (!viewer?.camera?.positionCartographic || !overlayElement) return
+
+		const altitude = viewer.camera.positionCartographic.height
+		const opacity = calculateOverlayOpacity(altitude)
+
+		overlayElement.style.opacity = opacity.toString()
+
+		logger.debug(
+			`[useFogEffect] Altitude: ${Math.round(altitude)}m, Overlay opacity: ${opacity.toFixed(2)}`
+		)
+	}
+
+	/**
+	 * Debounced overlay update handler
+	 */
+	const debouncedOverlayUpdate = () => {
+		if (updateDebounceTimeout) {
+			clearTimeout(updateDebounceTimeout)
+		}
+		updateDebounceTimeout = setTimeout(updateOverlayFromAltitude, OVERLAY_CONFIG.UPDATE_DEBOUNCE_MS)
+	}
+
+	/**
+	 * Initialize overlay effect with camera event listener
+	 */
+	const initFog = () => {
+		if (!viewer?.camera) {
+			logger.warn('[useFogEffect] Cannot init overlay - viewer not ready')
+			return
+		}
+
+		// Create the overlay element
+		overlayElement = createOverlayElement()
+		if (!overlayElement) return
+
+		// Set initial overlay state
+		updateOverlayFromAltitude()
+
+		// Listen for camera changes
+		cameraChangedHandler = debouncedOverlayUpdate
+		viewer.camera.changed.addEventListener(cameraChangedHandler)
+
+		logger.debug('[useFogEffect] Overlay effect initialized')
+	}
+
+	/**
+	 * Clean up event listeners, timeouts, and DOM element
+	 */
+	const cleanup = () => {
+		if (updateDebounceTimeout) {
+			clearTimeout(updateDebounceTimeout)
+			updateDebounceTimeout = null
+		}
+
+		if (viewer?.camera && cameraChangedHandler) {
+			viewer.camera.changed.removeEventListener(cameraChangedHandler)
+			cameraChangedHandler = null
+		}
+
+		if (overlayElement) {
+			overlayElement.remove()
+			overlayElement = null
+		}
+
+		logger.debug('[useFogEffect] Overlay effect cleaned up')
+	}
+
+	return {
+		initFog,
+		cleanup,
+	}
+}

--- a/src/constants/viewport.js
+++ b/src/constants/viewport.js
@@ -5,4 +5,7 @@ export const VIEWPORT = {
 	DRAG_DETECTION_THRESHOLD_PX: 5,
 	CLICK_PICK_TOLERANCE_PX: 5,
 	MIN_ZOOM_FOR_DETAILS: 15,
+	// Fog effect thresholds - indicates buildings won't load until zoomed in
+	FOG_START_HEIGHT: 3000, // meters - fog begins appearing
+	FOG_FULL_HEIGHT: 10000, // meters - fog reaches maximum density
 }

--- a/src/pages/CesiumViewer.vue
+++ b/src/pages/CesiumViewer.vue
@@ -141,6 +141,7 @@ import ViewportLoadingIndicator from '../components/ViewportLoadingIndicator.vue
 import { useCameraControls } from '../composables/useCameraControls.js'
 import { useDataLoading } from '../composables/useDataLoading.js'
 import { useEntityPicking } from '../composables/useEntityPicking.js'
+import { useFogEffect } from '../composables/useFogEffect.js'
 import { useKeyboardShortcuts } from '../composables/useKeyboardShortcuts.js'
 import { useUrlState } from '../composables/useUrlState.js'
 import { useViewerInitialization } from '../composables/useViewerInitialization.js'
@@ -292,6 +293,10 @@ export default {
 			// Initialize camera controls with URL update callback
 			cameraControlsInstance = useCameraControls(viewer.value, handleCameraSettled, handleUrlUpdate)
 			cameraControlsInstance.addCameraMoveEndListener()
+
+			// Initialize fog effect (visual indicator for zoom level)
+			const { initFog } = useFogEffect(viewer.value)
+			initFog()
 
 			// Initialize viewport streaming if enabled
 			await initViewportStreaming()

--- a/src/services/camera.js
+++ b/src/services/camera.js
@@ -143,7 +143,7 @@ export default class Camera {
 	 */
 	init() {
 		this.viewer.camera.setView({
-			destination: Cesium.Cartesian3.fromDegrees(24.945, 60.17, 4000),
+			destination: Cesium.Cartesian3.fromDegrees(24.945, 60.17, 2800),
 			orientation: {
 				heading: Cesium.Math.toRadians(0.0),
 				pitch: Cesium.Math.toRadians(-35.0),


### PR DESCRIPTION
## Summary

- Adds a CSS overlay that appears when camera altitude exceeds the building loading threshold (3000m)
- Provides natural visual feedback that buildings won't load until zoomed in
- Lowers default camera height from 4000m to 2800m so buildings load immediately on app start

## Changes

- **New composable**: `useFogEffect.js` - Manages altitude-based CSS overlay with camera event handling
- **Constants**: Added `FOG_START_HEIGHT` (3000m) and `FOG_FULL_HEIGHT` (10000m) thresholds
- **Camera service**: Lowered default camera height to 2800m
- **Documentation**: ADR-004 documenting the design decision and alternatives considered

## Technical Details

The overlay uses quadratic easing for natural appearance and debounced camera event handling (50ms) for performance. The effect reaches 40% opacity at maximum height, providing subtle visual feedback without being intrusive.

## Test plan

- [ ] Start app - verify buildings load immediately (camera starts at 2800m)
- [ ] Zoom out past 3000m - verify fog overlay gradually appears
- [ ] Zoom in - verify fog overlay smoothly clears
- [ ] Verify map interactions work through overlay (pointer-events: none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)