### PR TITLE
claude/fix-release-please-recursion-Nl4QC

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,9 @@ on:
   push:
     branches:
       - main
-      - 'release-*'  # Support backport release branches (e.g., release-1.22.x)
+      # Support backport release branches (e.g., release-1.22.x)
+      # Pattern must NOT match release-please PR branches (release-please--branches--*)
+      - 'release-[0-9]+.[0-9]+.x'
 
 permissions:
   contents: write


### PR DESCRIPTION
The branch pattern 'release-*' was matching both actual release branches (release-1.22.x) and release-please PR branches (release-please--branches--*), causing infinite workflow recursion.

Changed to 'release-[0-9]+.[0-9]+.x' which only matches semantic version release branches.