### PR TITLE
fix: TypeError in PrintBox when pickedEntity is null (#586)

### DIFF
--- a/src/components/PrintBox.vue
+++ b/src/components/PrintBox.vue
@@ -17,7 +17,7 @@ export default {
 		const entityPrint = () => {
 			const entity = store.pickedEntity
 
-			if (entity._polygon && entity.properties) {
+			if (entity?._polygon && entity?.properties) {
 				document.getElementById('printContainer').scroll({
 					top: 0,
 					behavior: 'instant',

--- a/tests/unit/components/PrintBox.test.js
+++ b/tests/unit/components/PrintBox.test.js
@@ -1,0 +1,120 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import PrintBox from '@/components/PrintBox.vue'
+import { useGlobalStore } from '@/stores/globalStore.js'
+
+vi.mock('@/services/cesiumProvider.js', () => ({
+	getCesium: vi.fn(() => ({
+		Color: (r, g, b, a) => ({ r, g, b, a }),
+	})),
+}))
+
+vi.mock('@/services/eventEmitter.js', () => ({
+	eventBus: {
+		on: vi.fn(),
+		off: vi.fn(),
+		emit: vi.fn(),
+	},
+}))
+
+describe('PrintBox Component', () => {
+	let wrapper
+	let store
+
+	beforeEach(() => {
+		setActivePinia(createPinia())
+		store = useGlobalStore()
+		vi.clearAllMocks()
+	})
+
+	afterEach(() => {
+		if (wrapper) {
+			wrapper.unmount()
+		}
+		vi.clearAllMocks()
+	})
+
+	describe('entityPrint with null pickedEntity', () => {
+		it('should not crash when pickedEntity is null', async () => {
+			// RED phase: This should fail without the null check fix
+			store.pickedEntity = null
+
+			expect(() => {
+				wrapper = mount(PrintBox)
+			}).not.toThrow()
+
+			await nextTick()
+			expect(wrapper.vm).toBeDefined()
+		})
+
+		it('should render component even when pickedEntity is null', async () => {
+			store.pickedEntity = null
+			wrapper = mount(PrintBox)
+			await nextTick()
+
+			expect(wrapper.find('#printContainer').exists()).toBe(true)
+		})
+	})
+
+	describe('entityPrint with valid data', () => {
+		it('should not crash when entity lacks _polygon property', async () => {
+			const invalidEntity = {
+				properties: { posno: '00100' },
+			}
+			store.pickedEntity = invalidEntity
+
+			expect(() => {
+				wrapper = mount(PrintBox)
+			}).not.toThrow()
+
+			await nextTick()
+			expect(wrapper.vm).toBeDefined()
+		})
+
+		it('should not crash when entity lacks properties', async () => {
+			const invalidEntity = {
+				_polygon: true,
+			}
+			store.pickedEntity = invalidEntity
+
+			expect(() => {
+				wrapper = mount(PrintBox)
+			}).not.toThrow()
+
+			await nextTick()
+			expect(wrapper.vm).toBeDefined()
+		})
+
+		it('should not crash when entity is undefined', async () => {
+			store.pickedEntity = undefined
+
+			expect(() => {
+				wrapper = mount(PrintBox)
+			}).not.toThrow()
+
+			await nextTick()
+			expect(wrapper.vm).toBeDefined()
+		})
+	})
+
+	describe('printContainer rendering', () => {
+		it('should render printContainer element', async () => {
+			store.pickedEntity = null
+			wrapper = mount(PrintBox)
+			await nextTick()
+
+			expect(wrapper.find('#printContainer').exists()).toBe(true)
+		})
+
+		it('should have initial placeholder text', async () => {
+			store.pickedEntity = null
+			wrapper = mount(PrintBox)
+			await nextTick()
+
+			const container = wrapper.find('#printContainer')
+			expect(container.text()).toContain('Please click on areas to retrieve more information')
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Fixes #586 - TypeError: Cannot read properties of null (reading '_polygon')

## Changes

- Add optional chaining null checks on pickedEntity in entityPrint function
- Uses optional chaining operator to safely check properties
- Prevents crash when pickedEntity is null or undefined on component mount

## Testing

- Add comprehensive unit tests for PrintBox component
- Tests cover null/undefined/invalid entity scenarios
- All tests pass with the fix applied