### PR TITLE
refactor(test): centralize API mocking via custom test fixture

### DIFF
--- a/tests/config/constants.ts
+++ b/tests/config/constants.ts
@@ -88,11 +88,27 @@ export const POSTAL_CODE_RANGES = {
  * await page.waitForRequest(API_ENDPOINTS.WMS_PROXY);
  */
 export const API_ENDPOINTS = {
-	WMS_PROXY: '/helsinki-wms',
+	WMS_PROXY: '/wms/proxy',
+	WMS_LAYERS: '/wms/layers',
+	HSY_ACTION: '/hsy-action',
+	HELSINKI_WMS: '/helsinki-wms',
 	DIGITRANSIT: '/digitransit',
 	PAAVO: '/paavo',
 	PYGEOAPI: '/pygeoapi',
 	TERRAIN_PROXY: '/terrain-proxy',
+	NDVI: '/ndvi_public',
+	FEATURE_FLAGS: '/feature-flags',
+} as const
+
+/**
+ * External domain patterns used by the application.
+ * Useful for asserting requests are intercepted by mocks.
+ */
+export const EXTERNAL_DOMAINS = {
+	HSY_WMS: 'kartta.hsy.fi',
+	HELSINKI_WMS: 'kartta.hel.fi',
+	SYKE_FLOOD: 'paikkatiedot.ymparisto.fi',
+	SENSOR: 'bri3.fvh.io',
 } as const
 
 /**

--- a/tests/control-panel.spec.ts
+++ b/tests/control-panel.spec.ts
@@ -1,10 +1,6 @@
-import { expect, test } from '@playwright/test'
 import { TEST_TIMEOUTS } from './e2e/helpers/test-helpers'
+import { expect, test } from './fixtures/test-fixture'
 import { dismissModalIfPresent } from './helpers/test-helpers' // TEST_TIMEOUTS;
-import { setupDigitransitMock } from './setup/digitransit-mock'
-
-// Setup digitransit mocking for all tests in this file
-setupDigitransitMock()
 
 test.describe('Control Panel Functionality', () => {
 	test.use({ tag: ['@e2e', '@ui'] })

--- a/tests/data-visualization.spec.ts
+++ b/tests/data-visualization.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from './fixtures/test-fixture'
 import {
 	clickOnMap,
 	dismissModalIfPresent,
@@ -7,10 +7,6 @@ import {
 	waitForCesiumReady,
 	waitForMapViewTransition,
 } from './helpers/test-helpers'
-import { setupDigitransitMock } from './setup/digitransit-mock'
-
-// Setup digitransit mocking for all tests in this file
-setupDigitransitMock()
 
 test.describe('Data Visualization Components', () => {
 	test.use({ tag: ['@e2e', '@data', '@visual'] })

--- a/tests/e2e/accessibility/building-hover.spec.ts
+++ b/tests/e2e/accessibility/building-hover.spec.ts
@@ -4,12 +4,8 @@
  *
  * @tags @e2e @accessibility
  */
-import { expect, test } from '@playwright/test'
-import { setupDigitransitMock } from '../../setup/digitransit-mock'
+import { expect, test } from '../../fixtures/test-fixture'
 import { TEST_TIMEOUTS } from '../helpers/test-helpers'
-
-// Setup digitransit mocking for all tests in this file
-setupDigitransitMock()
 
 // SKIPPED: Vuetify dialog component (disclaimer popup) does not render properly in Playwright CI environment
 // The "Explore Map" button is not visible because the dialog fails to mount its DOM elements

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '../fixtures/test-fixture'
 import { dismissModalIfPresent, TEST_TIMEOUTS, waitForCesiumReady } from '../helpers/test-helpers'
 
 test('Page load', { tag: ['@e2e', '@smoke'] }, async ({ page }) => {

--- a/tests/e2e/building-fill-regression.spec.ts
+++ b/tests/e2e/building-fill-regression.spec.ts
@@ -12,7 +12,7 @@
  * polygon.fill = true for all entities as the single authoritative location.
  */
 
-import { expect, test } from '@playwright/test'
+import { expect, test } from '../fixtures/test-fixture'
 import { TEST_TIMEOUTS } from './helpers/test-helpers'
 
 /**

--- a/tests/e2e/cache-headers.spec.ts
+++ b/tests/e2e/cache-headers.spec.ts
@@ -37,7 +37,7 @@
  *
  * @see https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/349
  */
-import { expect, test } from '@playwright/test'
+import { expect, test } from '../fixtures/test-fixture'
 
 /**
  * Matches Vite build output pattern: /assets/[name].[8-char-hex-hash].[semver].[ext]

--- a/tests/e2e/comprehensive.spec.ts
+++ b/tests/e2e/comprehensive.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from '@playwright/test'
 import { VIEWPORTS } from '../config/constants'
+import { expect, test } from '../fixtures/test-fixture'
 import {
 	clickOnMap,
 	dismissModalIfPresent,

--- a/tests/e2e/feature-flags.spec.ts
+++ b/tests/e2e/feature-flags.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '../fixtures/test-fixture'
 import { dismissModalIfPresent } from '../helpers/test-helpers' // TEST_TIMEOUTS;
 import { TEST_TIMEOUTS } from './helpers/test-helpers'
 

--- a/tests/e2e/view-transition-performance.spec.ts
+++ b/tests/e2e/view-transition-performance.spec.ts
@@ -1,9 +1,5 @@
-import { expect, test } from '@playwright/test'
-import { setupDigitransitMock } from '../setup/digitransit-mock'
+import { expect, test } from '../fixtures/test-fixture'
 import { TEST_TIMEOUTS } from './helpers/test-helpers'
-
-// Setup digitransit mocking for all tests in this file
-setupDigitransitMock()
 
 /**
  * View Transition Performance Tests

--- a/tests/e2e/viewport-building-loading.spec.ts
+++ b/tests/e2e/viewport-building-loading.spec.ts
@@ -16,7 +16,7 @@
  * 3. Building datasources are created with "Buildings Viewport" naming
  */
 
-import { expect, test } from '@playwright/test'
+import { expect, test } from '../fixtures/test-fixture'
 import { TEST_TIMEOUTS } from './helpers/test-helpers'
 
 /**

--- a/tests/fixtures/cesium-fixture.ts
+++ b/tests/fixtures/cesium-fixture.ts
@@ -1,6 +1,7 @@
-import { test as base, type Page } from '@playwright/test'
+import type { Page } from '@playwright/test'
 import { setupCesiumForCI, waitForAppReady, waitForCesiumReady } from '../e2e/helpers/cesium-helper'
 import { TEST_TIMEOUTS } from '../e2e/helpers/test-helpers'
+import { test as base } from './test-fixture'
 
 /**
  * Cesium Test Fixture
@@ -460,6 +461,7 @@ export const cesiumTest = base.extend<CesiumFixtures>({
 								this.north = north
 							}
 							static fromDegrees(west, south, east, north) {
+								// biome-ignore lint/complexity/noThisInStatic: Factory pattern for anonymous class
 								return new this(west, south, east, north)
 							}
 						},
@@ -476,6 +478,7 @@ export const cesiumTest = base.extend<CesiumFixtures>({
 								this.secondsOfDay = secondsOfDay
 							}
 							static now() {
+								// biome-ignore lint/complexity/noThisInStatic: Factory pattern for anonymous class
 								return new this()
 							}
 						},

--- a/tests/fixtures/test-fixture.ts
+++ b/tests/fixtures/test-fixture.ts
@@ -1,0 +1,25 @@
+// Custom base test with automatic external API mocking.
+//
+// All tests that import `test` from this module get mocked APIs
+// by default. Opt out per file with `test.use({ mockAPIs: false })`.
+//
+// Override a single API in a test:
+//   await page.unroute('**/wms/proxy*')
+//   await page.route('**/wms/proxy*', route => route.fulfill({ status: 503 }))
+import { test as base } from '@playwright/test'
+import { setupAllApiMocks } from '../setup/api-mocks'
+
+export const test = base.extend<{ mockAPIs: boolean; apiMocking: undefined }>({
+	mockAPIs: [true, { option: true }],
+	apiMocking: [
+		async ({ page, mockAPIs }, use) => {
+			if (mockAPIs) {
+				await setupAllApiMocks(page)
+			}
+			await use()
+		},
+		{ auto: true },
+	],
+})
+
+export { expect } from '@playwright/test'

--- a/tests/loading-performance.spec.ts
+++ b/tests/loading-performance.spec.ts
@@ -1,10 +1,6 @@
-import { expect, test } from '@playwright/test'
 import { BUNDLE_SIZE_BUDGETS, WEB_VITALS_BUDGETS } from './config/constants'
 import { TEST_TIMEOUTS } from './e2e/helpers/test-helpers'
-import { setupDigitransitMock } from './setup/digitransit-mock'
-
-// Setup digitransit mocking for all tests in this file
-setupDigitransitMock()
+import { expect, test } from './fixtures/test-fixture'
 
 test.describe('Loading Performance and User Experience', () => {
 	test.use({ tag: ['@performance'] })

--- a/tests/map-interactions.spec.ts
+++ b/tests/map-interactions.spec.ts
@@ -1,9 +1,5 @@
-import { expect, test } from '@playwright/test'
 import { TEST_TIMEOUTS } from './e2e/helpers/test-helpers'
-import { setupDigitransitMock } from './setup/digitransit-mock'
-
-// Setup digitransit mocking for all tests in this file
-setupDigitransitMock()
+import { expect, test } from './fixtures/test-fixture'
 
 test.describe('Map Interactions and Navigation', () => {
 	test.use({ tag: ['@e2e', '@map', '@navigation'] })

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -1,9 +1,5 @@
-import { expect, test } from '@playwright/test'
 import { VIEWPORTS } from './config/constants'
-import { setupDigitransitMock } from './setup/digitransit-mock'
-
-// Setup digitransit mocking for all tests in this file
-setupDigitransitMock()
+import { expect, test } from './fixtures/test-fixture'
 
 test.describe('Navigation and App Layout', () => {
 	test.use({ tag: ['@e2e', '@navigation', '@layout'] })

--- a/tests/r4c.spec.ts
+++ b/tests/r4c.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from './fixtures/test-fixture'
 import {
 	clickOnMap,
 	dismissModalIfPresent,
@@ -6,10 +6,6 @@ import {
 	waitForCesiumReady,
 	waitForMapViewTransition,
 } from './helpers/test-helpers'
-import { setupDigitransitMock } from './setup/digitransit-mock'
-
-// Setup digitransit mocking for all tests in this file
-setupDigitransitMock()
 
 test('Page load', { tag: ['@e2e', '@smoke'] }, async ({ page }) => {
 	await page.goto('/')

--- a/tests/setup/api-mocks/data-api-mocks.ts
+++ b/tests/setup/api-mocks/data-api-mocks.ts
@@ -1,0 +1,54 @@
+/**
+ * Data API route handlers for E2E test mocking.
+ *
+ * Intercepts non-WMS external API requests (PyGeoAPI, Paavo/Statistics Finland,
+ * terrain, NDVI, sensors, feature flags) so tests run offline.
+ */
+import type { Page } from '@playwright/test'
+import { EMPTY_FEATURE_COLLECTION, EMPTY_SENSOR_DATA, PAAVO_DATA } from './fixtures'
+
+export async function setupDataApiMocks(page: Page): Promise<void> {
+	await Promise.all([
+		// PyGeoAPI — all collection endpoints
+		page.route('**/pygeoapi/**', (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify(EMPTY_FEATURE_COLLECTION),
+			})
+		),
+
+		// Paavo / Statistics Finland postal code data
+		page.route('**/paavo*', (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify(PAAVO_DATA),
+			})
+		),
+
+		// Terrain proxy — not critical for tests, abort to save time
+		page.route('**/terrain-proxy/**', (route) => route.abort()),
+
+		// NDVI — not critical for tests
+		page.route('**/ndvi_public/**', (route) => route.abort()),
+
+		// R4C sensor endpoint
+		page.route('**/bri3.fvh.io/**', (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify(EMPTY_SENSOR_DATA),
+			})
+		),
+
+		// Feature flag service
+		page.route('**/feature-flags/**', (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({}),
+			})
+		),
+	])
+}

--- a/tests/setup/api-mocks/digitransit-mock.ts
+++ b/tests/setup/api-mocks/digitransit-mock.ts
@@ -1,0 +1,123 @@
+/**
+ * Digitransit geocoding API route handlers for E2E test mocking.
+ *
+ * Migrated from tests/setup/digitransit-mock.ts to the global
+ * API mocking system. Same logic, now called per-page instead of
+ * via test.beforeEach.
+ */
+import type { Page } from '@playwright/test'
+
+const MOCK_RESPONSES = {
+	autocomplete: {
+		type: 'FeatureCollection',
+		features: [
+			{
+				type: 'Feature',
+				geometry: { type: 'Point', coordinates: [24.9384, 60.1699] },
+				properties: {
+					id: 'helsinki:1',
+					gid: 'whosonfirst:locality:101748417',
+					layer: 'locality',
+					source: 'whosonfirst',
+					source_id: '101748417',
+					name: 'Helsinki',
+					confidence: 1,
+					match_type: 'exact',
+					accuracy: 'centroid',
+					country: 'Finland',
+					country_gid: 'whosonfirst:country:85633143',
+					country_a: 'FIN',
+					region: 'Uusimaa',
+					region_gid: 'whosonfirst:region:85682067',
+					locality: 'Helsinki',
+					locality_gid: 'whosonfirst:locality:101748417',
+					label: 'Helsinki, Finland',
+				},
+			},
+		],
+		geocoding: {
+			version: '0.2',
+			attribution: 'Test attribution',
+			query: {
+				text: 'helsinki',
+				size: 10,
+				private: false,
+				lang: { name: 'Finnish', iso6391: 'fi', iso6393: 'fin', defaulted: true },
+				querySize: 20,
+				parser: 'pelias',
+				parsed_text: { subject: 'helsinki' },
+			},
+			warnings: [],
+			engine: { name: 'Pelias', author: 'Mapzen', version: '1.0' },
+			timestamp: Date.now(),
+		},
+	},
+	search: {
+		type: 'FeatureCollection',
+		features: [
+			{
+				type: 'Feature',
+				geometry: { type: 'Point', coordinates: [24.9384, 60.1699] },
+				properties: {
+					id: 'helsinki:1',
+					gid: 'whosonfirst:locality:101748417',
+					layer: 'locality',
+					source: 'whosonfirst',
+					source_id: '101748417',
+					name: 'Helsinki',
+					confidence: 1,
+					match_type: 'exact',
+					accuracy: 'centroid',
+					country: 'Finland',
+					country_gid: 'whosonfirst:country:85633143',
+					country_a: 'FIN',
+					region: 'Uusimaa',
+					region_gid: 'whosonfirst:region:85682067',
+					locality: 'Helsinki',
+					locality_gid: 'whosonfirst:locality:101748417',
+					label: 'Helsinki, Finland',
+				},
+			},
+		],
+	},
+} as const
+
+export async function setupDigitransitMocks(page: Page): Promise<void> {
+	await page.route('**/digitransit/**', async (route) => {
+		const url = route.request().url()
+
+		if (url.includes('/geocoding/v1/autocomplete')) {
+			const urlObj = new URL(url)
+			const searchText = urlObj.searchParams.get('text') || ''
+
+			const response = {
+				...MOCK_RESPONSES.autocomplete,
+				features: MOCK_RESPONSES.autocomplete.features.map((feature) => ({
+					...feature,
+					properties: {
+						...feature.properties,
+						label: searchText ? `${searchText}, Finland` : feature.properties.label,
+					},
+				})),
+			}
+
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify(response),
+			})
+		} else if (url.includes('/geocoding/v1/search')) {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify(MOCK_RESPONSES.search),
+			})
+		} else {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ status: 'ok', timestamp: Date.now() }),
+			})
+		}
+	})
+}

--- a/tests/setup/api-mocks/fixtures.ts
+++ b/tests/setup/api-mocks/fixtures.ts
@@ -1,0 +1,144 @@
+/**
+ * Mock response data for external API mocking in E2E tests.
+ *
+ * All fixtures are intentionally minimal — just enough structure
+ * for the application to parse without errors.
+ */
+
+// 1×1 transparent PNG (67 bytes) — used for all WMS tile responses
+// prettier-ignore
+export const TRANSPARENT_PNG = Buffer.from([
+	0x89,
+	0x50,
+	0x4e,
+	0x47,
+	0x0d,
+	0x0a,
+	0x1a,
+	0x0a, // PNG signature
+	0x00,
+	0x00,
+	0x00,
+	0x0d,
+	0x49,
+	0x48,
+	0x44,
+	0x52, // IHDR chunk
+	0x00,
+	0x00,
+	0x00,
+	0x01,
+	0x00,
+	0x00,
+	0x00,
+	0x01, // 1×1
+	0x08,
+	0x06,
+	0x00,
+	0x00,
+	0x00,
+	0x1f,
+	0x15,
+	0xc4, // RGBA, 8-bit
+	0x89,
+	0x00,
+	0x00,
+	0x00,
+	0x0a,
+	0x49,
+	0x44,
+	0x41, // IDAT chunk
+	0x54,
+	0x78,
+	0x9c,
+	0x62,
+	0x00,
+	0x00,
+	0x00,
+	0x02, // compressed data
+	0x00,
+	0x01,
+	0xe5,
+	0x27,
+	0xde,
+	0xfc,
+	0x00,
+	0x00, // ...
+	0x00,
+	0x00,
+	0x49,
+	0x45,
+	0x4e,
+	0x44,
+	0xae,
+	0x42, // IEND chunk
+	0x60,
+	0x82,
+])
+
+// Minimal WMS GetCapabilities XML — 3 layers for HSYWMS.vue parsing
+export const WMS_CAPABILITIES_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<WMS_Capabilities version="1.3.0">
+  <Service><Name>WMS</Name><Title>Mock WMS</Title></Service>
+  <Capability>
+    <Layer>
+      <Title>Mock Layers</Title>
+      <Layer queryable="1"><Name>mock_ortho</Name><Title>Orthoimage 2023</Title></Layer>
+      <Layer queryable="1"><Name>mock_landcover</Name><Title>Land Cover</Title></Layer>
+      <Layer queryable="1"><Name>mock_buildings</Name><Title>Buildings</Title></Layer>
+    </Layer>
+  </Capability>
+</WMS_Capabilities>`
+
+// Minimal layer group hierarchy for BackgroundMapBrowser.vue
+export const HSY_LAYER_GROUPS = [
+	{
+		id: 1,
+		name: 'Background Maps',
+		layers: [
+			{ id: 101, name: 'mock_ortho', title: 'Orthoimage 2023', visible: true },
+			{ id: 102, name: 'mock_landcover', title: 'Land Cover', visible: false },
+		],
+	},
+]
+
+// Single postal code feature for socioEconomicsStore.js
+export const PAAVO_DATA = {
+	type: 'FeatureCollection',
+	features: [
+		{
+			type: 'Feature',
+			geometry: {
+				type: 'Polygon',
+				coordinates: [
+					[
+						[24.93, 60.17],
+						[24.95, 60.17],
+						[24.95, 60.19],
+						[24.93, 60.19],
+						[24.93, 60.17],
+					],
+				],
+			},
+			properties: {
+				postinumeroalue: '00100',
+				nimi: 'Helsinki keskusta - Etu-Töölö',
+				he_vakiy: 10000,
+				hr_mtu: 35000,
+				te_takiy: 5000,
+				pt_vakiy: 10000,
+			},
+		},
+	],
+}
+
+// Default empty GeoJSON response
+export const EMPTY_FEATURE_COLLECTION = {
+	type: 'FeatureCollection',
+	features: [],
+}
+
+// Empty sensor data response for bri3.fvh.io
+export const EMPTY_SENSOR_DATA = {
+	results: [],
+}

--- a/tests/setup/api-mocks/index.ts
+++ b/tests/setup/api-mocks/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Global API mock orchestrator for E2E tests.
+ *
+ * Registers route handlers for all external APIs before each test,
+ * making the full test suite offline-capable by default.
+ */
+import type { Page } from '@playwright/test'
+import { setupDataApiMocks } from './data-api-mocks'
+import { setupDigitransitMocks } from './digitransit-mock'
+import { setupWmsMocks } from './wms-mocks'
+
+export async function setupAllApiMocks(page: Page): Promise<void> {
+	await Promise.all([setupWmsMocks(page), setupDataApiMocks(page), setupDigitransitMocks(page)])
+}

--- a/tests/setup/api-mocks/wms-mocks.ts
+++ b/tests/setup/api-mocks/wms-mocks.ts
@@ -1,0 +1,81 @@
+/**
+ * WMS route handlers for E2E test mocking.
+ *
+ * Intercepts all WMS-related requests and returns minimal valid responses
+ * so tests run offline without depending on kartta.hsy.fi, kartta.hel.fi,
+ * or paikkatiedot.ymparisto.fi.
+ */
+import type { Page } from '@playwright/test'
+import {
+	EMPTY_FEATURE_COLLECTION,
+	HSY_LAYER_GROUPS,
+	TRANSPARENT_PNG,
+	WMS_CAPABILITIES_XML,
+} from './fixtures'
+
+export async function setupWmsMocks(page: Page): Promise<void> {
+	await Promise.all([
+		// WMS proxy tiles (landcover.js, floodwms.js)
+		page.route('**/wms/proxy*', (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'image/png',
+				body: TRANSPARENT_PNG,
+			})
+		),
+
+		// WMS GetCapabilities (HSYWMS.vue)
+		page.route('**/wms/layers*', (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'application/xml',
+				body: WMS_CAPABILITIES_XML,
+			})
+		),
+
+		// HSY layer groups (BackgroundMapBrowser.vue)
+		page.route('**/hsy-action*', (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify(HSY_LAYER_GROUPS),
+			})
+		),
+
+		// Helsinki WMS tiles (wms.js)
+		page.route('**/helsinki-wms*', (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'image/png',
+				body: TRANSPARENT_PNG,
+			})
+		),
+
+		// Direct Cesium ImageryProvider requests to HSY
+		page.route('**/kartta.hsy.fi/**', (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'image/png',
+				body: TRANSPARENT_PNG,
+			})
+		),
+
+		// Direct WFS requests to Helsinki
+		page.route('**/kartta.hel.fi/**', (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify(EMPTY_FEATURE_COLLECTION),
+			})
+		),
+
+		// SYKE flood WMS
+		page.route('**/paikkatiedot.ymparisto.fi/**', (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'image/png',
+				body: TRANSPARENT_PNG,
+			})
+		),
+	])
+}


### PR DESCRIPTION
## Summary

- Add `tests/fixtures/test-fixture.ts` as base test with automatic API mocking for all external services (WMS, data APIs, digitransit)
- Add modular `tests/setup/api-mocks/` replacing the old per-file `setupDigitransitMock()` pattern
- Update all E2E specs to import `test` from the new fixture, making tests offline-capable by default

## Test plan

- [ ] Run `just test-e2e` to verify all E2E tests still pass with centralized mocking
- [ ] Verify mock opt-out works: `test.use({ mockAPIs: false })`
- [ ] Verify per-test override works: `await page.unroute(); await page.route()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)