### PR TITLE
fix(test): update unit tests for postalCodeIndex and navigation changes

### DIFF
--- a/tests/unit/services/featurepicker.test.js
+++ b/tests/unit/services/featurepicker.test.js
@@ -36,6 +36,7 @@ vi.mock('@/services/building.js', () => ({
 	default: vi.fn(function () {
 		this.createBuildingCharts = vi.fn()
 		this.resetBuildingOutline = vi.fn()
+		this.cancelCurrentLoad = vi.fn()
 	}),
 }))
 

--- a/tests/unit/stores/globalStore.test.js
+++ b/tests/unit/stores/globalStore.test.js
@@ -183,6 +183,7 @@ describe('globalStore', () => {
 				retryCount: 0,
 				previousViewState: null,
 				loadingProgress: null,
+				pendingNavigation: null,
 			})
 		})
 
@@ -255,6 +256,7 @@ describe('globalStore', () => {
 				retryCount: 0,
 				previousViewState: null,
 				loadingProgress: null,
+				pendingNavigation: null,
 			})
 		})
 

--- a/tests/unit/stores/toggleStore.test.js
+++ b/tests/unit/stores/toggleStore.test.js
@@ -39,7 +39,7 @@ describe('toggleStore', () => {
 			const store = useToggleStore()
 			const stateKeys = Object.keys(store.$state)
 
-			expect(stateKeys).toHaveLength(22)
+			expect(stateKeys).toHaveLength(23)
 		})
 	})
 

--- a/tests/unit/utils/moduleLoader.test.js
+++ b/tests/unit/utils/moduleLoader.test.js
@@ -40,11 +40,17 @@ describe('moduleLoader', () => {
 		})
 
 		it('should use exponential backoff between retries', async () => {
+			const error = new Error('Failed to fetch dynamically imported module')
 			const mockImport = vi
 				.fn()
-				.mockRejectedValue(new Error('Failed to fetch dynamically imported module'))
+				.mockRejectedValueOnce(error)
+				.mockRejectedValueOnce(error)
+				.mockRejectedValueOnce(error)
+				.mockRejectedValueOnce(error)
 
 			const importPromise = loadWithRetry(mockImport, 3)
+			// Attach catch immediately to prevent unhandled rejection during timer advancement
+			importPromise.catch(() => {})
 
 			// Initial attempt happens synchronously
 			expect(mockImport).toHaveBeenCalledTimes(1)
@@ -66,11 +72,17 @@ describe('moduleLoader', () => {
 		})
 
 		it('should throw error after max retries exceeded', async () => {
+			const error = new Error('Failed to fetch dynamically imported module')
 			const mockImport = vi
 				.fn()
-				.mockRejectedValue(new Error('Failed to fetch dynamically imported module'))
+				.mockRejectedValueOnce(error)
+				.mockRejectedValueOnce(error)
+				.mockRejectedValueOnce(error)
+				.mockRejectedValueOnce(error)
 
 			const importPromise = loadWithRetry(mockImport, 3)
+			// Attach catch immediately to prevent unhandled rejection during timer advancement
+			importPromise.catch(() => {})
 
 			// Advance through all retry delays
 			await vi.advanceTimersByTimeAsync(1000) // First retry
@@ -101,11 +113,16 @@ describe('moduleLoader', () => {
 		})
 
 		it('should accept custom retry count', async () => {
+			const error = new Error('Failed to fetch dynamically imported module')
 			const mockImport = vi
 				.fn()
-				.mockRejectedValue(new Error('Failed to fetch dynamically imported module'))
+				.mockRejectedValueOnce(error)
+				.mockRejectedValueOnce(error)
+				.mockRejectedValueOnce(error)
 
 			const importPromise = loadWithRetry(mockImport, 2)
+			// Attach catch immediately to prevent unhandled rejection during timer advancement
+			importPromise.catch(() => {})
 
 			await vi.advanceTimersByTimeAsync(1000) // First retry
 			await vi.advanceTimersByTimeAsync(2000) // Second retry (final)
@@ -154,11 +171,17 @@ describe('moduleLoader', () => {
 		})
 
 		it('should default to 3 retries when not specified', async () => {
+			const error = new Error('Failed to fetch dynamically imported module')
 			const mockImport = vi
 				.fn()
-				.mockRejectedValue(new Error('Failed to fetch dynamically imported module'))
+				.mockRejectedValueOnce(error)
+				.mockRejectedValueOnce(error)
+				.mockRejectedValueOnce(error)
+				.mockRejectedValueOnce(error)
 
 			const importPromise = loadWithRetry(mockImport) // No retry count specified
+			// Attach catch immediately to prevent unhandled rejection during timer advancement
+			importPromise.catch(() => {})
 
 			await vi.advanceTimersByTimeAsync(1000) // First retry
 			await vi.advanceTimersByTimeAsync(2000) // Second retry


### PR DESCRIPTION
## Summary

- Camera tests: mock `postalCodeIndex` instead of traversing dataSources arrays
- PostalCodeLoader tests: mock `postalCodeIndex`, handle async `setNameOfZone`
- ModuleLoader tests: fix unhandled promise rejections by attaching `.catch()` before timer advancement
- GlobalStore/ToggleStore tests: align state assertions with `pendingNavigation` and `_previousGrid250m` additions

Closes #598

## Test plan

- [ ] Run `just test-unit` to verify all unit tests pass
- [ ] Confirm no unhandled promise rejection warnings in moduleLoader tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)