### PR TITLE
perf: lazy-load Cesium, services, and heavy components

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://cdn.jsdelivr.net/npm/@mdi/font@7.4.47/css/materialdesignicons.min.css" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover" />
     <meta name="theme-color" content="#1976d2" />

--- a/src/components/BuildingInformation.vue
+++ b/src/components/BuildingInformation.vue
@@ -83,9 +83,9 @@
  * - Cesium: Scene picking and screen space events
  */
 
-import { Cartesian2, ScreenSpaceEventType } from 'cesium'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { findAddressForBuilding } from '../services/address.js'
+import { getCesium } from '../services/cesiumProvider.js'
 import { useBuildingStore } from '../stores/buildingStore.js'
 import { useGlobalStore } from '../stores/globalStore.js'
 import { useURLStore } from '../stores/urlStore.js'
@@ -315,7 +315,10 @@ export default {
 				mousePosition.value = { x: endPosition.x, y: endPosition.y }
 
 				if (buildingStore.buildingFeatures && viewer) {
-					const pickedEntity = viewer.scene.pick(new Cartesian2(endPosition.x, endPosition.y))
+					const Cesium = getCesium()
+					const pickedEntity = viewer.scene.pick(
+						new Cesium.Cartesian2(endPosition.x, endPosition.y)
+					)
 
 					if (pickedEntity?.id) {
 						void fetchBuildingInfo(pickedEntity.id)
@@ -342,7 +345,11 @@ export default {
 				return
 			}
 
-			viewer.screenSpaceEventHandler.setInputAction(onMouseMove, ScreenSpaceEventType.MOUSE_MOVE)
+			const Cesium = getCesium()
+			viewer.screenSpaceEventHandler.setInputAction(
+				onMouseMove,
+				Cesium.ScreenSpaceEventType.MOUSE_MOVE
+			)
 			handlerRegistered.value = true
 			logger.debug('[BuildingInformation] ✅ MOUSE_MOVE handler registered successfully')
 		}
@@ -357,7 +364,8 @@ export default {
 				return
 			}
 
-			viewer.screenSpaceEventHandler.removeInputAction(ScreenSpaceEventType.MOUSE_MOVE)
+			const Cesium = getCesium()
+			viewer.screenSpaceEventHandler.removeInputAction(Cesium.ScreenSpaceEventType.MOUSE_MOVE)
 			handlerRegistered.value = false
 			logger.debug('[BuildingInformation] 🗑️ MOUSE_MOVE handler unregistered')
 		}

--- a/src/pages/CesiumViewer.vue
+++ b/src/pages/CesiumViewer.vue
@@ -132,8 +132,7 @@
  * - cacheWarmer: Background data preloading
  * - ViewportBuildingLoader: Tile-based viewport building streaming
  */
-import { computed, onMounted, ref } from 'vue'
-import BuildingInformation from '../components/BuildingInformation.vue'
+import { computed, defineAsyncComponent, onMounted, ref } from 'vue'
 import CameraControls from '../components/CameraControls.vue'
 import DisclaimerPopup from '../components/DisclaimerPopup.vue'
 import Loading from '../components/Loading.vue'
@@ -152,6 +151,10 @@ import { useFeatureFlagStore } from '../stores/featureFlagStore'
 import { useGlobalStore } from '../stores/globalStore.js'
 import { useToggleStore } from '../stores/toggleStore.js'
 import logger from '../utils/logger.js'
+
+const BuildingInformation = defineAsyncComponent(
+	() => import('../components/BuildingInformation.vue')
+)
 
 export default {
 	components: {


### PR DESCRIPTION
## Summary
- Replace static cesium import in BuildingInformation.vue with `getCesium()` pattern, preventing Vite from modulepreloading the ~4MB Cesium library before first paint
- Convert service imports (Building, Camera, Featurepicker, Tree, backgroundPreloader) to dynamic `import()` in App.vue and ControlPanel.vue — only loaded on user interaction
- Lazy-load ControlPanel (131 kB) and BuildingInformation with `defineAsyncComponent`
- Convert ControlPanel dialog sub-components from static to async imports
- Add `<link rel="preconnect">` for MDI font CDN

## Context
Lighthouse reports a performance score of 26/100 with 9.5s of main-thread script evaluation. The root cause was a static cesium import in BuildingInformation.vue that defeated the existing lazy-loading architecture in cesiumProvider.js, plus eagerly-loaded services and components that aren't needed for initial render.

## Test plan
- [ ] `bun run build` passes — verify cesium chunk is not in `<link rel="modulepreload">` in dist/index.html
- [ ] `bun run dev` smoke test — navigate start → postal code → building → back
- [ ] Building tooltip (hover) still works at building level
- [ ] Control panel opens/closes, analysis dialogs work
- [ ] Camera rotation, return-to-postal-code buttons work
- [ ] `bun run lint` passes clean
- [ ] Run Lighthouse on preview build — expect significant FCP/TBT improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)