### PR TITLE
feat: sidebar UX improvements

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -22,6 +22,16 @@
 				</v-btn>
 
 				<v-btn
+					v-if="currentLevel !== 'start'"
+					icon
+					variant="text"
+					aria-label="Reset to start view"
+					@click="smartReset"
+				>
+					<v-icon>mdi-home</v-icon>
+				</v-btn>
+
+				<v-btn
 					icon
 					variant="text"
 					aria-label="Sign out"
@@ -68,6 +78,12 @@
 						@click="returnToPostalCode"
 					/>
 					<v-list-item
+						v-if="currentLevel !== 'start'"
+						prepend-icon="mdi-home"
+						title="Reset to start"
+						@click="smartReset"
+					/>
+					<v-list-item
 						prepend-icon="mdi-logout"
 						title="Sign out"
 						@click="signOut"
@@ -102,17 +118,25 @@
 			<v-spacer />
 
 			<!-- Right section: Controls button -->
-			<v-btn
-				variant="outlined"
-				aria-label="Toggle control panel"
-				prepend-icon="mdi-tune"
-				class="mr-2 mr-sm-4"
-				size="small"
-				@click="sidebarVisible = !sidebarVisible"
+			<v-badge
+				:model-value="!sidebarVisible && activeLayerCount > 0"
+				:content="activeLayerCount"
+				color="primary"
+				offset-x="-4"
+				offset-y="-4"
 			>
-				<span class="d-none d-sm-inline">{{ sidebarVisible ? 'Hide' : 'Show' }} Controls</span>
-				<span class="d-inline d-sm-none">{{ sidebarVisible ? 'Hide' : '' }}</span>
-			</v-btn>
+				<v-btn
+					variant="outlined"
+					aria-label="Toggle control panel"
+					prepend-icon="mdi-tune"
+					class="mr-2 mr-sm-4"
+					size="small"
+					@click="sidebarVisible = !sidebarVisible"
+				>
+					<span class="d-none d-sm-inline">{{ sidebarVisible ? 'Hide' : 'Show' }} Controls</span>
+					<span class="d-inline d-sm-none">{{ sidebarVisible ? 'Hide' : '' }}</span>
+				</v-btn>
+			</v-badge>
 		</v-app-bar>
 
 		<!-- Enhanced Control Panel -->
@@ -135,8 +159,8 @@
 			</div>
 		</v-main>
 
-		<!-- Heat Timeline Overlay - shown when buildings are loaded (postalCode or building level) -->
-		<Timeline v-if="currentLevel === 'postalCode' || currentLevel === 'building'" />
+		<!-- Heat Timeline Overlay - disabled; compact timeline in app bar is sufficient -->
+		<!-- <Timeline v-if="currentLevel === 'postalCode' || currentLevel === 'building'" /> -->
 	</v-app>
 </template>
 
@@ -145,7 +169,7 @@ import { computed, defineAsyncComponent, onMounted, ref } from 'vue'
 
 // Lazy-loaded components (only shown at non-start navigation levels)
 const TimelineCompact = defineAsyncComponent(() => import('./components/TimelineCompact.vue'))
-const Timeline = defineAsyncComponent(() => import('./components/Timeline.vue'))
+// const Timeline = defineAsyncComponent(() => import('./components/Timeline.vue'))
 const SosEco250mGrid = defineAsyncComponent(() => import('./components/SosEco250mGrid.vue'))
 const ControlPanel = defineAsyncComponent(() => import('./pages/ControlPanel.vue'))
 
@@ -166,6 +190,7 @@ const userStore = useUserStore()
 
 const grid250m = computed(() => toggleStore.grid250m)
 const currentLevel = computed(() => globalStore.level)
+const activeLayerCount = computed(() => toggleStore.activeLayerCount)
 
 // UI state - use feature flag to determine default sidebar visibility
 const sidebarVisible = ref(featureFlagStore.isEnabled('controlPanelDefault'))

--- a/src/components/MapControls.vue
+++ b/src/components/MapControls.vue
@@ -15,6 +15,7 @@
 			@update:show-other-nature="loadOtherNature"
 			@update:land-cover="addLandCover"
 			@update:ndvi="toggleNDVI"
+			@reset:layers="resetLayers"
 		/>
 
 		<!-- Building Filters -->
@@ -27,6 +28,7 @@
 			@update:hide-non-sote="filterBuildings"
 			@update:hide-new-buildings="filterBuildings"
 			@update:hide-low="filterBuildings"
+			@reset:filters="resetFilters"
 		/>
 
 		<!-- Layer Conflict Warning -->
@@ -417,6 +419,29 @@ const filterBuildings = () => {
 		}
 		eventBus.emit('updateScatterPlot')
 	}
+}
+
+/**
+ * Resets all data layers to off and cleans up loaded data
+ *
+ * @returns {void}
+ */
+const resetLayers = () => {
+	showTrees.value = false
+	showVegetation.value = false
+	showOtherNature.value = false
+	landCover.value = false
+	ndvi.value = false
+	toggleStore.resetLayers()
+
+	// Clean up loaded layers
+	if (dataSourceService) {
+		dataSourceService.changeDataSourceShowByName('Trees', false)
+		dataSourceService.changeDataSourceShowByName('Vegetation', false)
+		dataSourceService.changeDataSourceShowByName('OtherNature', false)
+	}
+	removeLandcover()
+	removeTIFF().catch(logger.error)
 }
 
 /**

--- a/src/components/controls/BuildingFiltersControl.vue
+++ b/src/components/controls/BuildingFiltersControl.vue
@@ -3,11 +3,24 @@
 		v-if="view !== 'grid'"
 		class="control-group"
 	>
-		<h4 class="control-group-title">Building Filters</h4>
+		<h4 class="control-group-title">
+			Building Filters
+			<v-btn
+				v-if="hideNonSote || hideNewBuildings || hideLow"
+				icon
+				size="x-small"
+				variant="text"
+				aria-label="Reset all building filters"
+				class="ml-auto"
+				@click="$emit('reset:filters')"
+			>
+				<v-icon size="16">mdi-filter-remove</v-icon>
+			</v-btn>
+		</h4>
 
 		<!-- Public/Social Buildings Filter -->
 		<v-tooltip
-			location="left"
+			location="right"
 			max-width="200"
 		>
 			<template #activator="{ props }">
@@ -39,7 +52,7 @@
 		<!-- Building Age Filter (Helsinki only) -->
 		<v-tooltip
 			v-if="helsinkiView"
-			location="left"
+			location="right"
 			max-width="200"
 		>
 			<template #activator="{ props }">
@@ -62,7 +75,7 @@
 
 		<!-- Building Height Filter -->
 		<v-tooltip
-			location="left"
+			location="right"
 			max-width="200"
 		>
 			<template #activator="{ props }">
@@ -140,7 +153,12 @@ defineProps({
 	},
 })
 
-defineEmits(['update:hide-non-sote', 'update:hide-new-buildings', 'update:hide-low'])
+defineEmits([
+	'update:hide-non-sote',
+	'update:hide-new-buildings',
+	'update:hide-low',
+	'reset:filters',
+])
 </script>
 
 <style scoped>
@@ -158,6 +176,8 @@ defineEmits(['update:hide-non-sote', 'update:hide-new-buildings', 'update:hide-l
 	color: rgba(0, 0, 0, 0.87);
 	background-color: rgba(0, 0, 0, 0.02);
 	border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+	display: flex;
+	align-items: center;
 }
 
 .control-item {

--- a/src/components/controls/DataLayersControl.vue
+++ b/src/components/controls/DataLayersControl.vue
@@ -1,11 +1,24 @@
 <template>
 	<div class="control-group">
-		<h4 class="control-group-title">Data Layers</h4>
+		<h4 class="control-group-title">
+			Data Layers
+			<v-btn
+				v-if="hasActiveLayers"
+				icon
+				size="x-small"
+				variant="text"
+				aria-label="Reset all data layers"
+				class="ml-auto"
+				@click="$emit('reset:layers')"
+			>
+				<v-icon size="16">mdi-layers-off</v-icon>
+			</v-btn>
+		</h4>
 
 		<!-- Trees -->
 		<v-tooltip
 			v-if="view !== 'grid' && postalCode && featureFlagStore.isEnabled('treeCoverage')"
-			location="left"
+			location="right"
 			max-width="200"
 		>
 			<template #activator="{ props }">
@@ -49,7 +62,7 @@
 		<!-- Vegetation (Helsinki only) -->
 		<v-tooltip
 			v-if="helsinkiView"
-			location="left"
+			location="right"
 			max-width="200"
 		>
 			<template #activator="{ props }">
@@ -83,7 +96,7 @@
 		<!-- Other Nature (Helsinki only) -->
 		<v-tooltip
 			v-if="helsinkiView"
-			location="left"
+			location="right"
 			max-width="200"
 		>
 			<template #activator="{ props }">
@@ -107,7 +120,7 @@
 		<!-- HSY Land Cover -->
 		<v-tooltip
 			v-if="!helsinkiView && featureFlagStore.isEnabled('landCover')"
-			location="left"
+			location="right"
 			max-width="200"
 		>
 			<template #activator="{ props }">
@@ -131,7 +144,7 @@
 		<!-- NDVI -->
 		<v-tooltip
 			v-if="featureFlagStore.isEnabled('ndvi')"
-			location="left"
+			location="right"
 			max-width="200"
 		>
 			<template #activator="{ props }">
@@ -192,12 +205,13 @@
  * />
  */
 
+import { computed } from 'vue'
 import { useFeatureFlagStore } from '../../stores/featureFlagStore'
 import { useLoadingStore } from '../../stores/loadingStore.js'
 
 const featureFlagStore = useFeatureFlagStore()
 
-defineProps({
+const props = defineProps({
 	showTrees: {
 		type: Boolean,
 		required: true,
@@ -238,7 +252,17 @@ defineEmits([
 	'update:showOtherNature',
 	'update:landCover',
 	'update:ndvi',
+	'reset:layers',
 ])
+
+const hasActiveLayers = computed(
+	() =>
+		props.showTrees ||
+		props.showVegetation ||
+		props.showOtherNature ||
+		props.landCover ||
+		props.ndvi
+)
 
 const loadingStore = useLoadingStore()
 </script>
@@ -258,6 +282,8 @@ const loadingStore = useLoadingStore()
 	color: rgba(0, 0, 0, 0.87);
 	background-color: rgba(0, 0, 0, 0.02);
 	border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+	display: flex;
+	align-items: center;
 }
 
 .control-item {

--- a/src/pages/ControlPanel.vue
+++ b/src/pages/ControlPanel.vue
@@ -5,29 +5,48 @@
 		role="navigation"
 		aria-label="Analysis tools and data exploration"
 		class="analysis-sidebar"
-		width="350"
-		location="right"
+		:width="drawerWidth"
+		location="left"
 		@update:model-value="$emit('update:modelValue', $event)"
 	>
 		<div class="sidebar-content">
-			<div class="control-section">
-				<h3 class="section-subtitle">
-					<v-icon class="mr-2"> mdi-magnify </v-icon>Search & Navigate
-				</h3>
-				<p class="search-description">Find locations by address, postal code, or area name</p>
-				<UnifiedSearch />
-			</div>
-			<div class="control-section">
-				<h3 class="section-subtitle"><v-icon class="mr-2"> mdi-layers </v-icon>Map Controls</h3>
-				<p class="search-description">Toggle data layers and apply filters</p>
-				<MapControls />
-			</div>
-			<div class="control-section">
-				<h3 class="section-subtitle">
-					<v-icon class="mr-2"> mdi-map-outline </v-icon>Background Maps
-				</h3>
-				<BackgroundMapBrowser />
-			</div>
+			<v-expansion-panels
+				v-model="openPanels"
+				multiple
+				variant="accordion"
+			>
+				<v-expansion-panel value="search">
+					<v-expansion-panel-title>
+						<v-icon class="mr-2">mdi-magnify</v-icon>
+						Search & Navigate
+					</v-expansion-panel-title>
+					<v-expansion-panel-text>
+						<p class="search-description">Find locations by address, postal code, or area name</p>
+						<UnifiedSearch />
+					</v-expansion-panel-text>
+				</v-expansion-panel>
+
+				<v-expansion-panel value="mapControls">
+					<v-expansion-panel-title>
+						<v-icon class="mr-2">mdi-layers</v-icon>
+						Map Controls
+					</v-expansion-panel-title>
+					<v-expansion-panel-text>
+						<p class="search-description">Toggle data layers and apply filters</p>
+						<MapControls />
+					</v-expansion-panel-text>
+				</v-expansion-panel>
+
+				<v-expansion-panel value="backgroundMaps">
+					<v-expansion-panel-title>
+						<v-icon class="mr-2">mdi-map-outline</v-icon>
+						Background Maps
+					</v-expansion-panel-title>
+					<v-expansion-panel-text>
+						<BackgroundMapBrowser />
+					</v-expansion-panel-text>
+				</v-expansion-panel>
+			</v-expansion-panels>
 
 			<div class="control-section">
 				<h3 class="section-subtitle">
@@ -292,6 +311,7 @@
 
 import { storeToRefs } from 'pinia'
 import { computed, defineAsyncComponent, ref } from 'vue'
+import { useDisplay } from 'vuetify'
 import AreaProperties from '../components/AreaProperties.vue'
 import BackgroundMapBrowser from '../components/BackgroundMapBrowser.vue'
 import MapControls from '../components/MapControls.vue'
@@ -360,6 +380,17 @@ export default {
 	},
 	emits: ['update:modelValue'],
 	setup() {
+		const { smAndDown, mdAndDown } = useDisplay()
+
+		const drawerWidth = computed(() => {
+			if (smAndDown.value) return Math.min(window.innerWidth * 0.9, 320)
+			if (mdAndDown.value) return Math.min(window.innerWidth * 0.4, 350)
+			return 350
+		})
+
+		// Default-open sections: Search and Map Controls
+		const openPanels = ref(['search', 'mapControls'])
+
 		// ## NEW: State for the new panel ##
 		const adaptationTab = ref('centers')
 
@@ -582,6 +613,8 @@ export default {
 			// ## NEW: Return the new state variable ##
 			adaptationTab,
 			featureFlagStore,
+			drawerWidth,
+			openPanels,
 		}
 	},
 }
@@ -618,6 +651,18 @@ export default {
 	font-weight: 500;
 	margin-bottom: 8px;
 	color: rgba(0, 0, 0, 0.7);
+}
+
+/* Expansion panels inside sidebar */
+.sidebar-content :deep(.v-expansion-panel-title) {
+	font-size: 1rem;
+	font-weight: 600;
+	min-height: 48px;
+	padding: 12px 16px;
+}
+
+.sidebar-content :deep(.v-expansion-panel-text__wrapper) {
+	padding: 8px 16px 16px;
 }
 .analysis-buttons {
 	display: flex;

--- a/src/stores/toggleStore.js
+++ b/src/stores/toggleStore.js
@@ -69,6 +69,24 @@ export const useToggleStore = defineStore('toggle', {
 		// Internal state for visibility coordination
 		_previousGrid250m: false, // Tracks grid state before entering postal code
 	}),
+	getters: {
+		/**
+		 * Count of active data layers and building filters
+		 * @returns {number}
+		 */
+		activeLayerCount(state) {
+			let count = 0
+			if (state.showTrees) count++
+			if (state.showVegetation) count++
+			if (state.showOtherNature) count++
+			if (state.landCover) count++
+			if (state.ndvi) count++
+			if (state.hideNewBuildings) count++
+			if (state.hideNonSote) count++
+			if (state.hideLow) count++
+			return count
+		},
+	},
 	actions: {
 		/**
 		 * Toggle NDVI vegetation index imagery visibility
@@ -232,6 +250,28 @@ export const useToggleStore = defineStore('toggle', {
 		 */
 		reset() {
 			this.$reset() // Pinia has a built-in $reset function which resets state to initial values
+		},
+
+		/**
+		 * Resets data layer toggles to their default (off) state
+		 * @returns {void}
+		 */
+		resetLayers() {
+			this.showTrees = false
+			this.showVegetation = false
+			this.showOtherNature = false
+			this.landCover = false
+			this.ndvi = false
+		},
+
+		/**
+		 * Resets building filter toggles to their default (off) state
+		 * @returns {void}
+		 */
+		resetBuildingFilters() {
+			this.hideNewBuildings = false
+			this.hideNonSote = false
+			this.hideLow = false
 		},
 
 		// ============================================================


### PR DESCRIPTION
## Summary

- Move sidebar from right to left side (standard mapping app convention)
- Add active layer/filter count badge on Controls button when sidebar is closed
- Add reset buttons for data layers (`mdi-layers-off`) and building filters (`mdi-filter-remove`) in section headers
- Add home button (`mdi-home`) in app bar and mobile menu for quick navigation reset via `smartReset()`
- Wrap Search, Map Controls, and Background Maps in collapsible `v-expansion-panels` (Search + Map Controls default-open, Background Maps collapsed)
- Add responsive drawer width using `useDisplay()` (90vw/320px on mobile, 40vw/350px on tablet, 350px on desktop)
- Hide redundant bottom-left Timeline overlay (compact timeline in app bar is sufficient)
- Flip tooltip directions from left to right to match new sidebar placement
- Add `activeLayerCount` getter and `resetLayers()`/`resetBuildingFilters()` actions to toggleStore

## Test plan

- [ ] Verify sidebar opens on the left side and doesn't overlap Cesium camera controls
- [ ] Toggle layers → close sidebar → confirm badge shows correct count → reopen → reset clears all
- [ ] Test reset buttons in Data Layers and Building Filters section headers
- [ ] Test home button returns to start view from postal code and building levels
- [ ] Test collapsible sections open/close correctly, Background Maps starts collapsed
- [ ] Test responsive width at 375px, 768px, 1024px, 1440px viewports
- [ ] Run `bunx playwright test --grep @accessibility` to verify ARIA attributes preserved
- [ ] Confirm bottom-left timeline overlay no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)