### PR TITLE
fix(ci): correct Bash tool patterns in Claude workflow permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -60,4 +60,4 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "Bash(gh issue view *),Bash(gh search *),Bash(gh issue list *),Bash(gh pr comment *),Bash(gh pr diff *),Bash(gh pr view *),Bash(gh pr list *)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,4 +57,4 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(npm test:*),Bash(npx playwright:*),Bash(git:*),Bash(gh pr:*),Bash(gh issue:*)"'
+          claude_args: '--allowed-tools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(npm run test:*),Bash(bun run test:*),Bash(bun run build*),Bash(bun run lint*),Bash(npx playwright *),Bash(git *),Bash(gh pr *),Bash(gh issue *),Bash(gh api *)"'


### PR DESCRIPTION
The allowed-tools patterns used colons (e.g., `Bash(git:*)`) where spaces
are needed (`Bash(git *)`). The colon-based patterns match literal `git:`
prefixes, which never occur in actual commands like `git push` or
`gh pr create`, effectively blocking all git and gh CLI operations.

Also adds bun run, gh api patterns and fixes npm test pattern to match
actual `npm run test:*` invocation.

https://claude.ai/code/session_01AEjGUrkihqvRseiETkhmXb