### PR TITLE
fix(test): enhance WMS mock coverage with fallback handler

### DIFF
--- a/tests/setup/api-mocks/index.ts
+++ b/tests/setup/api-mocks/index.ts
@@ -10,5 +10,12 @@ import { setupDigitransitMocks } from './digitransit-mock'
 import { setupWmsMocks } from './wms-mocks'
 
 export async function setupAllApiMocks(page: Page): Promise<void> {
-	await Promise.all([setupWmsMocks(page), setupDataApiMocks(page), setupDigitransitMocks(page)])
+	// Enable WMS diagnostic logging in CI to help debug unmocked requests
+	const enableWmsLogging = process.env.CI === 'true' || process.env.DEBUG_WMS === 'true'
+
+	await Promise.all([
+		setupWmsMocks(page, { enableLogging: enableWmsLogging }),
+		setupDataApiMocks(page),
+		setupDigitransitMocks(page),
+	])
 }

--- a/tests/setup/api-mocks/wms-mocks.ts
+++ b/tests/setup/api-mocks/wms-mocks.ts
@@ -4,6 +4,10 @@
  * Intercepts all WMS-related requests and returns minimal valid responses
  * so tests run offline without depending on kartta.hsy.fi, kartta.hel.fi,
  * or paikkatiedot.ymparisto.fi.
+ *
+ * Route order matters: More specific patterns before generic fallbacks.
+ * All routes are registered via Promise.all() to prevent race conditions
+ * where tiles load before mocks are ready.
  */
 import type { Page } from '@playwright/test'
 import {
@@ -13,23 +17,37 @@ import {
 	WMS_CAPABILITIES_XML,
 } from './fixtures'
 
-export async function setupWmsMocks(page: Page): Promise<void> {
+/**
+ * Sets up WMS mocks with comprehensive coverage for all tile request patterns.
+ * Implements a fallback handler to catch any unmocked WMS/tile requests.
+ *
+ * @param page - Playwright page instance
+ * @param options - Configuration options
+ * @param options.enableLogging - Enable diagnostic logging for unmocked requests
+ */
+export async function setupWmsMocks(
+	page: Page,
+	options: { enableLogging?: boolean } = {}
+): Promise<void> {
+	const { enableLogging = false } = options
+
+	// Register all routes in parallel to prevent race conditions
 	await Promise.all([
+		// WMS GetCapabilities (HSYWMS.vue) - must come before proxy
+		page.route('**/wms/layers*', (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'application/xml',
+				body: WMS_CAPABILITIES_XML,
+			})
+		),
+
 		// WMS proxy tiles (landcover.js, floodwms.js)
 		page.route('**/wms/proxy*', (route) =>
 			route.fulfill({
 				status: 200,
 				contentType: 'image/png',
 				body: TRANSPARENT_PNG,
-			})
-		),
-
-		// WMS GetCapabilities (HSYWMS.vue)
-		page.route('**/wms/layers*', (route) =>
-			route.fulfill({
-				status: 200,
-				contentType: 'application/xml',
-				body: WMS_CAPABILITIES_XML,
 			})
 		),
 
@@ -42,7 +60,7 @@ export async function setupWmsMocks(page: Page): Promise<void> {
 			})
 		),
 
-		// Helsinki WMS tiles (wms.js)
+		// Helsinki WMS tiles (wms.js) - primary tile endpoint
 		page.route('**/helsinki-wms*', (route) =>
 			route.fulfill({
 				status: 200,
@@ -61,13 +79,23 @@ export async function setupWmsMocks(page: Page): Promise<void> {
 		),
 
 		// Direct WFS requests to Helsinki
-		page.route('**/kartta.hel.fi/**', (route) =>
-			route.fulfill({
+		page.route('**/kartta.hel.fi/**', (route) => {
+			const url = route.request().url()
+			// WMS tile requests (image/png)
+			if (url.includes('REQUEST=GetMap') || url.includes('FORMAT=image/png')) {
+				return route.fulfill({
+					status: 200,
+					contentType: 'image/png',
+					body: TRANSPARENT_PNG,
+				})
+			}
+			// WFS feature requests (GeoJSON)
+			return route.fulfill({
 				status: 200,
 				contentType: 'application/json',
 				body: JSON.stringify(EMPTY_FEATURE_COLLECTION),
 			})
-		),
+		}),
 
 		// SYKE flood WMS
 		page.route('**/paikkatiedot.ymparisto.fi/**', (route) =>
@@ -77,5 +105,31 @@ export async function setupWmsMocks(page: Page): Promise<void> {
 				body: TRANSPARENT_PNG,
 			})
 		),
+
+		// Fallback: Catch any unmocked tile/imagery requests
+		// This prevents test failures from unmocked patterns
+		page.route('**/*', (route) => {
+			const url = route.request().url()
+			const isTileRequest =
+				url.includes('tile') ||
+				url.includes('wms') ||
+				url.includes('imagery') ||
+				url.includes('GetMap') ||
+				url.includes('FORMAT=image/png')
+
+			if (isTileRequest) {
+				if (enableLogging) {
+					console.warn(`[WMS Mock] Fallback handler caught: ${url.substring(0, 100)}...`)
+				}
+				return route.fulfill({
+					status: 200,
+					contentType: 'image/png',
+					body: TRANSPARENT_PNG,
+				})
+			}
+
+			// Let non-tile requests pass through to other mocks
+			return route.continue()
+		}),
 	])
 }


### PR DESCRIPTION
## Summary

Adds comprehensive fallback handler to catch all unmocked WMS/tile requests, preventing the 8 tile failures reported in chromium/firefox tests.

## Changes

- Add fallback route pattern to catch any tile/imagery requests
- Enhance kartta.hel.fi mock to handle both WMS (PNG) and WFS (GeoJSON)
- Improve route ordering (specific patterns before generic)
- Add diagnostic logging in CI via enableLogging option
- Document race condition prevention via Promise.all()

The fallback handler identifies tile requests by URL patterns (tile, wms, GetMap, FORMAT=image/png) and returns transparent PNG, ensuring no tiles hit real endpoints or timeout.

Fixes #611

Generated with [Claude Code](https://claude.ai/code)