### PR TITLE
fix(build): convert manualChunks to function for Vite 8 compatibility

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -116,15 +116,12 @@ export default defineConfig(({ mode }) => {
 					assetFileNames: `assets/[name].[hash].${version}.[ext]`,
 					chunkFileNames: `assets/[name].[hash].${version}.js`,
 					entryFileNames: `assets/[name].[hash].${version}.js`,
-					manualChunks: {
-						// Split Cesium into its own chunk for better caching and async loading
-						cesium: ['cesium'],
-						// Split Vue ecosystem into separate chunks for optimal caching
-						'vue-vendor': ['vue', 'pinia'],
-						'vuetify-vendor': ['vuetify'],
-						'd3-vendor': ['d3'],
-						// Split other heavy dependencies
-						'turf-vendor': ['@turf/turf'],
+					manualChunks(id) {
+						if (id.includes('node_modules/vuetify')) return 'vuetify-vendor';
+						if (id.includes('node_modules/vue/') || id.includes('node_modules/pinia/'))
+							return 'vue-vendor';
+						if (id.includes('node_modules/d3')) return 'd3-vendor';
+						if (id.includes('node_modules/@turf')) return 'turf-vendor';
 					},
 				},
 			},


### PR DESCRIPTION
## Summary\n\n- Convert `manualChunks` from object syntax to function syntax, required by Vite 8's Rolldown bundler\n- Remove Cesium from manual chunks — Rolldown handles its chunking automatically (still produces a separate 5.4MB chunk)\n- Fix `vue` path matching to use `node_modules/vue/` (trailing slash) to avoid accidentally capturing `vuetify`\n\n## Context\n\nVite 8 replaced Rollup with Rolldown as the production bundler. Rolldown requires `manualChunks` to be a function, not an object. The object syntax caused `manualChunks is not a function` build failures in CI.\n\nAdditionally, putting all Cesium modules into a single manual chunk caused Rolldown to produce broken internal cross-references (`widgets_exports is not declared in this file`).\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)