### PR TITLE
fix: add missing gateway hostname causing 404 on r4c.dataportal.fi

### DIFF
--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -92,6 +92,11 @@ migrations:
     repository: ghcr.io/forumviriumhelsinki/r4c-cesium-viewer
 gateway:
   enabled: true
+  hosts:
+    - host: r4c.dataportal.fi
+      paths:
+        - path: /
+          pathType: PathPrefix
 ingress:
   enabled: false
 env:


### PR DESCRIPTION
## Summary

- Adds `gateway.hosts` with `r4c.dataportal.fi` to the Envoy Gateway configuration
- The migration to Envoy Gateway (#651) omitted the hostname, causing the HTTPRoute to default to `r4c-cesium-viewer-helm-webapp.dataportal.fi` instead of the production domain
- This resulted in a 404 for all requests to https://r4c.dataportal.fi/

## Test plan

- [ ] Verify ArgoCD syncs the updated HTTPRoute with the correct hostname
- [ ] Confirm https://r4c.dataportal.fi/ resolves and serves the application
- [ ] Note: authentication (previously via oauth2-proxy nginx annotations) is not restored by this fix — a separate Envoy Gateway SecurityPolicy is needed for OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)