### PR TITLE
fix(ui): resolve view mode toggle overflow and remove redundant top bar chip

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,17 +9,6 @@
 			<!-- Left: App Title -->
 			<AppTitle class="ml-2 ml-sm-4 mr-2" />
 
-			<!-- View mode context chip (hidden on mobile) -->
-			<v-chip
-				v-if="currentLevel === 'start' || currentLevel === 'postalCode'"
-				size="small"
-				variant="tonal"
-				class="d-none d-sm-flex mx-1"
-				:prepend-icon="viewModeIcon"
-			>
-				{{ viewModeLabel }}
-			</v-chip>
-
 			<!-- Location context chip (hidden on mobile) -->
 			<v-chip
 				v-if="locationLabel"
@@ -174,13 +163,9 @@ const showTimeline = computed(
 	() => currentLevel.value === 'postalCode' || currentLevel.value === 'building'
 )
 
-const currentView = computed(() => globalStore.view)
 const postalCode = computed(() => globalStore.postalCode)
 const nameOfZone = computed(() => globalStore.nameOfZone)
 const buildingAddress = computed(() => globalStore.buildingAddress)
-
-const viewModeLabel = computed(() => (currentView.value === 'grid' ? 'Grid' : 'Capital Region'))
-const viewModeIcon = computed(() => (currentView.value === 'grid' ? 'mdi-grid' : 'mdi-city'))
 
 const locationLabel = computed(() => {
 	if (currentLevel.value === 'building') return buildingAddress.value || 'Building'

--- a/src/components/ViewModeCompact.vue
+++ b/src/components/ViewModeCompact.vue
@@ -61,10 +61,10 @@ const activeViewMode = computed({
 const onToggleChange = (viewMode) => {
 	switch (viewMode) {
 		case 'capitalRegionView':
-			capitalRegion(viewMode)
+			capitalRegion()
 			break
 		case 'gridView':
-			gridView(viewMode)
+			gridView()
 			break
 		default:
 			break
@@ -74,8 +74,10 @@ const onToggleChange = (viewMode) => {
 const setCapitalRegion = async () => {
 	store.setView('capitalRegion')
 	toggleStore.setHelsinkiView(false)
+	toggleStore.setGridView(false)
+	toggleStore.setGrid250m(false)
 	if (store.level === 'start') {
-		removeLandcover(store.landcoverLayers)
+		removeLandcover()
 	}
 	await dataSourceService.removeDataSourcesAndEntities()
 	await dataSourceService.loadGeoJsonDataSource(0.2, './assets/data/hsy_po.json', 'PostCodes')
@@ -93,23 +95,19 @@ const setCapitalRegion = async () => {
 	}
 }
 
-const capitalRegion = (viewMode) => {
-	const checked = viewMode === 'capitalRegionView'
-	toggleStore.setCapitalRegionCold(!checked)
+const capitalRegion = () => {
+	toggleStore.setCapitalRegionCold(false)
 	setCapitalRegion().catch((error) => {
 		logger.error('Failed to set capital region:', error)
 	})
 }
 
-const gridView = (viewMode) => {
-	const isGridView = viewMode === 'gridView'
-	toggleStore.setGridView(isGridView)
+const gridView = () => {
+	toggleStore.setGridView(true)
 	toggleStore.setHelsinkiView(false)
-	store.setView(isGridView ? 'grid' : 'capitalRegion')
-	if (isGridView) {
-		store.setShowBuildingInfo(false)
-		toggleStore.setGrid250m(true)
-	}
+	store.setView('grid')
+	store.setShowBuildingInfo(false)
+	toggleStore.setGrid250m(true)
 }
 </script>
 

--- a/src/components/ViewModeCompact.vue
+++ b/src/components/ViewModeCompact.vue
@@ -1,49 +1,45 @@
 <template>
 	<div class="view-mode-compact">
-		<!-- View Mode Button Group -->
 		<v-btn-toggle
 			v-model="activeViewMode"
 			mandatory
 			variant="outlined"
 			density="compact"
-			class="view-toggle-group"
+			class="view-toggle-group w-100"
 		>
 			<v-btn
 				value="capitalRegionView"
 				size="small"
 				aria-label="Capital Region view"
-				@click="onToggleChange('capitalRegionView')"
 			>
 				<v-icon
-					:start="!isMobile"
+					start
 					size="16"
 				>
 					mdi-city
 				</v-icon>
-				<span class="d-none d-sm-inline">Capital Region</span>
+				Region
 			</v-btn>
 
 			<v-btn
 				value="gridView"
 				size="small"
 				aria-label="Statistical Grid view"
-				@click="onToggleChange('gridView')"
 			>
 				<v-icon
-					:start="!isMobile"
+					start
 					size="16"
 				>
 					mdi-grid
 				</v-icon>
-				<span class="d-none d-sm-inline">Statistical Grid</span>
+				Grid
 			</v-btn>
 		</v-btn-toggle>
 	</div>
 </template>
 
-<script>
-import { computed, ref, watch } from 'vue'
-import { useDisplay } from 'vuetify'
+<script setup>
+import { computed } from 'vue'
 import Datasource from '../services/datasource.js'
 import FeaturePicker from '../services/featurepicker'
 import { removeLandcover } from '../services/landcover'
@@ -52,100 +48,68 @@ import { useGlobalStore } from '../stores/globalStore.js'
 import { useToggleStore } from '../stores/toggleStore.js'
 import logger from '../utils/logger.js'
 
-export default {
-	name: 'ViewModeCompact',
-	setup() {
-		const activeViewMode = ref('capitalRegionView')
-		const toggleStore = useToggleStore()
-		const store = useGlobalStore()
-		const { smAndDown } = useDisplay()
-		const isMobile = computed(() => smAndDown.value)
-		const dataSourceService = new Datasource()
-		const featurePicker = new FeaturePicker()
+const toggleStore = useToggleStore()
+const store = useGlobalStore()
+const dataSourceService = new Datasource()
+const featurePicker = new FeaturePicker()
 
-		// Watcher for activeViewMode changes
-		watch(activeViewMode, (newViewMode) => {
-			onToggleChange(newViewMode)
+const activeViewMode = computed({
+	get: () => (store.view === 'grid' ? 'gridView' : 'capitalRegionView'),
+	set: (val) => onToggleChange(val),
+})
+
+const onToggleChange = (viewMode) => {
+	switch (viewMode) {
+		case 'capitalRegionView':
+			capitalRegion(viewMode)
+			break
+		case 'gridView':
+			gridView(viewMode)
+			break
+		default:
+			break
+	}
+}
+
+const setCapitalRegion = async () => {
+	store.setView('capitalRegion')
+	toggleStore.setHelsinkiView(false)
+	if (store.level === 'start') {
+		removeLandcover(store.landcoverLayers)
+	}
+	await dataSourceService.removeDataSourcesAndEntities()
+	await dataSourceService.loadGeoJsonDataSource(0.2, './assets/data/hsy_po.json', 'PostCodes')
+
+	if (store.postalcode) {
+		featurePicker.loadPostalCode().catch((error) => {
+			logger.error('Failed to load postal code:', error)
 		})
+	}
+	if (toggleStore.showTrees) {
+		const treeService = new Tree()
+		treeService.loadTrees().catch((error) => {
+			logger.error('Failed to load trees:', error)
+		})
+	}
+}
 
-		const onToggleChange = (viewMode) => {
-			activeViewMode.value = viewMode
+const capitalRegion = (viewMode) => {
+	const checked = viewMode === 'capitalRegionView'
+	toggleStore.setCapitalRegionCold(!checked)
+	setCapitalRegion().catch((error) => {
+		logger.error('Failed to set capital region:', error)
+	})
+}
 
-			switch (viewMode) {
-				case 'capitalRegionView':
-					void capitalRegion()
-					break
-				case 'gridView':
-					gridView()
-					break
-				default:
-					break
-			}
-		}
-
-		const setCapitalRegion = async () => {
-			store.setView('capitalRegion')
-			toggleStore.setHelsinkiView(false)
-			// Don't reset all toggles - preserve data layer states (landCover, ndvi, etc.)
-			// Only clear landCover imagery if at start level
-			if (store.level === 'start') {
-				await clearLandCover()
-			}
-			await dataSourceService.removeDataSourcesAndEntities()
-			await dataSourceService.loadGeoJsonDataSource(0.2, './assets/data/hsy_po.json', 'PostCodes')
-
-			if (store.postalcode) {
-				featurePicker.loadPostalCode().catch((error) => {
-					logger.error('Failed to load postal code:', error)
-				})
-			}
-			if (toggleStore.showTrees) {
-				await loadTrees()
-			}
-		}
-
-		const loadTrees = async () => {
-			const treeService = new Tree()
-			treeService.loadTrees().catch((error) => {
-				logger.error('Failed to load trees:', error)
-			})
-		}
-
-		const clearLandCover = async () => {
-			removeLandcover(store.landcoverLayers)
-		}
-
-		const capitalRegion = async () => {
-			const checked = activeViewMode.value === 'capitalRegionView'
-			toggleStore.setCapitalRegionCold(!checked)
-			setCapitalRegion().catch((error) => {
-				logger.error('Failed to set capital region:', error)
-			})
-		}
-
-		const gridView = () => {
-			const isGridView = activeViewMode.value === 'gridView'
-			toggleStore.setGridView(isGridView)
-			toggleStore.setHelsinkiView(false)
-			store.setView(isGridView ? 'grid' : 'capitalRegion')
-			if (isGridView) {
-				store.setShowBuildingInfo(false)
-				toggleStore.setGrid250m(true)
-			} else {
-				reset()
-			}
-		}
-
-		const reset = () => {
-			// Reset logic if needed
-		}
-
-		return {
-			activeViewMode,
-			onToggleChange,
-			isMobile,
-		}
-	},
+const gridView = (viewMode) => {
+	const isGridView = viewMode === 'gridView'
+	toggleStore.setGridView(isGridView)
+	toggleStore.setHelsinkiView(false)
+	store.setView(isGridView ? 'grid' : 'capitalRegion')
+	if (isGridView) {
+		store.setShowBuildingInfo(false)
+		toggleStore.setGrid250m(true)
+	}
 }
 </script>
 
@@ -153,39 +117,13 @@ export default {
 .view-mode-compact {
 	display: flex;
 	align-items: center;
-	gap: 12px;
 }
 
 .view-toggle-group {
 	border-radius: 6px;
 }
 
-/* Responsive adjustments */
-@media (max-width: 960px) {
-	.view-mode-compact {
-		gap: 8px;
-	}
-
-	.view-toggle-group :deep(.v-btn) {
-		font-size: 0.75rem;
-		padding: 0 8px;
-	}
-}
-
-/* Mobile: icon-only buttons */
-@media (max-width: 600px) {
-	.view-mode-compact {
-		gap: 4px;
-	}
-
-	.view-toggle-group :deep(.v-btn) {
-		min-width: 44px;
-		min-height: 44px;
-		padding: 0 8px;
-	}
-
-	.view-toggle-group :deep(.v-btn .v-icon) {
-		font-size: 20px;
-	}
+.view-toggle-group :deep(.v-btn) {
+	flex: 1;
 }
 </style>


### PR DESCRIPTION
## Summary

- **Fix view mode toggle overflow**: Shortened button labels ("Capital Region" → "Region", "Statistical Grid" → "Grid") and made buttons fill available width with `flex: 1` to prevent layout overflow on smaller screens
- **Remove redundant top bar chip**: Removed the view mode context chip from App.vue toolbar since the toggle itself already indicates the active view
- **Refactor ViewModeCompact to Composition API**: Converted from Options API to `<script setup>`, replaced local `ref` + `watch` with a writable `computed` synced to the global store, and removed unused code (empty `reset()` function, unnecessary async wrappers)

## Test plan

- [ ] Verify view mode toggle renders without overflow at various viewport widths
- [ ] Confirm toggling between Region and Grid views works correctly
- [ ] Check that the top bar no longer shows a redundant view mode chip
- [ ] Verify mobile responsiveness — buttons should fill width evenly

🤖 Generated with [Claude Code](https://claude.com/claude-code)