### PR TITLE
fix(ux): surface silent degradation patterns to users and developers

### DIFF
--- a/src/components/FeatureFlagsPanel.vue
+++ b/src/components/FeatureFlagsPanel.vue
@@ -40,6 +40,16 @@
 				Configure runtime feature flags for the application. Changes are saved to your browser.
 			</v-card-subtitle>
 
+			<v-alert
+				v-if="featureFlagStore.providerSource === 'fallback'"
+				type="warning"
+				density="compact"
+				variant="tonal"
+				class="mx-4 mt-2"
+			>
+				Using local defaults (GOFF unavailable)
+			</v-alert>
+
 			<v-divider />
 
 			<v-card-text style="max-height: 500px">
@@ -110,6 +120,14 @@
 											class="ml-2"
 										>
 											Not Supported
+										</v-chip>
+										<v-chip
+											v-if="flag.configRequirement && !flag.configRequirement.present"
+											size="x-small"
+											color="grey"
+											class="ml-2"
+										>
+											{{ flag.configRequirement.label }} not configured
 										</v-chip>
 									</v-list-item-title>
 

--- a/src/constants/flagMetadata.ts
+++ b/src/constants/flagMetadata.ts
@@ -62,6 +62,11 @@ export interface FlagMetadata {
 	requiresSupport: boolean
 	/** Default value when GOFF is unavailable (InMemoryProvider fallback) */
 	fallbackDefault: boolean
+	/** Environment variable required for this flag to function */
+	configRequirement?: {
+		label: string
+		present: boolean
+	}
 }
 
 export type FlagMetadataMap = Record<FeatureFlagName, FlagMetadata>
@@ -298,6 +303,11 @@ export const FLAG_METADATA: FlagMetadataMap = {
 		// Sentry is enabled when DSN is configured
 		fallbackDefault:
 			import.meta.env.VITE_SENTRY_DSN !== undefined && import.meta.env.VITE_SENTRY_DSN !== '',
+		configRequirement: {
+			label: 'Sentry DSN',
+			present:
+				import.meta.env.VITE_SENTRY_DSN !== undefined && import.meta.env.VITE_SENTRY_DSN !== '',
+		},
 	},
 	digitransitIntegration: {
 		goffId: 'r4c-digitransit-integration',
@@ -310,6 +320,12 @@ export const FLAG_METADATA: FlagMetadataMap = {
 		fallbackDefault:
 			import.meta.env.VITE_DIGITRANSIT_KEY !== undefined &&
 			import.meta.env.VITE_DIGITRANSIT_KEY !== '',
+		configRequirement: {
+			label: 'Digitransit API Key',
+			present:
+				import.meta.env.VITE_DIGITRANSIT_KEY !== undefined &&
+				import.meta.env.VITE_DIGITRANSIT_KEY !== '',
+		},
 	},
 	backgroundMapProviders: {
 		goffId: 'r4c-background-map-providers',

--- a/src/main.js
+++ b/src/main.js
@@ -104,57 +104,51 @@ pinia.use(
 
 const app = createApp(App)
 
-Sentry.init({
-	app,
-	// debug: true,
-	// Passing in `Vue` is optional, if you do not pass it `window.Vue` must be present.
-	// Vue: Vue,
-	dsn: import.meta.env.VITE_SENTRY_DSN,
-	environment: import.meta.env.MODE,
-	release: `r4c-cesium-viewer@${version}`,
+if (import.meta.env.VITE_SENTRY_DSN) {
+	Sentry.init({
+		app,
+		dsn: import.meta.env.VITE_SENTRY_DSN,
+		environment: import.meta.env.MODE,
+		release: `r4c-cesium-viewer@${version}`,
 
-	// This enables automatic instrumentation (highly recommended),
-	// but is not necessary for purely manual usage
-	// If you only want to use custom instrumentation:
-	// * Remove the `BrowserTracing` integration
-	// * add `Sentry.addTracingExtensions()` above your Sentry.init() call
-	integrations: [
-		Sentry.browserTracingIntegration(),
-		Sentry.replayIntegration(),
-		// Note: replayCanvasIntegration removed - incompatible with CesiumJS WebGL
-		// Canvas replay captures every frame, causing 30-40s of main thread blocking
-		// Session replay still works for DOM elements; only canvas content is excluded
-	],
+		integrations: [
+			Sentry.browserTracingIntegration(),
+			Sentry.replayIntegration(),
+			// Note: replayCanvasIntegration removed - incompatible with CesiumJS WebGL
+			// Canvas replay captures every frame, causing 30-40s of main thread blocking
+			// Session replay still works for DOM elements; only canvas content is excluded
+		],
 
-	// Sample error events - full capture in dev, 20% in production
-	sampleRate: import.meta.env.PROD ? 0.2 : 1.0,
+		// Sample error events - full capture in dev, 20% in production
+		sampleRate: import.meta.env.PROD ? 0.2 : 1.0,
 
-	// We recommend adjusting this value in production, or using tracesSampler
-	// for finer control
-	tracesSampleRate: 1.0,
+		// We recommend adjusting this value in production, or using tracesSampler
+		// for finer control
+		tracesSampleRate: 1.0,
 
-	// Set `tracePropagationTargets` to control for which URLs trace propagation should be enabled
-	tracePropagationTargets: [
-		'localhost',
-		/^https:\/\/r4c\.dataportal\.fi/,
-		/^https:\/\/r4c\.dev\.dataportal\.fi/,
-	],
+		// Set `tracePropagationTargets` to control for which URLs trace propagation should be enabled
+		tracePropagationTargets: [
+			'localhost',
+			/^https:\/\/r4c\.dataportal\.fi/,
+			/^https:\/\/r4c\.dev\.dataportal\.fi/,
+		],
 
-	// Capture Replay for 10% of all sessions,
-	// plus for 100% of sessions with an error
-	replaysSessionSampleRate: 0.1,
-	replaysOnErrorSampleRate: 1.0,
+		// Capture Replay for 10% of all sessions,
+		// plus for 100% of sessions with an error
+		replaysSessionSampleRate: 0.1,
+		replaysOnErrorSampleRate: 1.0,
 
-	// CPU profiling: 10% in production (minimal overhead), 100% in dev
-	profilesSampleRate: import.meta.env.PROD ? 0.1 : 1.0,
-})
+		// CPU profiling: 10% in production (minimal overhead), 100% in dev
+		profilesSampleRate: import.meta.env.PROD ? 0.1 : 1.0,
+	})
 
-// Log Sentry configuration in development only (security: avoid exposing DSN)
-logger.debug('Sentry configuration:', {
-	environment: import.meta.env.MODE,
-	release: `r4c-cesium-viewer@${version}`,
-	dsnConfigured: !!import.meta.env.VITE_SENTRY_DSN,
-})
+	logger.debug('Sentry configuration:', {
+		environment: import.meta.env.MODE,
+		release: `r4c-cesium-viewer@${version}`,
+	})
+} else {
+	logger.info('Sentry: DSN not configured, error monitoring disabled')
+}
 
 app.use(pinia)
 app.use(vuetify)

--- a/src/services/featureFlagProvider.ts
+++ b/src/services/featureFlagProvider.ts
@@ -6,6 +6,7 @@
 import { GoFeatureFlagWebProvider } from '@openfeature/go-feature-flag-web-provider'
 import { type EvaluationContext, InMemoryProvider, OpenFeature } from '@openfeature/web-sdk'
 import { ALL_FLAG_NAMES, FLAG_METADATA } from '@/constants/flagMetadata'
+import { useFeatureFlagStore } from '@/stores/featureFlagStore'
 import type { useUserStore } from '@/stores/userStore'
 import logger from '@/utils/logger'
 
@@ -95,16 +96,19 @@ export async function initializeFeatureFlags(userStore: UserStore): Promise<void
 		try {
 			await OpenFeature.setProviderAndWait(provider)
 			logger.info('Feature flags: GOFF provider initialized')
+			useFeatureFlagStore().setProviderSource('goff')
 		} catch (error) {
 			logger.warn('Feature flags: GOFF provider failed, falling back to defaults', error)
 			const fallbackProvider = new InMemoryProvider(buildFallbackFlags())
 			await OpenFeature.setProviderAndWait(fallbackProvider)
+			useFeatureFlagStore().setProviderSource('fallback')
 		}
 	} else {
 		logger.info('Feature flags: GOFF relay unavailable, using fallback defaults')
 		await OpenFeature.setContext(context)
 		const fallbackProvider = new InMemoryProvider(buildFallbackFlags())
 		await OpenFeature.setProviderAndWait(fallbackProvider)
+		useFeatureFlagStore().setProviderSource('fallback')
 	}
 }
 

--- a/src/services/loadingCoordinator.js
+++ b/src/services/loadingCoordinator.js
@@ -120,11 +120,15 @@ class LoadingCoordinator {
 	 * @private
 	 */
 	get loadingStore() {
-		if (!this._loadingStore) {
+		if (!this._loadingStore || this._loadingStoreFallback) {
 			try {
 				this._loadingStore = useLoadingStore()
+				this._loadingStoreFallback = false
 			} catch (error) {
-				logger.warn('Loading store not available, using fallback:', error.message)
+				if (!this._loadingStoreFallback) {
+					logger.warn('Loading store not available, using fallback:', error.message)
+				}
+				this._loadingStoreFallback = true
 				this._loadingStore = {
 					startLayerLoading: () => {},
 					updateLayerProgress: () => {},
@@ -145,11 +149,15 @@ class LoadingCoordinator {
 	 * @private
 	 */
 	get globalStore() {
-		if (!this._globalStore) {
+		if (!this._globalStore || this._globalStoreFallback) {
 			try {
 				this._globalStore = useGlobalStore()
+				this._globalStoreFallback = false
 			} catch (error) {
-				logger.warn('Global store not available, using fallback:', error.message)
+				if (!this._globalStoreFallback) {
+					logger.warn('Global store not available, using fallback:', error.message)
+				}
+				this._globalStoreFallback = true
 				this._globalStore = {
 					cesiumViewer: null,
 					postalcode: null,
@@ -585,61 +593,6 @@ class LoadingCoordinator {
 				? performance.now() - this.performanceMetrics.sessionStartTime
 				: 0,
 		}
-	}
-
-	/**
-	 * Smart preloading based on user context
-	 * Analyzes user behavior to predict and preload likely next actions.
-	 *
-	 * Note: Currently returns empty array. Future implementation will use
-	 * analytics and user history to predict needed data.
-	 *
-	 * @param {Object} [context={}] - User context for prediction
-	 * @param {string} [context.currentPostalCode] - Current postal code
-	 * @param {string} [context.view] - Current view mode
-	 * @param {string[]} [context.userHistory] - Recent user actions
-	 * @returns {Promise<SessionResult[]>} Preload results
-	 *
-	 * @example
-	 * // Intelligent preloading based on current location
-	 * await loadingCoordinator.intelligentPreload({
-	 *   currentPostalCode: '00100',
-	 *   view: 'postalcode',
-	 *   userHistory: ['00150', '00170']
-	 * });
-	 */
-	async intelligentPreload(context = {}) {
-		const {
-			currentPostalCode: _currentPostalCode,
-			view: _view,
-			userHistory: _userHistory = [],
-		} = context
-
-		// Determine what to preload based on context
-		const preloadConfigs = this.generatePreloadConfigs(context)
-
-		if (preloadConfigs.length > 0) {
-			logger.debug(`Starting intelligent preload of ${preloadConfigs.length} layers`)
-
-			await this.startLoadingSession('preload', preloadConfigs, {
-				priorityStrategy: 'balanced',
-				backgroundMode: true,
-			})
-		}
-	}
-
-	/**
-	 * Generate preload configurations based on context
-	 * Future: Analyze user patterns and predict likely next actions.
-	 *
-	 * @param {Object} context - User context
-	 * @returns {Object[]} Preload configurations (currently empty)
-	 * @private
-	 */
-	generatePreloadConfigs(_context) {
-		// This would analyze user patterns and predict likely next actions
-		// For now, return empty array - would be expanded based on analytics
-		return []
 	}
 
 	/**

--- a/src/services/unifiedLoader.js
+++ b/src/services/unifiedLoader.js
@@ -100,12 +100,15 @@ class UnifiedLoader {
 	 * @private
 	 */
 	get loadingStore() {
-		if (!this._loadingStore) {
+		if (!this._loadingStore || this._loadingStoreFallback) {
 			try {
 				this._loadingStore = useLoadingStore()
+				this._loadingStoreFallback = false
 			} catch (error) {
-				logger.warn('Loading store not available, using fallback:', error.message)
-				// Provide a fallback object with minimal interface
+				if (!this._loadingStoreFallback) {
+					logger.warn('Loading store not available, using fallback:', error.message)
+				}
+				this._loadingStoreFallback = true
 				this._loadingStore = {
 					startLayerLoading: () => {},
 					updateLayerProgress: () => {},

--- a/src/services/viewportBuildingLoader.js
+++ b/src/services/viewportBuildingLoader.js
@@ -33,6 +33,7 @@
 import { useBuildingStore } from '../stores/buildingStore.js'
 import { useFeatureFlagStore } from '../stores/featureFlagStore.ts'
 import { useGlobalStore } from '../stores/globalStore.js'
+import { useLoadingStore } from '../stores/loadingStore.js'
 import { useToggleStore } from '../stores/toggleStore.js'
 import { useURLStore } from '../stores/urlStore.js'
 import { processBatchAdaptive } from '../utils/batchProcessor.js'
@@ -108,6 +109,7 @@ export default class ViewportBuildingLoader {
 		this.urlStore = useURLStore()
 		this.buildingStore = useBuildingStore()
 		this.featureFlagStore = useFeatureFlagStore()
+		this.loadingStore = useLoadingStore()
 		this.viewer = null
 
 		// Service dependencies
@@ -634,6 +636,10 @@ export default class ViewportBuildingLoader {
 							logger.warn(
 								`[ViewportBuildingLoader] Heat data fetch failed:`,
 								error?.message || error
+							)
+							this.loadingStore?.setLayerError(
+								'heatData',
+								error?.message || 'Heat data unavailable'
 							)
 							return null
 						})

--- a/src/services/viewportBuildingLoader.js
+++ b/src/services/viewportBuildingLoader.js
@@ -109,7 +109,8 @@ export default class ViewportBuildingLoader {
 		this.urlStore = useURLStore()
 		this.buildingStore = useBuildingStore()
 		this.featureFlagStore = useFeatureFlagStore()
-		this.loadingStore = useLoadingStore()
+		/** @type {Object|null} Lazy-loaded loading store instance */
+		this._loadingStore = null
 		this.viewer = null
 
 		// Service dependencies
@@ -157,6 +158,36 @@ export default class ViewportBuildingLoader {
 		this.previousCameraTimestamp = null
 
 		logger.debug('[ViewportBuildingLoader] Service initialized')
+	}
+
+	/**
+	 * Get loading store instance (lazy-loaded to avoid Pinia initialization issues)
+	 * Provides fallback with no-op methods if store is unavailable.
+	 *
+	 * @returns {Object} Loading store instance or fallback
+	 * @private
+	 */
+	get loadingStore() {
+		if (!this._loadingStore || this._loadingStoreFallback) {
+			try {
+				this._loadingStore = useLoadingStore()
+				this._loadingStoreFallback = false
+			} catch (error) {
+				if (!this._loadingStoreFallback) {
+					logger.warn('Loading store not available, using fallback:', error.message)
+				}
+				this._loadingStoreFallback = true
+				this._loadingStore = {
+					startLayerLoading: () => {},
+					updateLayerProgress: () => {},
+					completeLayerLoading: () => {},
+					setLayerError: () => {},
+					clearLayerError: () => {},
+					layers: {},
+				}
+			}
+		}
+		return this._loadingStore
 	}
 
 	/**
@@ -637,7 +668,7 @@ export default class ViewportBuildingLoader {
 								`[ViewportBuildingLoader] Heat data fetch failed:`,
 								error?.message || error
 							)
-							this.loadingStore?.setLayerError(
+							this.loadingStore.setLayerError(
 								'heatData',
 								error?.message || 'Heat data unavailable'
 							)
@@ -645,6 +676,11 @@ export default class ViewportBuildingLoader {
 						})
 					: Promise.resolve(null),
 			])
+
+			// Clear stale heat data error if this fetch succeeded
+			if (heatDataPromise && heatResult !== null) {
+				this.loadingStore.clearLayerError('heatData')
+			}
 
 			logger.debug(
 				`[ViewportBuildingLoader] ✅ Received ${buildingData?.features?.length || 0} buildings for tile ${tileKey}`

--- a/src/stores/featureFlagStore.ts
+++ b/src/stores/featureFlagStore.ts
@@ -40,6 +40,10 @@ export interface FeatureFlagConfig {
 	description: string
 	experimental?: boolean
 	requiresSupport?: boolean
+	configRequirement?: {
+		label: string
+		present: boolean
+	}
 }
 
 export type FeatureFlagsMap = Record<FeatureFlagName, FeatureFlagConfig>
@@ -48,6 +52,8 @@ export type UserOverridesMap = Partial<Record<FeatureFlagName, boolean>>
 export interface FeatureFlagWithName extends FeatureFlagConfig {
 	name: FeatureFlagName
 }
+
+export type ProviderSource = 'goff' | 'fallback' | 'unknown'
 
 interface FeatureFlagState {
 	/** Cached evaluation results from OpenFeature */
@@ -58,6 +64,8 @@ interface FeatureFlagState {
 	hardwareSupport: Partial<Record<FeatureFlagName, boolean>>
 	/** Whether flags have been evaluated at least once */
 	initialized: boolean
+	/** Which provider is active: GOFF relay or local fallback defaults */
+	providerSource: ProviderSource
 }
 
 export const useFeatureFlagStore = defineStore('featureFlags', {
@@ -66,6 +74,7 @@ export const useFeatureFlagStore = defineStore('featureFlags', {
 		userOverrides: {},
 		hardwareSupport: {},
 		initialized: false,
+		providerSource: 'unknown',
 	}),
 
 	getters: {
@@ -129,6 +138,7 @@ export const useFeatureFlagStore = defineStore('featureFlags', {
 							description: meta.description,
 							experimental: meta.experimental,
 							requiresSupport: meta.requiresSupport,
+							configRequirement: meta.configRequirement,
 						}
 					})
 			},
@@ -256,6 +266,11 @@ export const useFeatureFlagStore = defineStore('featureFlags', {
 					logger.info(`Feature '${flagName}' disabled: hardware not supported`)
 				}
 			}
+		},
+
+		/** Set which provider is active (called by featureFlagProvider after init) */
+		setProviderSource(source: ProviderSource): void {
+			this.providerSource = source
 		},
 
 		/** Get feature flag metadata */


### PR DESCRIPTION
## Summary

- **Heat data failures surfaced to users** — when heat API fails during building load, the existing `LoadingIndicator` error alert now shows the failure with a retry button instead of silently rendering buildings without heat coloring
- **Feature flag provider transparency** — FeatureFlagsPanel now shows a warning banner when running on local defaults (GOFF unavailable) and config requirement chips for env-dependent flags (Sentry DSN, Digitransit API Key)
- **Loading store fallback retry** — no-op store fallbacks in `loadingCoordinator` and `unifiedLoader` now retry on next access, so loading indicators recover once Pinia is ready
- **Sentry DSN guard** — `Sentry.init()` is now guarded with an explicit log message when DSN is not configured
- **Dead code removal** — removed unreachable `intelligentPreload()` and `generatePreloadConfigs()` methods from `loadingCoordinator`

## Test plan

- [ ] Run `just dev-mock`, navigate to a postal code, block heat data endpoint in devtools Network tab — verify error alert appears in loading indicator
- [ ] Open `?flags=true` in local dev (no GOFF relay) — verify "Using local defaults" warning banner appears in feature flags dialog
- [ ] Verify Digitransit and Sentry flags show "not configured" chips when env vars are unset
- [ ] Run without `VITE_SENTRY_DSN` — verify console shows "Sentry: DSN not configured" info log
- [ ] `bun run lint` passes (pre-existing lint issues in unrelated files)
- [ ] `just test-unit` — no new test failures (13 pre-existing failures in sensor/traveltime tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)