### PR TITLE
fix(nginx): route /pygeoapi/ via VITE_PYGEOAPI_HOST to bypass Envoy Gateway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,13 @@ RUN npx vite build && npx vite optimize
 
 FROM nginx:1.27
 
+# Default PyGeoAPI host — overridden at runtime via deploy/values.yaml env
+ENV VITE_PYGEOAPI_HOST=pygeoapi.dataportal.fi
+# DNS resolver: "auto" detects from /etc/resolv.conf at startup.
+# Works in both Docker (127.0.0.11) and Kubernetes (kube-dns ClusterIP).
+ENV NGINX_DNS_RESOLVER=auto
+
 COPY --link --from=build /app/dist/ /usr/share/nginx/html
 COPY nginx/default.conf.template /etc/nginx/templates/
+# Sourced by nginx entrypoint to populate NGINX_DNS_RESOLVER before envsubst
+COPY nginx/docker-entrypoint.d/05-set-dns-resolver.envsh /docker-entrypoint.d/

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -7,6 +7,11 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # DNS resolver — required because /pygeoapi/ uses a variable in proxy_pass.
+    # Value populated at container startup by 05-set-dns-resolver.envsh
+    # (Docker: 127.0.0.11, Kubernetes: kube-dns ClusterIP).
+    resolver ${NGINX_DNS_RESOLVER} valid=30s ipv6=off;
+
     # Global proxy settings
     proxy_cache global_cache;
     proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
@@ -84,11 +89,41 @@ server {
     }
 
     location /pygeoapi/ {
-        proxy_pass https://pygeoapi.dataportal.fi/;
-        proxy_set_header Host pygeoapi.dataportal.fi;
-        # Required for Envoy Gateway: send SNI so the gateway can identify the virtual host
-        proxy_ssl_server_name on;
+        # Host is supplied at deploy time via VITE_PYGEOAPI_HOST. In production
+        # this points at the in-cluster pygeoapi service
+        # (e.g. pygeoapi-helm-webapp.pygeoapi.svc.cluster.local), bypassing
+        # Envoy Gateway entirely. For local dev it can be pygeoapi.dataportal.fi
+        # or a localhost:port. Using a variable forces nginx to re-resolve DNS
+        # at runtime instead of baking in the IP at config-load time.
+        set $pygeoapi_host "${VITE_PYGEOAPI_HOST}";
+
+        # Protocol follows host shape:
+        #   - localhost:port       -> http  (dev)
+        #   - short hostname       -> http  (in-cluster short service name)
+        #   - *.svc.cluster.local  -> http  (in-cluster FQDN)
+        #   - anything else        -> https (public endpoint)
+        set $pygeoapi_protocol "https";
+        if ($pygeoapi_host ~* "^localhost:[0-9]+$") {
+            set $pygeoapi_protocol "http";
+        }
+        if ($pygeoapi_host ~* "\.svc\.cluster\.local$") {
+            set $pygeoapi_protocol "http";
+        }
+        if ($pygeoapi_host ~* "^[^.]+$") {
+            set $pygeoapi_protocol "http";
+        }
+
+        # Strip the /pygeoapi prefix before forwarding.
+        # With a variable in proxy_pass, nginx does NOT do prefix-replacement,
+        # so the rewrite must produce the final upstream path.
         rewrite ^/pygeoapi/(.*)$ /$1 break;
+
+        # proxy_pass without a URI preserves the rewritten path verbatim.
+        proxy_pass $pygeoapi_protocol://$pygeoapi_host;
+        proxy_set_header Host $pygeoapi_host;
+        # Send SNI when talking to an https upstream (Envoy Gateway requires it).
+        proxy_ssl_server_name on;
+        proxy_ssl_name $pygeoapi_host;
     }
 
     location /wms/proxy {

--- a/nginx/docker-entrypoint.d/05-set-dns-resolver.envsh
+++ b/nginx/docker-entrypoint.d/05-set-dns-resolver.envsh
@@ -1,0 +1,24 @@
+# Auto-detect DNS resolver from /etc/resolv.conf if NGINX_DNS_RESOLVER is not set
+# or is set to the placeholder value "auto"
+#
+# This file is sourced (not executed) by nginx's docker-entrypoint.sh
+# Priority:
+# 1. If NGINX_DNS_RESOLVER is set to a valid IP, use it
+# 2. If NGINX_DNS_RESOLVER is "auto" or unset, detect from /etc/resolv.conf
+# 3. Fall back to 127.0.0.11 (Docker's embedded DNS)
+
+if [ -z "$NGINX_DNS_RESOLVER" ] || [ "$NGINX_DNS_RESOLVER" = "auto" ]; then
+    # Extract first nameserver from /etc/resolv.conf
+    DETECTED_DNS=$(grep -m1 '^nameserver' /etc/resolv.conf 2>/dev/null | awk '{print $2}')
+
+    if [ -n "$DETECTED_DNS" ]; then
+        export NGINX_DNS_RESOLVER="$DETECTED_DNS"
+        echo "05-set-dns-resolver.envsh: Auto-detected DNS resolver: $NGINX_DNS_RESOLVER"
+    else
+        # Fall back to Docker's embedded DNS
+        export NGINX_DNS_RESOLVER="127.0.0.11"
+        echo "05-set-dns-resolver.envsh: Using fallback DNS resolver: $NGINX_DNS_RESOLVER"
+    fi
+else
+    echo "05-set-dns-resolver.envsh: Using configured DNS resolver: $NGINX_DNS_RESOLVER"
+fi


### PR DESCRIPTION
## Summary

- On `release-1.22.x`, `nginx/default.conf.template` hardcoded `pygeoapi.dataportal.fi` for the `/pygeoapi/` proxy. The pod therefore routed every pygeoapi call back out through the public domain and Envoy Gateway instead of talking to the in-cluster pygeoapi service. After the ingress-nginx → Envoy Gateway migration, that round-trip became fragile (SNI/SSL handshake resets) and building layer loading broke on production.
- `main`'s `deploy/values.yaml` already sets `VITE_PYGEOAPI_HOST=pygeoapi-helm-webapp.pygeoapi.svc.cluster.local`, but this branch's nginx never read it. This PR makes nginx actually honor the env var so the pod reaches pygeoapi directly over cluster DNS.
- Narrow backport from `main` — no health endpoints, no bun migration, no other proxy changes.

## Changes

- `nginx/default.conf.template`
  - `/pygeoapi/` now uses `$VITE_PYGEOAPI_HOST` with protocol auto-detection (short hostname or `*.svc.cluster.local` → `http`, else `https`), rewrite-before-proxy_pass, and `proxy_ssl_name` so SNI reflects the actual host when the upstream is https.
  - Adds the `resolver ${NGINX_DNS_RESOLVER}` directive that's mandatory when `proxy_pass` uses a variable.
- `Dockerfile`
  - `ENV VITE_PYGEOAPI_HOST=pygeoapi.dataportal.fi` as a safe public default; prod overrides via `deploy/values.yaml`.
  - `ENV NGINX_DNS_RESOLVER=auto`.
  - Copies the resolver-detection entrypoint script.
- `nginx/docker-entrypoint.d/05-set-dns-resolver.envsh` (new)
  - Sourced by the nginx entrypoint; populates `NGINX_DNS_RESOLVER` from the first nameserver in `/etc/resolv.conf` (works in Docker and Kubernetes).

## Test plan

- [ ] `docker build .` succeeds
- [ ] Local run with `VITE_PYGEOAPI_HOST=pygeoapi.dataportal.fi` — `curl -sI http://localhost/pygeoapi/collections?limit=1` returns 200
- [ ] After release + ArgoCD sync: `kubectl exec` into the pod and `curl -sI http://localhost/pygeoapi/collections?limit=1` returns 200 — resolved via `pygeoapi-helm-webapp.pygeoapi.svc.cluster.local`, not via the public gateway
- [ ] Building layer loads on https://r4c.dataportal.fi/
- [ ] `/paavo`, `/wms/proxy`, `/terrain-proxy`, `/digitransit` continue to work (untouched in this PR)

## Follow-ups (not in this PR)

- If the postal-code layer is also broken, the `/paavo` typename fix (`pno_tilasto_2024` → `pno_tilasto`) from `main` is a one-line backport.
- Worth re-testing `main` in prod too — the original symptom may not be unique to this release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)