### PR TITLE
feat(deploy): add beta values for r4c-beta.dataportal.fi

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Forum Virium Helsinki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/deploy/values-beta.yaml
+++ b/deploy/values-beta.yaml
@@ -1,0 +1,133 @@
+# Beta deployment — r4c-beta.dataportal.fi
+#
+# Independent deployment of the latest `main` build for stakeholder validation
+# before promotion to r4c.dataportal.fi. Shares the regions4climate namespace
+# and database with prod; deliberately avoids running DB migrations here so
+# that main's schema changes cannot affect the stable release.
+#
+# image.tag is maintained by ArgoCD Image Updater (see r4c-cesium-viewer-beta
+# Application in infrastructure/argocd/apps/templates/regions4climate/).
+image:
+  repository: ghcr.io/forumviriumhelsinki/r4c-cesium-viewer
+  tag: '1.22.6'
+# Distinct release name to avoid Service/Deployment collisions with stable
+fullnameOverride: r4c-cesium-viewer-beta
+imagePullSecrets:
+  - name: ghcr-login-secret
+serviceAccount:
+  create: true
+  # Distinct name to avoid collision with the stable ServiceAccount
+  name: r4c-cesium-viewer-beta
+  annotations:
+    iam.gke.io/gcp-service-account: pygeoapi@fvh-project-containers-etc.iam.gserviceaccount.com
+# Cloud SQL Proxy sidecar (read-only DB access; migrations disabled below)
+initContainers:
+  - name: cloud-sql-proxy
+    image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.19.0
+    restartPolicy: Always
+    args:
+      - '--structured-logs'
+      - '--port=5432'
+      - '--auto-iam-authn'
+      - 'fvh-project-containers-etc:europe-north1:fvh-postgres'
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 65532
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+# Migrations disabled on beta — the stable release owns schema changes against
+# the shared regions4climate database. Re-enable only once main is ready to
+# promote to prod.
+migrations:
+  enabled: false
+gateway:
+  enabled: true
+  hosts:
+    - host: r4c-beta.dataportal.fi
+      paths:
+        - path: /
+          pathType: PathPrefix
+ingress:
+  enabled: false
+env:
+  - name: SENTRY_AUTH_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: regions4climate-secrets # pragma: allowlist secret
+        key: SENTRY_AUTH_TOKEN
+  - name: VITE_SENTRY_DSN
+    valueFrom:
+      secretKeyRef:
+        name: regions4climate-secrets # pragma: allowlist secret
+        key: VITE_SENTRY_DSN
+  - name: SENTRY_DSN
+    valueFrom:
+      secretKeyRef:
+        name: regions4climate-secrets # pragma: allowlist secret
+        key: SENTRY_DSN
+  - name: VITE_DIGITRANSIT_KEY
+    valueFrom:
+      secretKeyRef:
+        name: regions4climate-secrets # pragma: allowlist secret
+        key: VITE_DIGITRANSIT_KEY
+  - name: VITE_PYGEOAPI_HOST
+    value: 'pygeoapi-helm-webapp.pygeoapi.svc.cluster.local'
+  - name: VITE_PYGEOAPI_URL
+    value: 'https://pygeoapi.dataportal.fi'
+replicaCount: 1
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 500m
+    memory: 512Mi
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 101
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+volumes:
+  - name: nginx-cache
+    emptyDir: {}
+  - name: nginx-run
+    emptyDir: {}
+  - name: nginx-conf
+    emptyDir: {}
+  - name: tmp
+    emptyDir: {}
+volumeMounts:
+  - name: nginx-cache
+    mountPath: /var/cache/nginx
+  - name: nginx-run
+    mountPath: /var/run
+  - name: nginx-conf
+    mountPath: /etc/nginx/conf.d
+  - name: tmp
+    mountPath: /tmp
+keda:
+  enabled: true
+  minReplicaCount: 0
+  maxReplicaCount: 1
+  pollingInterval: 30
+  cooldownPeriod: 300
+  triggers:
+    - type: cron
+      metadata:
+        timezone: Europe/Helsinki
+        start: 0 7 * * 1-5
+        end: 0 20 * * 1-5
+        desiredReplicas: '1'

--- a/deploy/values-beta.yaml
+++ b/deploy/values-beta.yaml
@@ -19,8 +19,14 @@ serviceAccount:
   # Distinct name to avoid collision with the stable ServiceAccount
   name: r4c-cesium-viewer-beta
   annotations:
+    # TODO: Replace with a dedicated read-only beta GSA once provisioned in GCP.
+    # Using the production GSA here means the beta pod has the same DDL/DML
+    # privileges as the stable release. Acceptable for an internal-only beta
+    # (stakeholder validation), but should be tightened before any wider rollout.
     iam.gke.io/gcp-service-account: pygeoapi@fvh-project-containers-etc.iam.gserviceaccount.com
-# Cloud SQL Proxy sidecar (read-only DB access; migrations disabled below)
+# Cloud SQL Proxy sidecar — NOTE: connection is NOT read-only (uses production GSA).
+# Migrations are disabled below to protect the shared schema, but application-level
+# DML is still possible. See TODO above for the longer-term mitigation.
 initContainers:
   - name: cloud-sql-proxy
     image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.19.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "r4c-cesium-viewer",
 	"private": true,
+	"license": "MIT",
 	"version": "1.46.0",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

- Adds `deploy/values-beta.yaml` — a sibling of `deploy/values.yaml` for a parallel deployment at **https://r4c-beta.dataportal.fi** that tracks the latest tagged build of `main`.
- Stable `r4c.dataportal.fi` (pinned at 1.22.x) is **unchanged**.
- DB migrations disabled on beta (shared namespace & database with prod — main's schema changes must not touch production data until promotion).
- `fullnameOverride` + distinct ServiceAccount name prevent collisions with the stable release.

The matching ArgoCD Application lives in the infrastructure repo (linked PR below). Image Updater will maintain `image.tag` here via a dedicated `image-updater-beta-*` branch prefix.

Paired with: ForumViriumHelsinki/infrastructure#TBD

## Test plan

- [ ] Merge after the infra PR is ready (values file is referenced by the beta Application)
- [ ] After ArgoCD syncs: `kubectl -n regions4climate get httproute,svc,deploy | grep beta` shows resources
- [ ] `dig +short r4c-beta.dataportal.fi` resolves to gateway LB (external-dns)
- [ ] `curl -sI https://r4c-beta.dataportal.fi/` returns 200 with valid TLS
- [ ] Browser smoke: HSY Landcover, pygeoapi layers, building info load
- [ ] Stable untouched: `curl -sI https://r4c.dataportal.fi/` still serves 1.22.x

## Follow-up (tracked separately when promoting main to prod)

Re-enable `migrations.enabled: true` here, then remove the beta Application and DNS.