### PR TITLE
chore(deploy): bump beta image to 1.47.0

### DIFF
--- a/deploy/values-beta.yaml
+++ b/deploy/values-beta.yaml
@@ -9,7 +9,7 @@
 # Application in infrastructure/argocd/apps/templates/regions4climate/).
 image:
   repository: ghcr.io/forumviriumhelsinki/r4c-cesium-viewer
-  tag: '1.22.6'
+  tag: '1.47.0'
 # Distinct release name to avoid Service/Deployment collisions with stable
 fullnameOverride: r4c-cesium-viewer-beta
 imagePullSecrets:


### PR DESCRIPTION
## Summary

Manually bump `deploy/values-beta.yaml` from `1.22.6` → `1.47.0` so https://r4c-beta.dataportal.fi runs the latest release from `main` (r4c-cesium-viewer 1.47.0, cut earlier today).

## Why a manual bump

ArgoCD Image Updater *should* maintain this automatically — the `r4c-cesium-viewer-beta` Application added in ForumViriumHelsinki/infrastructure#1664 is correctly configured:

- `image-list: app=ghcr.io/forumviriumhelsinki/r4c-cesium-viewer` (no version constraint)
- `write-back-target: helmvalues:deploy/values-beta.yaml`
- `git-branch: image-updater-beta-...`

However, no `image-updater-beta-*` PR has been opened in the hours since that Application was created. This appears to be the same write-back issue affecting prod: the last Image Updater PR on this repo was #578 on 2026-01-19, and the recent `1.22.5` / `1.22.6` bumps were likewise manual (`cf3e293`, `8c3279f`).

This PR is a stop-gap so beta doesn't sit on stale code while the underlying Image Updater issue is investigated.

## Related

- Refs: ForumViriumHelsinki/infrastructure#1664 (adds beta Application)
- Refs: ForumViriumHelsinki/infrastructure#989 (open PR to unpin prod — independent)

## Test plan

- [ ] ArgoCD syncs `r4c-cesium-viewer-beta` to the new tag after merge
- [ ] `curl -sI https://r4c-beta.dataportal.fi/` returns 200
- [ ] Browser smoke: map loads, dark-mode toggle works (1.47.0 feature set)
- [ ] Prod (`r4c.dataportal.fi`) still on 1.22.6 — unaffected