### PR TITLE
claude/triage-issues-FQ4sR

### DIFF
--- a/src/services/building/buildingLoader.js
+++ b/src/services/building/buildingLoader.js
@@ -71,7 +71,8 @@ export class BuildingLoader {
 	 *
 	 * @param {string} [postalCode] - Optional postal code to load buildings for.
 	 *                                If not provided, uses current postal code from store.
-	 * @returns {Promise<Array>} Building entities
+	 * @returns {Promise<Array|null>} Building entities, or null if the load was
+	 *                                superseded by a newer navigation (stale result).
 	 */
 	async loadBuildings(postalCode) {
 		const targetPostalCode = postalCode || this.store.postalcode
@@ -106,6 +107,18 @@ export class BuildingLoader {
 				this.unifiedLoader.loadLayer(buildingConfig),
 				this.urbanheatService.getHeatData(targetPostalCode),
 			])
+
+			// Navigation may have changed while both fetches were in flight.
+			// `_currentLoadingLayerId` is cleared on cancel or reassigned on a new
+			// loadBuildings() call, so a mismatch means these results are stale.
+			// Bail out before merging/creating datasources with the wrong postal code.
+			if (this._currentLoadingLayerId !== layerId) {
+				logger.debug(
+					'[HelsinkiBuilding] Navigation changed during load, discarding stale results for:',
+					layerId
+				)
+				return null
+			}
 
 			// Handle building data (required)
 			if (buildingResult.status === 'rejected') {

--- a/src/services/featureFlagProvider.ts
+++ b/src/services/featureFlagProvider.ts
@@ -10,7 +10,16 @@ import { useFeatureFlagStore } from '@/stores/featureFlagStore'
 import type { useUserStore } from '@/stores/userStore'
 import logger from '@/utils/logger'
 
-const GOFF_ENDPOINT = '/feature-flags'
+/**
+ * GOFF endpoint must be an absolute URL: the provider's websocket setup calls
+ * `new URL(endpoint)` directly, which throws `TypeError: Failed to construct 'URL'`
+ * on relative paths. Build it from `window.location.origin` so dev (Vite proxy),
+ * preview, and prod (nginx proxy) all route through the same `/feature-flags` path.
+ */
+const GOFF_ENDPOINT =
+	typeof window !== 'undefined' && window.location?.origin
+		? `${window.location.origin}/feature-flags`
+		: '/feature-flags'
 const GOFF_HEALTH_TIMEOUT_MS = 3000
 
 type UserStore = ReturnType<typeof useUserStore>


### PR DESCRIPTION
The GoFeatureFlagWebProvider's websocket setup calls `new URL(endpoint)`
directly, which throws `TypeError: Failed to construct 'URL': Invalid URL`
when given a relative path. The fetch-based health check accepts relative
paths, which masked the issue until the provider tried to open its WS.

Build the endpoint from window.location.origin so dev (Vite proxy),
preview, and prod (nginx proxy) all continue to route through the same
/feature-flags path, while new URL() succeeds.

Fixes #686