### PR TITLE
fix: tighten request lifecycle, listener cleanup, and URL resolution

### DIFF
--- a/src/services/backgroundPreloader.js
+++ b/src/services/backgroundPreloader.js
@@ -482,9 +482,10 @@ class BackgroundPreloader {
 	removeIdleDetection() {
 		if (this.eventListenersAttached && this.boundResetIdleTimer) {
 			;['mousedown', 'mousemove', 'keypress', 'scroll', 'touchstart'].forEach((event) => {
-				document.removeEventListener(event, this.boundResetIdleTimer, { passive: true })
+				document.removeEventListener(event, this.boundResetIdleTimer)
 			})
 			this.eventListenersAttached = false
+			this.boundResetIdleTimer = null
 		}
 
 		if (this.idleTimer) {

--- a/src/services/building/buildingLoader.js
+++ b/src/services/building/buildingLoader.js
@@ -64,6 +64,12 @@ export class BuildingLoader {
 		}
 	}
 
+	_isStale(layerId) {
+		if (this._currentLoadingLayerId === layerId) return false
+		logger.debug('[BuildingLoader] Navigation changed during load, discarding stale results')
+		return true
+	}
+
 	/**
 	 * Loads Helsinki buildings for a postal code with caching support.
 	 * Uses unifiedLoader for IndexedDB caching with 1-hour TTL.
@@ -108,17 +114,7 @@ export class BuildingLoader {
 				this.urbanheatService.getHeatData(targetPostalCode),
 			])
 
-			// Navigation may have changed while both fetches were in flight.
-			// `_currentLoadingLayerId` is cleared on cancel or reassigned on a new
-			// loadBuildings() call, so a mismatch means these results are stale.
-			// Bail out before merging/creating datasources with the wrong postal code.
-			if (this._currentLoadingLayerId !== layerId) {
-				logger.debug(
-					'[HelsinkiBuilding] Navigation changed during load, discarding stale results for:',
-					layerId
-				)
-				return null
-			}
+			if (this._isStale(layerId)) return null
 
 			// Handle building data (required)
 			if (buildingResult.status === 'rejected') {
@@ -157,6 +153,8 @@ export class BuildingLoader {
 				buildingData.features?.length || 0,
 				'building features'
 			)
+
+			if (this._isStale(layerId)) return null
 
 			// Create Cesium datasource with entities
 			const entities = await this.datasourceService.addDataSourceWithPolygonFix(

--- a/src/services/building/buildingLoader.js
+++ b/src/services/building/buildingLoader.js
@@ -37,6 +37,8 @@ export class BuildingLoader {
 		this.unifiedLoader = unifiedLoader
 		/** @type {string|null} Currently loading layer ID for cancellation */
 		this._currentLoadingLayerId = null
+		/** @type {symbol|null} Unique per-invocation token used to detect stale loads */
+		this._currentLoadingToken = null
 	}
 
 	/**
@@ -62,10 +64,21 @@ export class BuildingLoader {
 			this.unifiedLoader.cancelLoading(this._currentLoadingLayerId)
 			this._currentLoadingLayerId = null
 		}
+		this._currentLoadingToken = null
 	}
 
-	_isStale(layerId) {
-		if (this._currentLoadingLayerId === layerId) return false
+	/**
+	 * Returns true when a newer load has superseded this invocation.
+	 * Each call to loadBuildings creates a unique Symbol token; as soon as
+	 * _currentLoadingToken is replaced by a subsequent call, any earlier
+	 * invocation sees a mismatch and treats itself as stale — including when
+	 * the same postal code is requested twice in quick succession.
+	 *
+	 * @param {symbol} token - The token captured at the start of a loadBuildings call
+	 * @returns {boolean}
+	 */
+	_isStale(token) {
+		if (this._currentLoadingToken === token) return false
 		logger.debug('[BuildingLoader] Navigation changed during load, discarding stale results')
 		return true
 	}
@@ -88,8 +101,12 @@ export class BuildingLoader {
 		logger.debug('[HelsinkiBuilding] Loading Helsinki buildings for postal code:', targetPostalCode)
 		logger.debug('[HelsinkiBuilding] API URL:', url)
 
-		// Track current load for cancellation support
+		// Track current load: layerId for unifiedLoader cancellation, token for staleness detection.
+		// Using a Symbol per invocation ensures two concurrent calls for the same postal code
+		// are distinguished — a non-unique layerId string would cause both to pass _isStale().
+		const loadToken = Symbol(layerId)
 		this._currentLoadingLayerId = layerId
+		this._currentLoadingToken = loadToken
 
 		try {
 			// Configure building data fetch
@@ -114,7 +131,7 @@ export class BuildingLoader {
 				this.urbanheatService.getHeatData(targetPostalCode),
 			])
 
-			if (this._isStale(layerId)) return null
+			if (this._isStale(loadToken)) return []
 
 			// Handle building data (required)
 			if (buildingResult.status === 'rejected') {
@@ -154,7 +171,7 @@ export class BuildingLoader {
 				'building features'
 			)
 
-			if (this._isStale(layerId)) return null
+			if (this._isStale(loadToken)) return []
 
 			// Create Cesium datasource with entities
 			const entities = await this.datasourceService.addDataSourceWithPolygonFix(
@@ -177,12 +194,14 @@ export class BuildingLoader {
 
 			// Clear tracking on successful load
 			this._currentLoadingLayerId = null
+			this._currentLoadingToken = null
 
 			return entities
 		} catch (error) {
 			// Clear tracking on error (but not on cancellation - already cleared)
-			if (this._currentLoadingLayerId === layerId) {
+			if (this._currentLoadingToken === loadToken) {
 				this._currentLoadingLayerId = null
+				this._currentLoadingToken = null
 			}
 			logger.error('[HelsinkiBuilding] Error loading buildings:', error)
 			throw error

--- a/src/services/building/buildingLoader.js
+++ b/src/services/building/buildingLoader.js
@@ -90,8 +90,8 @@ export class BuildingLoader {
 	 *
 	 * @param {string} [postalCode] - Optional postal code to load buildings for.
 	 *                                If not provided, uses current postal code from store.
-	 * @returns {Promise<Array|null>} Building entities, or null if the load was
-	 *                                superseded by a newer navigation (stale result).
+	 * @returns {Promise<Array>} Building entities, or an empty array if the load
+	 *                           was superseded by a newer navigation (stale result).
 	 */
 	async loadBuildings(postalCode) {
 		const targetPostalCode = postalCode || this.store.postalcode

--- a/src/services/wms.js
+++ b/src/services/wms.js
@@ -82,18 +82,13 @@ export default class Wms {
 			tilingScheme: new Cesium.GeographicTilingScheme(),
 		})
 
-		// Attach retry handler for transient network failures (ECONNRESET, etc.)
 		const errorHandler = (error) => {
 			this.retryHandler.handleTileError(error, layerName)
 		}
-		provider.errorEvent.addEventListener(errorHandler)
+		const removeErrorListener = provider.errorEvent.addEventListener(errorHandler)
 
 		const layer = new Cesium.ImageryLayer(provider)
-
-		// Store cleanup function on the layer so it can be called when the layer is removed
-		layer._removeErrorHandler = () => {
-			provider.errorEvent.removeEventListener(errorHandler)
-		}
+		layer._removeErrorHandler = removeErrorListener
 
 		return layer
 	}

--- a/src/stores/loadingStore.js
+++ b/src/stores/loadingStore.js
@@ -336,19 +336,28 @@ export const useLoadingStore = defineStore('loading', {
 				this.clearStaleLoading(timeout)
 			}, interval)
 
+			if (typeof window !== 'undefined' && !this._staleCleanupUnloadHandler) {
+				this._staleCleanupUnloadHandler = () => this.stopStaleCleanupTimer()
+				window.addEventListener('beforeunload', this._staleCleanupUnloadHandler, { once: true })
+			}
+
 			logger.debug(
 				`[loadingStore] Started stale cleanup timer (${interval}ms interval, ${timeout}ms timeout)`
 			)
 		},
 
 		/**
-		 * Stop automatic stale loading cleanup.
+		 * Stop automatic stale loading cleanup. Idempotent — safe to call multiple times.
 		 */
 		stopStaleCleanupTimer() {
 			if (this._staleCleanupTimer) {
 				clearInterval(this._staleCleanupTimer)
 				this._staleCleanupTimer = null
 				logger.debug('[loadingStore] Stopped stale cleanup timer')
+			}
+			if (typeof window !== 'undefined' && this._staleCleanupUnloadHandler) {
+				window.removeEventListener('beforeunload', this._staleCleanupUnloadHandler)
+				this._staleCleanupUnloadHandler = null
 			}
 		},
 


### PR DESCRIPTION
Addresses issues #681, #682, and #686:

- buildingLoader: discard stale Promise.allSettled results when navigation
  changes mid-load via _isStale helper (#681)
- wms: capture Cesium event remove-callback directly so error listeners
  detach deterministically when a layer is removed (#682)
- loadingStore: auto-clear stale-cleanup interval on beforeunload so the
  interval does not outlive the page (#682)
- backgroundPreloader: drop invalid passive flag on removeEventListener
  and null the bound handler so it can be GC'd (#682)
- featureFlagProvider: resolve the GOFF endpoint against the current origin
  so GoFeatureFlagWebProvider's internal new URL(endpoint) no longer throws
  on the bare /feature-flags proxy path (#686)

https://claude.ai/code/session_014wRULejZXqA96FYvNPEdbt