### PR TITLE
feat: typecheck job and improve CI/local testing setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,39 @@ jobs:
       - name: Run Biome lint
         run: bun run lint
 
-  # Build once and share across all browser-based test jobs
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.6 # Pinned for reproducible builds
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v5.0.4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run vue-tsc
+        run: bunx vue-tsc --noEmit
+
+  # Build once and share across all browser-based test jobs.
+  # VITE_E2E_TEST=true bakes the E2E test harness into the bundle
+  # (window.__viewer / window.__cesium hooks in useViewerInitialization.js)
+  # so downstream e2e/accessibility/performance jobs get the same viewer
+  # exposure that local `just test-e2e` relies on.
   build:
     name: Build Frontend
     runs-on: ubuntu-latest
@@ -62,6 +94,7 @@ jobs:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       VITE_DIGITRANSIT_KEY: ${{ secrets.DIGITRANSIT_KEY }}
+      VITE_E2E_TEST: 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -418,7 +451,16 @@ jobs:
     name: Test Summary
     runs-on: ubuntu-latest
     needs:
-      [lint, build, unit-tests, integration-tests, e2e-tests, accessibility-tests, security-scan]
+      [
+        lint,
+        typecheck,
+        build,
+        unit-tests,
+        integration-tests,
+        e2e-tests,
+        accessibility-tests,
+        security-scan,
+      ]
     if: always()
     steps:
       - name: Generate test summary
@@ -433,6 +475,15 @@ jobs:
             echo "- ⏭️ **Lint**: Skipped" >> $GITHUB_STEP_SUMMARY
           else
             echo "- ❌ **Lint**: Failed" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          # Typecheck
+          if [ "${{ needs.typecheck.result }}" == "success" ]; then
+            echo "- ✅ **Typecheck**: Passed" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.typecheck.result }}" == "skipped" ]; then
+            echo "- ⏭️ **Typecheck**: Skipped" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- ❌ **Typecheck**: Failed" >> $GITHUB_STEP_SUMMARY
           fi
 
           # Build

--- a/justfile
+++ b/justfile
@@ -273,6 +273,10 @@ format-check:
 typecheck:
     bunx vue-tsc --noEmit
 
+# Scan dependencies for known vulnerabilities (mirrors CI security-scan job)
+audit:
+    bun audit
+
 # Code quality gate (non-mutating, no tests)
 check: format-check lint typecheck
 
@@ -301,6 +305,16 @@ test-file file *args:
 [group: "testing"]
 test-accessibility *args:
     VITE_E2E_TEST=true bunx playwright test tests/e2e/accessibility/ --project=chromium --reporter=line {{ args }}
+
+# Run accessibility tests across all CI viewports (desktop, tablet, mobile)
+[group: "testing"]
+test-accessibility-all-viewports *args:
+    VITE_E2E_TEST=true bun run test:accessibility:all-viewports {{ args }}
+
+# Run accessibility tests for a single CI viewport (desktop | tablet | mobile)
+[group: "testing"]
+test-accessibility-viewport viewport *args:
+    VITE_E2E_TEST=true bun run test:accessibility:{{ viewport }} {{ args }}
 
 # Run tests in interactive UI mode for debugging
 [group: "testing"]

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -148,7 +148,7 @@ export default defineConfig({
 	webServer: process.env.CI
 		? undefined
 		: {
-				command: 'npm run dev:test',
+				command: 'bun run dev:test',
 				url: 'http://localhost:5173',
 				reuseExistingServer: true,
 			},


### PR DESCRIPTION
## Summary
This PR adds a dedicated typecheck job to the CI pipeline and improves the testing infrastructure by enabling E2E test harness in builds and adding new local testing commands.

## Key Changes

- **Add typecheck CI job**: New `typecheck` job runs `vue-tsc --noEmit` to catch TypeScript errors in the CI pipeline, with proper dependency caching and included in the test summary report

- **Enable E2E test harness in builds**: Set `VITE_E2E_TEST=true` in the build job to bake the E2E test harness into the bundle, ensuring downstream e2e/accessibility/performance jobs have consistent viewer exposure

- **Expand local testing commands**: Added new `justfile` commands:
  - `audit`: Run `bun audit` for dependency vulnerability scanning
  - `test-accessibility-all-viewports`: Run accessibility tests across all CI viewports (desktop, tablet, mobile)
  - `test-accessibility-viewport`: Run accessibility tests for a specific viewport

- **Update CI dependencies**: Update test summary job to include the new `typecheck` job in its dependency list and reporting

- **Fix dev server command**: Update `playwright.config.ts` to use `bun run dev:test` instead of `npm run dev:test` for consistency with the project's package manager

## Implementation Details

The typecheck job follows the same pattern as other CI jobs with:
- Bun 1.3.6 pinned for reproducible builds
- Dependency caching using `bun.lockb`
- Frozen lockfile installation to ensure consistency

The E2E test harness environment variable is documented in the build job comments to explain why it's needed for downstream test jobs.

https://claude.ai/code/session_01FJMThPpwHTTen9k3aLYS8s