### PR TITLE
chore(deploy): bump beta image to 1.48.0

### DIFF
--- a/deploy/values-beta.yaml
+++ b/deploy/values-beta.yaml
@@ -9,7 +9,7 @@
 # Application in infrastructure/argocd/apps/templates/regions4climate/).
 image:
   repository: ghcr.io/forumviriumhelsinki/r4c-cesium-viewer
-  tag: '1.47.0'
+  tag: '1.48.0'
 # Distinct release name to avoid Service/Deployment collisions with stable
 fullnameOverride: r4c-cesium-viewer-beta
 imagePullSecrets:


### PR DESCRIPTION
## Summary

- Restores `r4c-beta.dataportal.fi` (currently 503) by pointing `deploy/values-beta.yaml` at a tag that actually exists in GHCR.
- `1.47.0` was never published because that release hit the `buildkit-cache-dance@v3.3.2` EACCES bug (fixed by #700 after the fact).
- `1.48.0` was cut on 2026-04-21 using the new reusable pipeline; the image is live on GHCR (`sha256:72969995bfced306f62255e36a2ba3ed0c180fb378fffa1192246671d58a7f88`). The `Container Release` run shows `failure` only because its Trivy-scan step failed **after** `Promote PR image to release tags` succeeded.

## Test plan

- [ ] ArgoCD `r4c-cesium-viewer-beta` syncs to 1.48.0 after merge
- [ ] `curl -sI https://r4c-beta.dataportal.fi/` → 200
- [ ] Browser smoke: map loads, dark-mode toggle, newest `main` features work
- [ ] Prod (`r4c.dataportal.fi`) remains on 1.22.6 — unaffected

## Related

- Refs: ForumViriumHelsinki/infrastructure#1701 — outage tracking
- Refs: ForumViriumHelsinki/infrastructure#1673 — Image Updater GHCR write-back failure (why this bump is manual)
- Context: #699 (the 1.47.0 bump that exposed the broken build), #700 (migrated to reusable workflows)
