### PR TITLE
fix(ci): clear pre-existing lint failure and unblock typecheck cleanup

### DIFF
--- a/src/components/BackgroundMapBrowser.vue
+++ b/src/components/BackgroundMapBrowser.vue
@@ -278,8 +278,8 @@
 
 <script>
 import { computed, onMounted, ref, watch } from 'vue'
-import { createFloodImageryLayer, removeFloodLayers } from '../services/floodwms'
 import { getCesium } from '../services/cesiumProvider'
+import { createFloodImageryLayer, removeFloodLayers } from '../services/floodwms'
 import { useBackgroundMapStore } from '../stores/backgroundMapStore'
 import { useFeatureFlagStore } from '../stores/featureFlagStore'
 import { useGlobalStore } from '../stores/globalStore'
@@ -538,8 +538,7 @@ export default {
 				// race conditions where both layers end up on the map simultaneously.
 				removeLayer(hsyMapLayer, 'Error removing previous HSY imagery layer:')
 
-				hsyMapLayer.value =
-					globalStore.cesiumViewer.imageryLayers.addImageryProvider(provider)
+				hsyMapLayer.value = globalStore.cesiumViewer.imageryLayers.addImageryProvider(provider)
 				logger.debug('[BackgroundMapBrowser] HSY layer added:', layer.name)
 			} catch (error) {
 				logger.error('Error creating HSY imagery layer:', error)

--- a/src/components/Layers.vue
+++ b/src/components/Layers.vue
@@ -342,10 +342,7 @@ export default {
 				toggleStore.setNDVI(false)
 				removeTIFF().catch((error) => {
 					logger.error('[Layers] Failed to hide NDVI when switching to landcover:', error)
-					store.showError(
-						'Unable to hide NDVI imagery.',
-						`NDVI removal failed: ${error.message}`
-					)
+					store.showError('Unable to hide NDVI imagery.', `NDVI removal failed: ${error.message}`)
 				})
 			}
 		}
@@ -386,19 +383,13 @@ export default {
 			if (ndvi.value) {
 				changeTIFF().catch((error) => {
 					logger.error('[Layers] Failed to load NDVI imagery:', error)
-					store.showError(
-						'Unable to load NDVI imagery.',
-						`NDVI load failed: ${error.message}`
-					)
+					store.showError('Unable to load NDVI imagery.', `NDVI load failed: ${error.message}`)
 				})
 				eventBus.emit('addNDVI')
 			} else {
 				removeTIFF().catch((error) => {
 					logger.error('[Layers] Failed to hide NDVI imagery:', error)
-					store.showError(
-						'Unable to hide NDVI imagery.',
-						`NDVI removal failed: ${error.message}`
-					)
+					store.showError('Unable to hide NDVI imagery.', `NDVI removal failed: ${error.message}`)
 				})
 			}
 		}

--- a/src/services/viewportBuildingLoader.js
+++ b/src/services/viewportBuildingLoader.js
@@ -668,10 +668,7 @@ export default class ViewportBuildingLoader {
 								`[ViewportBuildingLoader] Heat data fetch failed:`,
 								error?.message || error
 							)
-							this.loadingStore.setLayerError(
-								'heatData',
-								error?.message || 'Heat data unavailable'
-							)
+							this.loadingStore.setLayerError('heatData', error?.message || 'Heat data unavailable')
 							return null
 						})
 					: Promise.resolve(null),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,10 @@
 		"paths": {
 			"@/*": ["./src/*"]
 		},
+		// Silence the TS5101 deprecation warning for `baseUrl` until a follow-up
+		// PR migrates to `paths`-only resolution. Required for TypeScript 6.x;
+		// `baseUrl` is removed in TypeScript 7.0.
+		"ignoreDeprecations": "6.0",
 
 		// Library types
 		"lib": ["ES2020", "DOM", "DOM.Iterable"]


### PR DESCRIPTION
## Context

Two CI jobs have been failing on `main`, blocking accurate CI status
on every downstream PR. Failing run:
https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/actions/runs/25430900043

This PR fully fixes **Lint** and partially addresses **Typecheck** —
clearing the deprecation halt that was masking ~953 pre-existing type
errors. Cleanup of those errors is tracked in a follow-up.

Other failures from the same run are tracked separately:

- Unit Tests → #718
- Security Scan → #719
- Typecheck masked-errors cleanup → #721 (created from this PR's CI run)

## Changes

### 1. Lint — biome formatter + organize-imports (✅ green)

Mechanical autofixes from `bunx biome check --write src/`:

- `src/components/BackgroundMapBrowser.vue` — organize-imports +
  collapse multi-line `addImageryProvider` call.
- `src/components/Layers.vue` — collapse three multi-line
  `store.showError(...)` calls into single-line form.
- `src/services/viewportBuildingLoader.js` — collapse multi-line
  `loadingStore.setLayerError('heatData', ...)` call.

### 2. Typecheck — silence TS5101 deprecation (⚠️ partial)

Add `"ignoreDeprecations": "6.0"` to `tsconfig.json`. TypeScript 5.5+
deprecates `baseUrl` and removes it in TS 7.0. The deprecation halts
vue-tsc at config-load time before any source-file checks. Silencing
it lets the typecheck proceed.

**This change will not turn Typecheck green on its own** — it surfaces
~953 pre-existing type errors across ~113 files that were always
present but masked by the early exit. See #721 for the full cleanup
plan: pin `vue-tsc`/`typescript`, bucket the errors by category, and
migrate `baseUrl` → `paths`-only.

The deprecation fix is included here (rather than in #721) because:

1. It is the proximate cause of the existing CI failure.
2. Without it, #721 cannot be worked — the masked errors stay invisible.
3. It is the canonical migration step documented by the TS team.

## Verification

- `bun run lint` — exits 0
- `bunx vue-tsc --noEmit` — clears TS5101; surfaces the ~953 masked
  errors tracked in #721