### PR TITLE
fix(charts): guard SocioEconomicsChart against undefined heatData

### DIFF
--- a/src/components/SocioEconomicsChart.vue
+++ b/src/components/SocioEconomicsChart.vue
@@ -12,6 +12,7 @@ import { useHeatExposureStore } from '../stores/heatExposureStore.js'
 import { usePropsStore } from '../stores/propsStore.js'
 import { useSocioEconomicsStore } from '../stores/socioEconomicsStore.js'
 import { useToggleStore } from '../stores/toggleStore.js'
+import { logger } from '../utils/logger.js'
 
 export default {
 	setup() {
@@ -178,7 +179,19 @@ export default {
 				const compareHeatData = helsinkiOrCapitalHeatExposure(
 					heatExposureStore.getDataById(compareData.postinumeroalue)
 				)
-				const compareValues = calculateYValues(compareData, statsData, compareHeatData)
+				// Skip the comparison series when heat exposure data for the
+				// compared postal code is missing — otherwise null values
+				// would propagate into d3 scale/axis computation.
+				const hasCompareHeatData = compareHeatData != null
+				const compareValues = hasCompareHeatData
+					? calculateYValues(compareData, statsData, compareHeatData)
+					: []
+				if (!hasCompareHeatData) {
+					logger.debug(
+						'[SocioEconomicsChart] Skipping comparison series; no heat exposure data for',
+						compareData.postinumeroalue
+					)
+				}
 				// Combine both yValues and compareValues arrays
 				const allYValues = yValues.concat(compareValues)
 				const xScale = plotService.createScaleBand(xLabels, width - 50)
@@ -186,26 +199,27 @@ export default {
 				setupAxes(svg, xScale, yScale, height)
 
 				const barData = yValues.map((value, index) => ({ value, label: xLabels[index] }))
-				const compareBarData = compareValues.map((value, index) => ({
-					value,
-					label: xLabels[index],
-				}))
-
 				const tooltip = plotService.createTooltip('#socioeonomicsContainer')
 				createBars(svg, barData, xScale, yScale, height, tooltip, 0, 'lightblue', sosData.nimi)
 
-				const xOffsetForCompareData = xScale.bandwidth() / 2.5 // Adjust as needed for proper spacing
-				createBars(
-					svg,
-					compareBarData,
-					xScale,
-					yScale,
-					height,
-					tooltip,
-					xOffsetForCompareData,
-					'orange',
-					selectedNimi
-				)
+				if (hasCompareHeatData) {
+					const compareBarData = compareValues.map((value, index) => ({
+						value,
+						label: xLabels[index],
+					}))
+					const xOffsetForCompareData = xScale.bandwidth() / 2.5 // Adjust as needed for proper spacing
+					createBars(
+						svg,
+						compareBarData,
+						xScale,
+						yScale,
+						height,
+						tooltip,
+						xOffsetForCompareData,
+						'orange',
+						selectedNimi
+					)
+				}
 
 				plotService.addTitleWithLink(
 					svg,
@@ -240,6 +254,13 @@ export default {
 		}
 
 		const helsinkiOrCapitalHeatExposure = (heatData) => {
+			// Guard: heat exposure data may be undefined when the store hasn't
+			// loaded yet (e.g. compareData postal code not present in
+			// heatExposureStore). Return null so the caller can skip the
+			// comparison cleanly. See Sentry REGIONS4CLIMATE-2C.
+			if (heatData?.properties == null) {
+				return null
+			}
 			return toggleStore.capitalRegionCold
 				? 1 - heatData.properties.avgcoldexposure.toFixed(3)
 				: toggleStore.helsinkiView

--- a/tests/unit/components/SocioEconomicsChart.test.js
+++ b/tests/unit/components/SocioEconomicsChart.test.js
@@ -1,0 +1,156 @@
+/**
+ * Regression test for #728: SocioEconomicsChart must not throw when the
+ * heatExposure store has no data for the compared postal code.
+ *
+ * Sentry: REGIONS4CLIMATE-2C
+ * @see {@link file://./src/components/SocioEconomicsChart.vue}
+ */
+
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Stub the plot service — its d3 internals don't matter for this regression,
+// only that calling them does not propagate the unguarded toFixed() throw.
+vi.mock('@/services/plot.js', () => {
+	const Plot = vi.fn(function () {
+		this.initializePlotContainerForGrid = vi.fn()
+		this.createSVGElement = vi.fn(() => ({
+			append: vi.fn().mockReturnThis(),
+			attr: vi.fn().mockReturnThis(),
+			call: vi.fn().mockReturnThis(),
+			selectAll: vi.fn().mockReturnThis(),
+			data: vi.fn().mockReturnThis(),
+			enter: vi.fn().mockReturnThis(),
+			exit: vi.fn().mockReturnThis(),
+			remove: vi.fn().mockReturnThis(),
+			on: vi.fn().mockReturnThis(),
+			style: vi.fn().mockReturnThis(),
+			text: vi.fn().mockReturnThis(),
+		}))
+		this.createScaleBand = vi.fn(() => ({ bandwidth: () => 10 }))
+		this.createScaleLinear = vi.fn(() => vi.fn())
+		this.createTooltip = vi.fn()
+		this.handleMouseover = vi.fn()
+		this.handleMouseout = vi.fn()
+		this.addTitleWithLink = vi.fn()
+	})
+	return { default: Plot }
+})
+
+// Stub eventBus — the component subscribes on mount; we don't need the real one.
+vi.mock('@/services/eventEmitter.js', () => ({
+	eventBus: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+}))
+
+// Stub stores with the exact shape the component reads. Keeping them inline
+// (instead of using the real Pinia definitions) avoids depending on cross-store
+// initialization that isn't relevant to this regression.
+vi.mock('@/stores/globalStore.js', () => ({
+	useGlobalStore: () => ({
+		postalcode: '00100',
+		view: 'helsinki',
+		nameOfZone: 'Test Zone',
+		navbarWidth: 400,
+		averageHeatExposure: 0.5,
+	}),
+}))
+
+vi.mock('@/stores/toggleStore.js', () => ({
+	useToggleStore: () => ({
+		capitalRegionCold: false,
+		helsinkiView: true,
+	}),
+}))
+
+vi.mock('@/stores/propsStore.js', () => ({
+	usePropsStore: () => ({
+		socioEconomics: 'Test Nimi',
+	}),
+}))
+
+const heatExposureGetDataById = vi.fn(() => undefined)
+vi.mock('@/stores/heatExposureStore.js', () => ({
+	useHeatExposureStore: () => ({
+		getDataById: heatExposureGetDataById,
+	}),
+}))
+
+const sosDataFixture = {
+	nimi: 'Test Nimi',
+	he_0_2: 10,
+	he_3_6: 10,
+	he_7_12: 10,
+	he_65_69: 5,
+	he_70_74: 5,
+	he_80_84: 5,
+	he_85_: 5,
+	he_vakiy: 100,
+	pt_tyott: 5,
+	ra_as_kpa: 50,
+	ko_perus: 10,
+	ko_ika18y: 80,
+	hr_ktu: 30000,
+	te_vuok_as: 10,
+	te_taly: 50,
+}
+
+const compareDataFixture = {
+	...sosDataFixture,
+	nimi: 'Compare Nimi',
+	postinumeroalue: '00200',
+}
+
+const statsFixture = {
+	ra_as_kpa: { min: 0, max: 100 },
+	hr_ktu: { min: 0, max: 60000 },
+}
+
+vi.mock('@/stores/socioEconomicsStore.js', () => ({
+	useSocioEconomicsStore: () => ({
+		getDataByPostcode: vi.fn(() => sosDataFixture),
+		getDataByNimi: vi.fn(() => compareDataFixture),
+		helsinkiStatistics: statsFixture,
+		regionStatistics: statsFixture,
+	}),
+}))
+
+import SocioEconomicsChart from '@/components/SocioEconomicsChart.vue'
+
+describe('SocioEconomicsChart — #728 heatData guard', { tags: ['@unit'] }, () => {
+	let wrapper
+
+	beforeEach(() => {
+		setActivePinia(createPinia())
+		heatExposureGetDataById.mockClear()
+	})
+
+	afterEach(() => {
+		if (wrapper) wrapper.unmount()
+	})
+
+	it('does not throw when heatExposureStore.getDataById returns undefined', () => {
+		// Pre-regression: heatExposureStore.getDataById returning undefined
+		// caused helsinkiOrCapitalHeatExposure to do undefined.properties.X
+		// and crash (Sentry REGIONS4CLIMATE-2C).
+		heatExposureGetDataById.mockReturnValue(undefined)
+
+		expect(() => {
+			wrapper = mount(SocioEconomicsChart, {
+				attachTo: document.body,
+			})
+		}).not.toThrow()
+	})
+
+	it('does not throw when the heat-exposure entry exists but has no properties', () => {
+		// Sibling regression: an entry that exists but lacks `.properties`
+		// (e.g. a stub or in-flight record) must also be handled.
+		heatExposureGetDataById.mockReturnValue({})
+
+		expect(() => {
+			wrapper = mount(SocioEconomicsChart, {
+				attachTo: document.body,
+			})
+		}).not.toThrow()
+	})
+})


### PR DESCRIPTION
## Summary

- Guard `helsinkiOrCapitalHeatExposure()` against `undefined`/`null` `heatData.properties` (Sentry REGIONS4CLIMATE-2C, 2 users affected).
- Update caller `createSocioEconomicsDiagram` to skip the comparison series when the guard returns `null` instead of feeding nulls into d3 scale/axis math.
- Add a Vitest regression test (`SocioEconomicsChart.test.js`) that mounts the component with the heat-exposure store stubbed to return `undefined` and asserts no throw. Verified failing without the guard.

## Test plan

- [x] `bunx vitest run tests/unit/components/SocioEconomicsChart.test.js` — 2/2 pass.
- [x] Verified the regression test fails when the guard is removed.
- [x] Full unit suite still green (762 pass, 4 skipped — same as `main`).
- [ ] Smoke test the Helsinki/capital toggle on a postal code with missing comparison data once deployed to beta.

Closes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)