### PR TITLE
test(services): fix sensor/traveltime fetch mocks to preserve statusText

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ k8s/migration-secret.yaml
 
 # Claude Code local settings
 .claude/settings.local.json
+.claude/worktrees/
 
 # Auto-generated TypeScript declaration files
 src/auto-imports.d.ts

--- a/tests/unit/services/sensor.test.js
+++ b/tests/unit/services/sensor.test.js
@@ -85,9 +85,9 @@ describe('Sensor Service - Error Handling', { tags: ['@unit', '@sensor'] }, () =
 
 		it('should handle invalid JSON response', async () => {
 			// Arrange
-			global.fetch.mockResolvedValue({
-				json: vi.fn().mockRejectedValue(new Error('Invalid JSON')),
-			})
+			const response = new Response('invalid', { status: 200, statusText: 'OK' })
+			response.json = vi.fn().mockRejectedValue(new Error('Invalid JSON'))
+			global.fetch.mockResolvedValue(response)
 
 			// Act & Assert
 			await expect(sensor.loadSensorData()).rejects.toThrow('Invalid JSON')
@@ -102,18 +102,17 @@ describe('Sensor Service - Error Handling', { tags: ['@unit', '@sensor'] }, () =
 		})
 
 		it.each([
-			[404, 'Not found'],
-			[500, 'Server error'],
-			[503, 'Service unavailable'],
-		])('should handle %i HTTP error (%s)', async (status, message) => {
+			[404, 'Not Found'],
+			[500, 'Internal Server Error'],
+			[503, 'Service Unavailable'],
+		])('should handle %i HTTP error (%s)', async (status, statusText) => {
 			// Arrange
-			global.fetch.mockResolvedValue({
-				status,
-				json: vi.fn().mockRejectedValue(new Error(message)),
-			})
+			const response = new Response('error', { status, statusText })
+			global.fetch.mockResolvedValue(response)
 
 			// Act & Assert
-			await expect(sensor.loadSensorData()).rejects.toThrow(message)
+			// Service throws HTTP error format, not the mocked json error
+			await expect(sensor.loadSensorData()).rejects.toThrow(`HTTP ${status}: ${statusText}`)
 		})
 
 		it('should handle connection timeout', async () => {
@@ -126,9 +125,9 @@ describe('Sensor Service - Error Handling', { tags: ['@unit', '@sensor'] }, () =
 
 		it('should handle malformed GeoJSON from sensor API', async () => {
 			// Arrange: Return invalid GeoJSON
-			global.fetch.mockResolvedValue({
-				json: vi.fn().mockResolvedValue({ invalid: 'structure' }),
-			})
+			const response = new Response(JSON.stringify({ invalid: 'structure' }), { status: 200, statusText: 'OK' })
+			response.json = vi.fn().mockResolvedValue({ invalid: 'structure' })
+			global.fetch.mockResolvedValue(response)
 			sensor.addSensorDataSource = vi.fn().mockRejectedValue(new Error('Invalid GeoJSON format'))
 
 			// Act & Assert
@@ -171,16 +170,18 @@ describe('Sensor Service - Error Handling', { tags: ['@unit', '@sensor'] }, () =
 					},
 				],
 			}
-			global.fetch.mockResolvedValue({
-				json: vi.fn().mockResolvedValue(mockData),
-			})
+			const response = new Response(JSON.stringify(mockData), { status: 200, statusText: 'OK' })
+			response.json = vi.fn().mockResolvedValue(mockData)
+			global.fetch.mockResolvedValue(response)
 			sensor.addSensorDataSource = vi.fn().mockResolvedValue()
 
 			// Act
 			await sensor.loadSensorData()
 
 			// Assert
-			expect(global.fetch).toHaveBeenCalledWith('https://bri3.fvh.io/opendata/r4c/r4c_last.geojson')
+			expect(global.fetch).toHaveBeenCalledWith(
+				'https://bri3.fvh.io/opendata/r4c/r4c_all_latest.geojson'
+			)
 			expect(sensor.addSensorDataSource).toHaveBeenCalledWith(mockData)
 		})
 	})

--- a/tests/unit/services/sensor.test.js
+++ b/tests/unit/services/sensor.test.js
@@ -125,8 +125,10 @@ describe('Sensor Service - Error Handling', { tags: ['@unit', '@sensor'] }, () =
 
 		it('should handle malformed GeoJSON from sensor API', async () => {
 			// Arrange: Return invalid GeoJSON
-			const response = new Response(JSON.stringify({ invalid: 'structure' }), { status: 200, statusText: 'OK' })
-			response.json = vi.fn().mockResolvedValue({ invalid: 'structure' })
+			const response = new Response(JSON.stringify({ invalid: 'structure' }), {
+				status: 200,
+				statusText: 'OK',
+			})
 			global.fetch.mockResolvedValue(response)
 			sensor.addSensorDataSource = vi.fn().mockRejectedValue(new Error('Invalid GeoJSON format'))
 
@@ -171,7 +173,6 @@ describe('Sensor Service - Error Handling', { tags: ['@unit', '@sensor'] }, () =
 				],
 			}
 			const response = new Response(JSON.stringify(mockData), { status: 200, statusText: 'OK' })
-			response.json = vi.fn().mockResolvedValue(mockData)
 			global.fetch.mockResolvedValue(response)
 			sensor.addSensorDataSource = vi.fn().mockResolvedValue()
 

--- a/tests/unit/services/traveltime.test.js
+++ b/tests/unit/services/traveltime.test.js
@@ -171,7 +171,6 @@ describe('Traveltime Service - Error Handling', { tags: ['@unit', '@traveltime']
 				features: [{ properties: {} }], // Missing travel_data
 			}
 			const response = new Response(JSON.stringify(mockData), { status: 200, statusText: 'OK' })
-			response.json = vi.fn().mockResolvedValue(mockData)
 			global.fetch.mockResolvedValue(response)
 
 			// Act & Assert: addTravelTimeLabels receives undefined but handles it
@@ -186,7 +185,6 @@ describe('Traveltime Service - Error Handling', { tags: ['@unit', '@traveltime']
 				features: [{ properties: { travel_data: [] } }], // Empty but present
 			}
 			const response = new Response(JSON.stringify(mockData), { status: 200, statusText: 'OK' })
-			response.json = vi.fn().mockResolvedValue(mockData)
 			global.fetch.mockResolvedValue(response)
 			traveltime.addTravelTimeLabels = vi.fn()
 
@@ -204,7 +202,6 @@ describe('Traveltime Service - Error Handling', { tags: ['@unit', '@traveltime']
 				features: [], // Empty array
 			}
 			const response = new Response(JSON.stringify(mockData), { status: 200, statusText: 'OK' })
-			response.json = vi.fn().mockResolvedValue(mockData)
 			global.fetch.mockResolvedValue(response)
 
 			// Act & Assert: Should throw when accessing features[0]
@@ -261,7 +258,6 @@ describe('Traveltime Service - Error Handling', { tags: ['@unit', '@traveltime']
 				],
 			}
 			const response = new Response(JSON.stringify(mockData), { status: 200, statusText: 'OK' })
-			response.json = vi.fn().mockResolvedValue(mockData)
 			global.fetch.mockResolvedValue(response)
 			traveltime.addTravelTimeLabels = vi.fn()
 

--- a/tests/unit/services/traveltime.test.js
+++ b/tests/unit/services/traveltime.test.js
@@ -156,9 +156,9 @@ describe('Traveltime Service - Error Handling', { tags: ['@unit', '@traveltime']
 
 		it('should handle invalid JSON response', async () => {
 			// Arrange
-			global.fetch.mockResolvedValue({
-				json: vi.fn().mockRejectedValue(new Error('Invalid JSON')),
-			})
+			const response = new Response('invalid', { status: 200, statusText: 'OK' })
+			response.json = vi.fn().mockRejectedValue(new Error('Invalid JSON'))
+			global.fetch.mockResolvedValue(response)
 
 			// Act & Assert
 			await expect(traveltime.loadTravelTimeData(5975375)).rejects.toThrow('Invalid JSON')
@@ -166,12 +166,13 @@ describe('Traveltime Service - Error Handling', { tags: ['@unit', '@traveltime']
 
 		it('should handle missing travel_data property gracefully', async () => {
 			// Arrange: Return data without travel_data
-			global.fetch.mockResolvedValue({
-				json: vi.fn().mockResolvedValue({
-					type: 'FeatureCollection',
-					features: [{ properties: {} }], // Missing travel_data
-				}),
-			})
+			const mockData = {
+				type: 'FeatureCollection',
+				features: [{ properties: {} }], // Missing travel_data
+			}
+			const response = new Response(JSON.stringify(mockData), { status: 200, statusText: 'OK' })
+			response.json = vi.fn().mockResolvedValue(mockData)
+			global.fetch.mockResolvedValue(response)
 
 			// Act & Assert: addTravelTimeLabels receives undefined but handles it
 			// gracefully since the entity loop is empty (no entities to process)
@@ -184,9 +185,9 @@ describe('Traveltime Service - Error Handling', { tags: ['@unit', '@traveltime']
 				type: 'FeatureCollection',
 				features: [{ properties: { travel_data: [] } }], // Empty but present
 			}
-			global.fetch.mockResolvedValue({
-				json: vi.fn().mockResolvedValue(mockData),
-			})
+			const response = new Response(JSON.stringify(mockData), { status: 200, statusText: 'OK' })
+			response.json = vi.fn().mockResolvedValue(mockData)
+			global.fetch.mockResolvedValue(response)
 			traveltime.addTravelTimeLabels = vi.fn()
 
 			// Act: Should not throw
@@ -198,30 +199,32 @@ describe('Traveltime Service - Error Handling', { tags: ['@unit', '@traveltime']
 
 		it('should handle empty features array', async () => {
 			// Arrange
-			global.fetch.mockResolvedValue({
-				json: vi.fn().mockResolvedValue({
-					type: 'FeatureCollection',
-					features: [], // Empty array
-				}),
-			})
+			const mockData = {
+				type: 'FeatureCollection',
+				features: [], // Empty array
+			}
+			const response = new Response(JSON.stringify(mockData), { status: 200, statusText: 'OK' })
+			response.json = vi.fn().mockResolvedValue(mockData)
+			global.fetch.mockResolvedValue(response)
 
 			// Act & Assert: Should throw when accessing features[0]
 			await expect(traveltime.loadTravelTimeData(5975375)).rejects.toThrow()
 		})
 
 		it.each([
-			[404, 'Not found'],
-			[500, 'Server error'],
-			[503, 'Service unavailable'],
-		])('should handle %i HTTP error (%s)', async (status, message) => {
+			[404, 'Not Found'],
+			[500, 'Internal Server Error'],
+			[503, 'Service Unavailable'],
+		])('should handle %i HTTP error (%s)', async (status, statusText) => {
 			// Arrange
-			global.fetch.mockResolvedValue({
-				status,
-				json: vi.fn().mockRejectedValue(new Error(message)),
-			})
+			const response = new Response('error', { status, statusText })
+			global.fetch.mockResolvedValue(response)
 
 			// Act & Assert
-			await expect(traveltime.loadTravelTimeData(5975375)).rejects.toThrow(message)
+			// Service throws HTTP error format, not the mocked json error
+			await expect(traveltime.loadTravelTimeData(5975375)).rejects.toThrow(
+				`HTTP ${status}: ${statusText}`
+			)
 		})
 
 		it('should handle invalid from_id parameter', async () => {
@@ -257,9 +260,9 @@ describe('Traveltime Service - Error Handling', { tags: ['@unit', '@traveltime']
 					},
 				],
 			}
-			global.fetch.mockResolvedValue({
-				json: vi.fn().mockResolvedValue(mockData),
-			})
+			const response = new Response(JSON.stringify(mockData), { status: 200, statusText: 'OK' })
+			response.json = vi.fn().mockResolvedValue(mockData)
+			global.fetch.mockResolvedValue(response)
 			traveltime.addTravelTimeLabels = vi.fn()
 
 			// Act


### PR DESCRIPTION
## Summary

- Repair 13 unit-test failures (now 0) in `tests/unit/services/{sensor,traveltime}.test.js` by replacing plain-object fetch mocks with real `new Response(body, { status, statusText })` instances so the service's `HTTP <status>: <statusText>` error format is reproduced.
- Update `it.each` HTTP-error assertions to use real `statusText` values (`Not Found`, `Internal Server Error`, `Service Unavailable`) since the service throws **before** calling `.json()` when `!response.ok` — the previous rejected-JSON mocks were never reached.
- Fix sensor success-path URL assertion: the URL store now serves `r4c_all_latest.geojson` (renamed from `r4c_last.geojson`) and the test had drifted.
- Address review feedback from @gemini-code-assist: drop redundant `response.json` mocks on success paths — the `Response` constructor already parses the stringified body natively. Rejection-path mocks are retained (they must throw).
- Add `.claude/worktrees/` to `.gitignore` so the pre-commit biome hook stops descending into other agents' local worktree checkouts (no impact on CI, where the directory does not exist).

## Test plan

- [x] `bunx vitest run tests/unit/services/sensor.test.js tests/unit/services/traveltime.test.js` — 27/27 pass.
- [x] Full unit suite — 762 pass, 4 skipped, 0 fail.
- [x] Failing CI run that exposed this: https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/actions/runs/25430900043/job/74596611342

Closes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)