### PR TITLE
docs(testing): cross-reference Mock API limitations from TESTING.md

### DIFF
--- a/docs/core/TESTING.md
+++ b/docs/core/TESTING.md
@@ -113,6 +113,8 @@ npm run test:e2e -- --headed  # With browser UI
 npm run test:e2e -- --debug   # Debug mode
 ```
 
+> **Mock API mode caveats:** when E2E tests run against the mock backend (`just dev-mock`), some endpoints return synthetic fixtures rather than full production-shaped data. See [Mock API Limitations](../GETTING_STARTED.md#mock-api-limitations) for the list of unsupported queries and the recommended fallback (`just dev` with a seeded DB) when a test exercises those code paths.
+
 ### 3a. Accessibility Tests (`tests/e2e/accessibility/`)
 
 Comprehensive accessibility testing for WCAG compliance and keyboard navigation.


### PR DESCRIPTION
## Summary
- Adds a callout in `docs/core/TESTING.md` linking to the existing **Mock API Limitations** section in `docs/GETTING_STARTED.md`.
- Closes the documentation gap flagged by #659 (limitations were already documented, but TESTING.md had no pointer).

## Test plan
- [x] Section anchor `#mock-api-limitations` exists in `docs/GETTING_STARTED.md:131`
- [ ] Render preview on GitHub confirms the relative link resolves

Closes #659