### PR TITLE
chore: sync CI/CD rule and blueprint manifest to v3.3

### DIFF
--- a/.claude/rules/development.md
+++ b/.claude/rules/development.md
@@ -78,6 +78,11 @@ bun run lint:fix # Biome auto-fix
 
 ## CI/CD
 
-- `container-build.yml` - Builds and pushes to GHCR on push to main and tags
-- `release-please.yml` - Manages releases and CHANGELOG via conventional commits
-- `lighthouse-ci.yml` - Performance monitoring on PRs
+Container build/release use the org reusable workflows (`ForumViriumHelsinki/.github`) with a build-once/promote pattern.
+
+- `container-build.yml` — calls `reusable-container-build.yml` on release-please PRs; produces a `:next-{version}` pre-release image
+- `container-release.yml` — calls `reusable-container-release.yml` on `release: published`; promotes the pre-release image to semver tags via manifest retag (seconds, not minutes), with a full rebuild as fallback
+- `release-please.yml` — manages releases and CHANGELOG via conventional commits
+- `lighthouse.yml` — performance monitoring on PRs
+
+Sentry build args (`SENTRY_AUTH_TOKEN`, `VITE_SENTRY_DSN`) reach the build via the reusable workflows' `secret-build-args` passthrough — secrets cannot flow through plain `inputs.build-args` on reusable-workflow callers.

--- a/docs/blueprint/manifest.json
+++ b/docs/blueprint/manifest.json
@@ -1,7 +1,7 @@
 {
-  "format_version": "3.2.0",
+  "format_version": "3.3.0",
   "created_at": "2026-03-19T17:20:29Z",
-  "updated_at": "2026-03-20T05:58:20Z",
+  "updated_at": "2026-04-17T10:05:15Z",
   "created_by": {
     "blueprint_plugin": "3.2.0"
   },
@@ -142,5 +142,17 @@
       "stats": {},
       "context": {}
     }
-  }
+  },
+  "upgrade_history": [
+    {
+      "from": "3.2.0",
+      "to": "3.3.0",
+      "date": "2026-04-17T10:05:15Z",
+      "changes": [
+        "Added workspaces block for monorepo support",
+        "Enabled cross-workspace cross-references (`<path>/ADR-NNN`, `/ADR-NNN`)",
+        "Optional: implemented_by portfolio links in feature-tracker.json"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
Two unrelated working-tree edits made in earlier sessions, batched into one PR because each is too small to merit a standalone PR:

- **\`.claude/rules/development.md\`** — rewrite the CI/CD section to describe the build-once/promote pattern via the org reusable workflows. \`container-build.yml\` calls \`reusable-container-build.yml\` on release-please PRs producing \`:next-{version}\`; \`container-release.yml\` calls \`reusable-container-release.yml\` on \`release: published\` and promotes via manifest retag. Adds the Sentry build-args caveat (\`SENTRY_AUTH_TOKEN\` / \`VITE_SENTRY_DSN\` flow through \`secret-build-args\`, not \`inputs.build-args\`).
- **\`docs/blueprint/manifest.json\`** — bump \`format_version\` 3.2.0 → 3.3.0 and append the \`upgrade_history\` entry. v3.3 adds the \`workspaces\` block for monorepo support, cross-workspace cross-references, and optional \`implemented_by\` portfolio links. Matches what \`/blueprint:upgrade\` writes for a v3.2 → v3.3 migration.

## Test plan
- [x] Pre-commit hooks pass locally (Biome, prettier, JSON check, conventional-commit)
- [ ] CI checks pass on the PR