### PR TITLE
fix(charts): guard SocioEconomicsChart against undefined compareData (#733)

### DIFF
--- a/src/components/SocioEconomicsChart.vue
+++ b/src/components/SocioEconomicsChart.vue
@@ -189,8 +189,10 @@ export default {
 						: null
 				// Skip the comparison series when either the compared record or
 				// its heat exposure data is missing — otherwise null values would
-				// propagate into d3 scale/axis computation.
-				const hasCompareSeries = compareData != null && compareHeatData != null
+				// propagate into d3 scale/axis computation. The compareData ==
+				// null case already coerces compareHeatData to null via the
+				// ternary above, so the single check is sufficient.
+				const hasCompareSeries = compareHeatData != null
 				const compareValues = hasCompareSeries
 					? calculateYValues(compareData, statsData, compareHeatData)
 					: []

--- a/src/components/SocioEconomicsChart.vue
+++ b/src/components/SocioEconomicsChart.vue
@@ -176,20 +176,28 @@ export default {
 					: globalStore.averageHeatExposure.toFixed(3) // Use heat exposure data
 
 				const yValues = calculateYValues(sosData, statsData, heatData)
-				const compareHeatData = helsinkiOrCapitalHeatExposure(
-					heatExposureStore.getDataById(compareData.postinumeroalue)
-				)
-				// Skip the comparison series when heat exposure data for the
-				// compared postal code is missing — otherwise null values
-				// would propagate into d3 scale/axis computation.
-				const hasCompareHeatData = compareHeatData != null
-				const compareValues = hasCompareHeatData
+				// Guard: compareData may be undefined when getDataByNimi finds no
+				// matching record (e.g. first load before a comparison area is
+				// selected, or propsStore.socioEconomics pointing at a stale nimi).
+				// Accessing compareData.postinumeroalue would throw — bail before
+				// the heat-exposure lookup and skip the comparison series. See #733.
+				const compareHeatData =
+					compareData != null
+						? helsinkiOrCapitalHeatExposure(
+								heatExposureStore.getDataById(compareData.postinumeroalue)
+							)
+						: null
+				// Skip the comparison series when either the compared record or
+				// its heat exposure data is missing — otherwise null values would
+				// propagate into d3 scale/axis computation.
+				const hasCompareSeries = compareData != null && compareHeatData != null
+				const compareValues = hasCompareSeries
 					? calculateYValues(compareData, statsData, compareHeatData)
 					: []
-				if (!hasCompareHeatData) {
+				if (!hasCompareSeries) {
 					logger.debug(
-						'[SocioEconomicsChart] Skipping comparison series; no heat exposure data for',
-						compareData.postinumeroalue
+						'[SocioEconomicsChart] Skipping comparison series; missing compareData or heat exposure for',
+						compareData?.postinumeroalue ?? selectedNimi
 					)
 				}
 				// Combine both yValues and compareValues arrays
@@ -202,7 +210,7 @@ export default {
 				const tooltip = plotService.createTooltip('#socioeonomicsContainer')
 				createBars(svg, barData, xScale, yScale, height, tooltip, 0, 'lightblue', sosData.nimi)
 
-				if (hasCompareHeatData) {
+				if (hasCompareSeries) {
 					const compareBarData = compareValues.map((value, index) => ({
 						value,
 						label: xLabels[index],

--- a/tests/unit/components/SocioEconomicsChart.test.js
+++ b/tests/unit/components/SocioEconomicsChart.test.js
@@ -1,8 +1,10 @@
 /**
- * Regression test for #728: SocioEconomicsChart must not throw when the
- * heatExposure store has no data for the compared postal code.
+ * Regression tests for SocioEconomicsChart resilience:
+ * - #728 (Sentry REGIONS4CLIMATE-2C): heatExposureStore.getDataById returning
+ *   undefined must not crash the chart.
+ * - #733: socioEconomicsStore.getDataByNimi returning undefined (no compare
+ *   area selected, or stale propsStore.socioEconomics reference) must not crash.
  *
- * Sentry: REGIONS4CLIMATE-2C
  * @see {@link file://./src/components/SocioEconomicsChart.vue}
  */
 
@@ -106,10 +108,11 @@ const statsFixture = {
 	hr_ktu: { min: 0, max: 60000 },
 }
 
+const socioEconomicsGetDataByNimi = vi.fn(() => compareDataFixture)
 vi.mock('@/stores/socioEconomicsStore.js', () => ({
 	useSocioEconomicsStore: () => ({
 		getDataByPostcode: vi.fn(() => sosDataFixture),
-		getDataByNimi: vi.fn(() => compareDataFixture),
+		getDataByNimi: socioEconomicsGetDataByNimi,
 		helsinkiStatistics: statsFixture,
 		regionStatistics: statsFixture,
 	}),
@@ -117,12 +120,14 @@ vi.mock('@/stores/socioEconomicsStore.js', () => ({
 
 import SocioEconomicsChart from '@/components/SocioEconomicsChart.vue'
 
-describe('SocioEconomicsChart — #728 heatData guard', { tags: ['@unit'] }, () => {
+describe('SocioEconomicsChart — undefined data guards', { tags: ['@unit'] }, () => {
 	let wrapper
 
 	beforeEach(() => {
 		setActivePinia(createPinia())
 		heatExposureGetDataById.mockClear()
+		socioEconomicsGetDataByNimi.mockReset()
+		socioEconomicsGetDataByNimi.mockReturnValue(compareDataFixture)
 	})
 
 	afterEach(() => {
@@ -132,7 +137,7 @@ describe('SocioEconomicsChart — #728 heatData guard', { tags: ['@unit'] }, () 
 	it('does not throw when heatExposureStore.getDataById returns undefined', () => {
 		// Pre-regression: heatExposureStore.getDataById returning undefined
 		// caused helsinkiOrCapitalHeatExposure to do undefined.properties.X
-		// and crash (Sentry REGIONS4CLIMATE-2C).
+		// and crash (Sentry REGIONS4CLIMATE-2C, #728).
 		heatExposureGetDataById.mockReturnValue(undefined)
 
 		expect(() => {
@@ -146,6 +151,20 @@ describe('SocioEconomicsChart — #728 heatData guard', { tags: ['@unit'] }, () 
 		// Sibling regression: an entry that exists but lacks `.properties`
 		// (e.g. a stub or in-flight record) must also be handled.
 		heatExposureGetDataById.mockReturnValue({})
+
+		expect(() => {
+			wrapper = mount(SocioEconomicsChart, {
+				attachTo: document.body,
+			})
+		}).not.toThrow()
+	})
+
+	it('does not throw when socioEconomicsStore.getDataByNimi returns undefined (#733)', () => {
+		// Pre-regression: getDataByNimi returning undefined (no comparison area
+		// selected yet, or stale propsStore.socioEconomics referencing a removed
+		// nimi) caused `compareData.postinumeroalue` to throw before reaching
+		// the heat-exposure guard.
+		socioEconomicsGetDataByNimi.mockReturnValue(undefined)
 
 		expect(() => {
 			wrapper = mount(SocioEconomicsChart, {


### PR DESCRIPTION
## Summary

`SocioEconomicsChart.vue` crashed with `TypeError: Cannot read properties of undefined (reading 'postinumeroalue')` when `socioEconomicsStore.getDataByNimi(selectedNimi)` returned undefined — reachable on first load (no comparison area picked yet) or when `propsStore.socioEconomics` referenced a nimi removed from the dataset. This is the sibling of #728 the gemini-code-assist review on #731 flagged.

## Root cause + fix

`compareData.postinumeroalue` was read before any null-check. Mirrored the #728 guard pattern: only call `helsinkiOrCapitalHeatExposure` when `compareData != null`, otherwise coerce `compareHeatData` to `null`. The comparison series (debug log, `compareValues`, second `createBars` call) is then gated on a single `hasCompareSeries = compareHeatData != null` predicate (the compareData == null case already coerces compareHeatData to null via the ternary, so one check suffices — per review).

## Test plan

- [x] `bunx vitest run tests/unit/components/SocioEconomicsChart.test.js` — 3/3 pass.
- [x] New regression case covers the `compareData == null` path; the existing #728 cases stay green.
- [ ] Smoke test on beta: load a postal code before selecting a comparison area, confirm chart renders the primary series without the comparison bars.

Sentry signature: REGIONS4CLIMATE-2C (sibling class — comparison-data branch).

Closes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)