### PR TITLE
perf(cache): stop eager startup warming of building data

### DIFF
--- a/src/services/cacheWarmer.js
+++ b/src/services/cacheWarmer.js
@@ -122,46 +122,26 @@ class CacheWarmer {
 
 	/**
 	 * Warm critical data caches on app startup
-	 * Runs in background using requestIdleCallback to avoid blocking UI.
-	 * Loads building data for most popular postal codes into IndexedDB.
 	 *
-	 * Warming Strategy:
-	 * - Loads building data only (most frequently accessed)
-	 * - Uses low-priority background loading
-	 * - 1-hour cache TTL (shorter than normal for freshness)
-	 * - Continues on failure (doesn't block app startup)
+	 * **No-op by default** (since 2026-05). Eager fan-out of 8 parallel
+	 * `/hsy_buildings_optimized/items?postinumero=*` requests at page load
+	 * was triggering Sentry's N+1 detector (R4C-CESIUM-VIEWER-5,
+	 * R4C-CESIUM-VIEWER-6) and shipping 8 large GeoJSON payloads the user
+	 * had not yet asked for (R4C-CESIUM-VIEWER-4). Buildings are now loaded
+	 * lazily on first postal-code selection, and predictive warming for
+	 * nearby postal codes (`warmNearbyPostalCodes`) handles the warm-cache
+	 * case once the user has expressed intent.
+	 *
+	 * Kept as a no-op (rather than removed) so callers and tests do not
+	 * break, and so the path can be re-enabled behind a feature flag if a
+	 * future use case justifies the network cost.
 	 *
 	 * @returns {Promise<void>}
-	 *
-	 * @example
-	 * // Call on app initialization
-	 * import cacheWarmer from './services/cacheWarmer.js';
-	 * cacheWarmer.warmCriticalData();
 	 */
 	async warmCriticalData() {
-		if (import.meta.env.VITE_E2E_TEST === 'true') {
-			logger.debug('[CacheWarmer] Skipping cache warming in E2E test mode')
-			return
-		}
-
-		if (this.warmingInProgress) {
-			logger.debug('[CacheWarmer] ⏳ Warming already in progress, skipping')
-			return
-		}
-
-		this.warmingInProgress = true
-		logger.debug('[CacheWarmer] 🔥 Starting cache warming for critical data...')
-
-		try {
-			// Warm popular postal codes' building data
-			await this.warmPopularBuildingData()
-
-			logger.debug('[CacheWarmer] ✅ Cache warming complete')
-		} catch (error) {
-			logger.warn('[CacheWarmer] ⚠️ Cache warming encountered error:', error?.message || error)
-		} finally {
-			this.warmingInProgress = false
-		}
+		logger.debug(
+			'[CacheWarmer] ⏭️ Startup warming disabled — buildings are loaded on first selection (see perf/#722,#724,#726)'
+		)
 	}
 
 	/**

--- a/src/services/cacheWarmer.js
+++ b/src/services/cacheWarmer.js
@@ -59,7 +59,8 @@ import unifiedLoader from './unifiedLoader.js'
 class CacheWarmer {
 	/**
 	 * Creates a CacheWarmer instance
-	 * Initializes store references and defines popular postal codes for warming.
+	 * Initializes store references and the warmed-postal-code tracking set
+	 * shared with `postalCodeLoader.checkCacheForPostalCode`.
 	 */
 	constructor() {
 		/** @type {Object|null} Lazy-loaded global store instance */
@@ -68,26 +69,8 @@ class CacheWarmer {
 		this._toggleStore = null
 		/** @type {Object|null} Lazy-loaded URL store instance */
 		this._urlStore = null
-		/** @type {boolean} Flag to prevent concurrent warming operations */
-		this.warmingInProgress = false
 		/** @type {Set<string>} Tracking set of already-warmed postal codes */
 		this.warmedPostalCodes = new Set()
-
-		/**
-		 * Most popular postal codes in Helsinki (based on typical usage patterns)
-		 * These will be warmed on app startup for instant loading.
-		 * @type {string[]}
-		 */
-		this.popularPostalCodes = [
-			'00100', // Helsinki center (Keskusta)
-			'00150', // Punavuori
-			'00170', // Kamppi
-			'00180', // Länsisatama
-			'00200', // Lauttasaari
-			'00530', // Munkkiniemi
-			'00250', // Taka-Töölö
-			'00260', // Katajanokka
-		]
 	}
 
 	/**
@@ -123,51 +106,28 @@ class CacheWarmer {
 	/**
 	 * Warm critical data caches on app startup
 	 *
-	 * **No-op by default** (since 2026-05). Eager fan-out of 8 parallel
-	 * `/hsy_buildings_optimized/items?postinumero=*` requests at page load
-	 * was triggering Sentry's N+1 detector (R4C-CESIUM-VIEWER-5,
-	 * R4C-CESIUM-VIEWER-6) and shipping 8 large GeoJSON payloads the user
-	 * had not yet asked for (R4C-CESIUM-VIEWER-4). Buildings are now loaded
-	 * lazily on first postal-code selection, and predictive warming for
-	 * nearby postal codes (`warmNearbyPostalCodes`) handles the warm-cache
-	 * case once the user has expressed intent.
+	 * **No-op** (since 2026-05). The previous implementation fanned out 8
+	 * parallel `/hsy_buildings_optimized/items?postinumero=*` requests at
+	 * page load (one per "popular" postal code), which triggered Sentry's
+	 * N+1 detector (R4C-CESIUM-VIEWER-5, R4C-CESIUM-VIEWER-6) and shipped
+	 * 8 large GeoJSON payloads the user had not yet asked for
+	 * (R4C-CESIUM-VIEWER-4). Buildings are now loaded lazily on first
+	 * postal-code selection, and predictive warming for nearby postal
+	 * codes (`warmNearbyPostalCodes`) handles the warm-cache case once
+	 * the user has expressed intent.
 	 *
-	 * Kept as a no-op (rather than removed) so callers and tests do not
-	 * break, and so the path can be re-enabled behind a feature flag if a
-	 * future use case justifies the network cost.
+	 * Method retained as a callable no-op so `useDataLoading` and any
+	 * existing tests/imports keep working. If a future use case
+	 * resurrects startup warming, gate it behind a GoFeatureFlag
+	 * (org-wide standard, see CLAUDE.md "feature-flags" rule) and not an
+	 * env-var build flag.
 	 *
 	 * @returns {Promise<void>}
 	 */
 	async warmCriticalData() {
 		logger.debug(
-			'[CacheWarmer] ⏭️ Startup warming disabled — buildings are loaded on first selection (see perf/#722,#724,#726)'
+			'[CacheWarmer] ⏭️ Startup warming disabled — buildings load on first selection (see perf/#722,#724,#726)'
 		)
-	}
-
-	/**
-	 * Preload building data for most popular postal codes
-	 * Loads data into cache only (doesn't process or display).
-	 * Uses Promise.allSettled to continue warming even if some areas fail.
-	 *
-	 * @returns {Promise<void>}
-	 * @private
-	 */
-	async warmPopularBuildingData() {
-		logger.debug(
-			'[CacheWarmer] 🏢 Warming building caches for',
-			this.popularPostalCodes.length,
-			'popular areas...'
-		)
-
-		// Use Promise.allSettled to continue even if some fail
-		const results = await Promise.allSettled(
-			this.popularPostalCodes.map((postalCode) => this.warmBuildingsForPostalCode(postalCode))
-		)
-
-		const successful = results.filter((r) => r.status === 'fulfilled').length
-		const failed = results.filter((r) => r.status === 'rejected').length
-
-		logger.debug(`[CacheWarmer] 📊 Warming complete: ${successful} successful, ${failed} failed`)
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Disable `cacheWarmer.warmCriticalData()` startup fan-out. Eight parallel GETs to `/pygeoapi/collections/hsy_buildings_optimized/items?postinumero=*` on every page load were triggering Sentry's N+1 detector and shipping multi-MB payloads the user had not asked for.

## Sentry fingerprints

- **R4C-CESIUM-VIEWER-5** — N+1 API Call (1654 occurrences) — Closes #722
- **R4C-CESIUM-VIEWER-4** — Large HTTP payload (1640 occurrences) — Closes #724
- **R4C-CESIUM-VIEWER-6** — HTTP/1.1 Overhead (240 occurrences) — Closes #726

All three fingerprints point at the same endpoint (`/hsy_buildings_optimized/items`); removing the startup fan-out is one fix that addresses all three.

## Root cause

`src/services/cacheWarmer.js#warmCriticalData()` ran on every page load via `useDataLoading.startCacheWarming()` (inside `requestIdleCallback`), calling `Promise.allSettled` over eight hardcoded popular postal codes (00100, 00150, 00170, 00180, 00200, 00250, 00260, 00530). Each call hits a paged GeoJSON endpoint returning up to 10 000 features per postal code. Sentry's perf detectors flag the resulting cluster as N+1 + large-payload + HTTP/1.1 overhead.

## Fix

- `warmCriticalData()` is now a documented no-op. Buildings load lazily on first postal-code selection (already the path for cold-start users today).
- Predictive warming for nearby postal codes (`warmNearbyPostalCodes`) is **untouched** — it still warms adjacent areas once the user clicks one, which is the cheap and intent-driven path.
- Method kept (rather than removed) so the path can be re-enabled behind a feature flag if a future use case justifies the network cost.

## Expected impact

- Eliminates 8 building-endpoint requests per page load.
- Drops Sentry occurrences for R4C-CESIUM-VIEWER-5/-4/-6 to ~0 once deployed (current trio averages ~1100 ev/wk combined).
- LCP improvement on cold loads (idle callback no longer competes with first-paint network).

## Test plan

- [x] `bun run lint` passes
- [x] `bun run test:unit` — 718/722 pass (4 pre-existing skips)
- [ ] Smoke: load app, click a postal code, confirm buildings still load (lazy path)
- [ ] Sentry: confirm R4C-CESIUM-VIEWER-5/-4/-6 stop firing on the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)