### PR TITLE
fix(feature-flags): raise GOFF websocket timeout and handle reconnect rejections (#735)

### DIFF
--- a/src/services/featureFlagProvider.ts
+++ b/src/services/featureFlagProvider.ts
@@ -5,6 +5,7 @@
 
 import { GoFeatureFlagWebProvider } from '@openfeature/go-feature-flag-web-provider'
 import { type EvaluationContext, InMemoryProvider, OpenFeature } from '@openfeature/web-sdk'
+import * as Sentry from '@sentry/vue'
 import { ALL_FLAG_NAMES, FLAG_METADATA } from '@/constants/flagMetadata'
 import { useFeatureFlagStore } from '@/stores/featureFlagStore'
 import type { useUserStore } from '@/stores/userStore'
@@ -21,6 +22,17 @@ const GOFF_ENDPOINT =
 		? `${window.location.origin}/feature-flags`
 		: '/feature-flags'
 const GOFF_HEALTH_TIMEOUT_MS = 3000
+
+/**
+ * GOFF websocket init timeout. The provider's built-in default is 5000 ms,
+ * which is too aggressive for cold relay-proxy connections — production
+ * traffic surfaces ~26 unhandled-rejection events per day from slow handshakes
+ * (Sentry R4C-CESIUM-VIEWER-1Z, #735). Bumped to 15s; override via
+ * `VITE_GOFF_TIMEOUT_MS` in environments with consistently slow handshakes.
+ * The flag-evaluation path is unaffected — fallback defaults are already
+ * applied when init fails or the relay is unreachable.
+ */
+const GOFF_WEBSOCKET_TIMEOUT_MS = Number(import.meta.env.VITE_GOFF_TIMEOUT_MS ?? 15000)
 
 type UserStore = ReturnType<typeof useUserStore>
 
@@ -84,12 +96,72 @@ async function isGoffAvailable(): Promise<boolean> {
 }
 
 /**
+ * Convert a GOFF rejection reason to a readable string. The library rejects
+ * with bare strings ("timeout of 5000 ms reached when initializing the
+ * websocket") and Error instances depending on the path.
+ */
+function describeGoffReason(reason: unknown): string {
+	if (reason instanceof Error) return reason.message
+	if (typeof reason === 'string') return reason
+	try {
+		return JSON.stringify(reason)
+	} catch {
+		return String(reason)
+	}
+}
+
+/**
+ * Test whether an unhandled rejection originated from the GOFF provider's
+ * background retry/reconnect loop. The library's `initialize()` catches its
+ * synchronous failure path, then fires `retryFetchAll()` and
+ * `reconnectWebsocket()` **without awaiting** — those returned promises can
+ * reject silently and surface as unhandled rejections (Sentry
+ * R4C-CESIUM-VIEWER-1Z, #735).
+ */
+function isGoffWebsocketRejection(reason: unknown): boolean {
+	const message = describeGoffReason(reason)
+	return (
+		/websocket/i.test(message) &&
+		/go-?feature-?flag|GoFeatureFlag|impossible to connect|reached when initializing/i.test(message)
+	)
+}
+
+let goffRejectionHandlerInstalled = false
+
+/**
+ * Convert GOFF's background-reconnect unhandled rejections into a single
+ * warning + Sentry breadcrumb, instead of letting them bubble up as
+ * production errors. Idempotent; safe to call multiple times.
+ */
+function installGoffRejectionHandler(): void {
+	if (goffRejectionHandlerInstalled || typeof window === 'undefined') {
+		return
+	}
+	goffRejectionHandlerInstalled = true
+	window.addEventListener('unhandledrejection', (event) => {
+		if (!isGoffWebsocketRejection(event.reason)) {
+			return
+		}
+		const message = describeGoffReason(event.reason)
+		logger.warn('Feature flags: GOFF websocket reconnect failed (handled)', message)
+		Sentry.addBreadcrumb({
+			category: 'feature-flags',
+			level: 'warning',
+			message: 'GOFF websocket reconnect failed',
+			data: { reason: message },
+		})
+		event.preventDefault()
+	})
+}
+
+/**
  * Initialize OpenFeature with the appropriate provider.
  * Attempts GOFF relay first, falls back to InMemoryProvider.
  *
  * @param userStore - The user identity store (must be initialized first)
  */
 export async function initializeFeatureFlags(userStore: UserStore): Promise<void> {
+	installGoffRejectionHandler()
 	const context = buildEvaluationContext(userStore)
 
 	const goffAvailable = await isGoffAvailable()
@@ -98,6 +170,7 @@ export async function initializeFeatureFlags(userStore: UserStore): Promise<void
 		logger.info('Feature flags: connecting to GOFF relay')
 		const provider = new GoFeatureFlagWebProvider({
 			endpoint: GOFF_ENDPOINT,
+			apiTimeout: GOFF_WEBSOCKET_TIMEOUT_MS,
 		})
 
 		await OpenFeature.setContext(context)
@@ -108,6 +181,12 @@ export async function initializeFeatureFlags(userStore: UserStore): Promise<void
 			useFeatureFlagStore().setProviderSource('goff')
 		} catch (error) {
 			logger.warn('Feature flags: GOFF provider failed, falling back to defaults', error)
+			Sentry.addBreadcrumb({
+				category: 'feature-flags',
+				level: 'warning',
+				message: 'GOFF provider init failed; using fallback defaults',
+				data: { reason: describeGoffReason(error) },
+			})
 			const fallbackProvider = new InMemoryProvider(buildFallbackFlags())
 			await OpenFeature.setProviderAndWait(fallbackProvider)
 			useFeatureFlagStore().setProviderSource('fallback')

--- a/src/services/featureFlagProvider.ts
+++ b/src/services/featureFlagProvider.ts
@@ -32,7 +32,10 @@ const GOFF_HEALTH_TIMEOUT_MS = 3000
  * The flag-evaluation path is unaffected — fallback defaults are already
  * applied when init fails or the relay is unreachable.
  */
-const GOFF_WEBSOCKET_TIMEOUT_MS = Number(import.meta.env.VITE_GOFF_TIMEOUT_MS ?? 15000)
+// Use `|| 15000` (not `??`) so empty string, NaN, and 0 all fall back to the
+// default. `apiTimeout: 0` would otherwise make the GOFF library use its
+// internal 5000 ms default — the bug this fix addresses.
+const GOFF_WEBSOCKET_TIMEOUT_MS = Number(import.meta.env.VITE_GOFF_TIMEOUT_MS) || 15000
 
 type UserStore = ReturnType<typeof useUserStore>
 
@@ -104,7 +107,9 @@ function describeGoffReason(reason: unknown): string {
 	if (reason instanceof Error) return reason.message
 	if (typeof reason === 'string') return reason
 	try {
-		return JSON.stringify(reason)
+		// JSON.stringify returns undefined for undefined/functions/symbols;
+		// fall back to String(reason) so the return type is always a string.
+		return JSON.stringify(reason) ?? String(reason)
 	} catch {
 		return String(reason)
 	}
@@ -120,9 +125,20 @@ function describeGoffReason(reason: unknown): string {
  */
 function isGoffWebsocketRejection(reason: unknown): boolean {
 	const message = describeGoffReason(reason)
+	// Require both:
+	//   1) "websocket" — narrows to the websocket-init failure class.
+	//   2) one of the GOFF-specific fingerprints:
+	//      - library name (defensive against future error wording)
+	//      - "reached when initializing" — the exact phrase the library uses
+	//        in its timeout reject path (index.esm.js: "timeout of N ms reached
+	//        when initializing the websocket"). This phrasing is highly
+	//        specific to GOFF, so it won't match Cesium Ion, Sentry replays,
+	//        or other websocket-using subsystems.
+	// The earlier "impossible to connect" alternative was too generic and
+	// risked swallowing unrelated websocket rejections (per code review on #745).
 	return (
 		/websocket/i.test(message) &&
-		/go-?feature-?flag|GoFeatureFlag|impossible to connect|reached when initializing/i.test(message)
+		/go-?feature-?flag|GoFeatureFlag|reached when initializing/i.test(message)
 	)
 }
 


### PR DESCRIPTION
## Summary

Sentry R4C-CESIUM-VIEWER-1Z is escalating — 26 unhandled-rejection events in 10 hours on production cold starts from the GoFeatureFlag web provider's 5000 ms websocket-init timeout. App boots with fallback defaults already, but the rejection escapes our try/catch and surfaces as a production error.

## Root cause + fix

The GOFF library's `initialize()` catches its synchronous failure path but then fires `retryFetchAll()` and `reconnectWebsocket()` **without awaiting** — those returned promises can reject silently and bypass our existing try/catch around `setProviderAndWait`. Two minimal changes in `src/services/featureFlagProvider.ts`:

1. Pass `apiTimeout: 15000` to the provider (overridable via `VITE_GOFF_TIMEOUT_MS`) so cold relay-proxy handshakes have a realistic window. The provider's `apiTimeout` option drives the websocket-init timeout. The env-var coercion uses `Number(...) || 15000` so empty string / NaN / 0 all fall back to the 15s default (passing `apiTimeout: 0` would make the library use its 5000 ms internal default — the exact bug we're fixing).
2. Install a window-scoped `unhandledrejection` listener that matches GOFF-shaped websocket reconnect failures, drops a Sentry breadcrumb + logger warning, and `preventDefault()`s the rejection. Idempotent and narrowly-scoped: requires "websocket" plus either the GOFF library name or the specific phrase `reached when initializing` (the GOFF timeout-reject path's unique fingerprint). Other promise rejections still bubble.

Flag-evaluation behaviour and defaults are unchanged; the fallback `InMemoryProvider` path was already correct.

## Related

- Related to #738 (URL `Invalid URL` umbrella) — the GOFF endpoint already uses `window.location.origin` (since the URL-construction guard at the top of the file), so this PR does not change the URL construction. If #738 needs a deeper audit of GOFF URL handling, it can reference this file.
- Cross-FVH issue: TFDS_Dashboard#160 tracks the same pattern. If a shared fix is wanted in `openfeature-config`, the timeout + rejection-handler pattern here can be extracted; not done in this PR.

## Test plan

- [x] `bunx vitest run tests/unit/stores/featureFlagStore.test.ts` — 77/77 pass.
- [x] `bunx biome check src/services/featureFlagProvider.ts` — clean.
- [ ] Monitor R4C-CESIUM-VIEWER-1Z post-deploy: unhandled-rejection volume should drop to zero; new breadcrumbs should appear on session replays of slow handshakes.
- [ ] Confirm beta cold start still falls back to defaults when relay is unreachable (existing health-check path unchanged).

Sentry: R4C-CESIUM-VIEWER-1Z

Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)