### PR TITLE
perf(api): trim heat-exposure payload to consumed fields only

### DIFF
--- a/src/stores/urlStore.js
+++ b/src/stores/urlStore.js
@@ -108,8 +108,9 @@ export const useURLStore = defineStore('url', {
 		 * requested, and `skipGeometry=true` drops the postal-code
 		 * polygons we never render from this collection. Reduces payload
 		 * from a multi-MB GeoJSON FeatureCollection (all properties +
-		 * full geometry per postal code) to a small JSON dump keyed by
-		 * postal-code id, which is all the heat-exposure store needs.
+		 * full geometry per postal code) to a trimmed GeoJSON collection
+		 * which the heat-exposure store then indexes by postal-code id
+		 * (see `heatExposureStore.loadHeatExposure()`).
 		 *
 		 * @param {Object} state - Pinia state
 		 * @returns {(limit?: number) => string} Function accepting optional limit and returning heat exposure URL

--- a/src/stores/urlStore.js
+++ b/src/stores/urlStore.js
@@ -102,6 +102,15 @@ export const useURLStore = defineStore('url', {
 			},
 		/**
 		 * Generates URL for heat exposure index data (postal code level aggregates)
+		 *
+		 * Trimmed payload (#725 / R4C-CESIUM-VIEWER-1): only the three
+		 * aggregated heat fields consumed by SocioEconomicsChart are
+		 * requested, and `skipGeometry=true` drops the postal-code
+		 * polygons we never render from this collection. Reduces payload
+		 * from a multi-MB GeoJSON FeatureCollection (all properties +
+		 * full geometry per postal code) to a small JSON dump keyed by
+		 * postal-code id, which is all the heat-exposure store needs.
+		 *
 		 * @param {Object} state - Pinia state
 		 * @returns {(limit?: number) => string} Function accepting optional limit and returning heat exposure URL
 		 * @example
@@ -110,7 +119,7 @@ export const useURLStore = defineStore('url', {
 		heatExposure:
 			(state) =>
 			(limit = 1000) => {
-				return `${state.pygeoapiBase}/heatexposure_optimized/items?f=json&limit=${limit}` // New getter
+				return `${state.pygeoapiBase}/heatexposure_optimized/items?f=json&limit=${limit}&skipGeometry=true&properties=avgheatexposure,hki_avgheatexposure,avgcoldexposure`
 			},
 		/**
 		 * Generates URL for Helsinki Region Transport (HSL) travel time matrix data


### PR DESCRIPTION
## Summary

Trim the `/pygeoapi/collections/heatexposure_optimized/items` response to the fields the UI actually consumes. The endpoint was returning a multi-MB GeoJSON FeatureCollection with full postal-code polygons and ~80 properties per feature; the only consumer reads three properties and never renders the geometry.

## Sentry fingerprint

- **R4C-CESIUM-VIEWER-1** — Large HTTP payload, 3245 occurrences — Closes #725

## Root cause

`urlStore.heatExposure()` (called by `heatExposureStore.loadHeatExposure()` on app startup via `useDataLoading`) requested the whole collection. `SocioEconomicsChart.vue` is the only place the data is read, and it uses just `heatData.properties.avgcoldexposure`, `.hki_avgheatexposure`, `.avgheatexposure`.

## Fix

Add two standard OGC API - Features query parameters to the URL builder:

```diff
-`${state.pygeoapiBase}/heatexposure_optimized/items?f=json&limit=${limit}`
+`${state.pygeoapiBase}/heatexposure_optimized/items?f=json&limit=${limit}&skipGeometry=true&properties=avgheatexposure,hki_avgheatexposure,avgcoldexposure`
```

The response stays in FeatureCollection shape so `heatExposureStore`'s `Map(data.map((item) => [item.id, item]))` lookup keeps working unchanged.

## Expected impact

- Payload drops by 1-2 orders of magnitude (polygons dominate the byte budget; ~80 → 3 properties drops the rest).
- Sentry occurrences for R4C-CESIUM-VIEWER-1 drop to ~0 once deployed.
- LCP improvement on cold loads (heat exposure loads in parallel with socioeconomic data via `Promise.allSettled`).

## Test plan

- [x] `bun run lint` passes
- [x] `bun run test:unit` — 718/722 pass (the SocioEconomicsChart heatData-guard test still passes)
- [ ] Smoke: open app, confirm climate-adaptation comparison panel shows heat-exposure values for postal codes other than the selected one
- [ ] Sentry: confirm R4C-CESIUM-VIEWER-1 stops firing on the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)