### PR TITLE
fix: postal-code breadcrumb renders "undefined" prefix

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -173,10 +173,7 @@ const buildingAddress = computed(() => globalStore.buildingAddress)
 const locationLabel = computed(() => {
 	if (currentLevel.value === 'building') return buildingAddress.value || 'Building'
 	if (currentLevel.value === 'postalCode') {
-		const code = postalCode.value
-		const zone = nameOfZone.value
-		if (code && zone) return `${code} ${zone}`
-		return zone || code || null
+		return [postalCode.value, nameOfZone.value].filter(Boolean).join(' ') || null
 	}
 	return null
 })

--- a/src/App.vue
+++ b/src/App.vue
@@ -163,14 +163,21 @@ const showTimeline = computed(
 	() => currentLevel.value === 'postalCode' || currentLevel.value === 'building'
 )
 
-const postalCode = computed(() => globalStore.postalCode)
+// Store property is `postalcode` (lowercase) — reading `postalCode` (camelCase)
+// resolved to `undefined` and rendered as the literal string "undefined" in the
+// breadcrumb (issue #711).
+const postalCode = computed(() => globalStore.postalcode)
 const nameOfZone = computed(() => globalStore.nameOfZone)
 const buildingAddress = computed(() => globalStore.buildingAddress)
 
 const locationLabel = computed(() => {
 	if (currentLevel.value === 'building') return buildingAddress.value || 'Building'
-	if (currentLevel.value === 'postalCode')
-		return nameOfZone.value ? `${postalCode.value} ${nameOfZone.value}` : postalCode.value
+	if (currentLevel.value === 'postalCode') {
+		const code = postalCode.value
+		const zone = nameOfZone.value
+		if (code && zone) return `${code} ${zone}`
+		return zone || code || null
+	}
 	return null
 })
 

--- a/src/composables/useSidebarNavigation.js
+++ b/src/composables/useSidebarNavigation.js
@@ -11,7 +11,10 @@ export function useSidebarNavigation() {
 	const globalStore = useGlobalStore()
 
 	const currentLevel = computed(() => globalStore.level)
-	const postalCode = computed(() => globalStore.postalCode)
+	// Store property is `postalcode` (lowercase) — reading `postalCode` (camelCase)
+	// resolved to `undefined` and rendered as the literal string "undefined" in the
+	// sidebar breadcrumb (issue #711).
+	const postalCode = computed(() => globalStore.postalcode)
 	const nameOfZone = computed(() => globalStore.nameOfZone)
 	const buildingAddress = computed(() => globalStore.buildingAddress)
 
@@ -19,9 +22,11 @@ export function useSidebarNavigation() {
 		const items = [{ label: 'Capital Region', level: 'start' }]
 
 		if (currentLevel.value === 'postalCode' || currentLevel.value === 'building') {
-			const postalLabel = nameOfZone.value
-				? `${postalCode.value} ${nameOfZone.value}`
-				: postalCode.value || 'Area'
+			const code = postalCode.value
+			const zone = nameOfZone.value
+			let postalLabel
+			if (code && zone) postalLabel = `${code} ${zone}`
+			else postalLabel = zone || code || 'Area'
 			items.push({ label: postalLabel, level: 'postalCode' })
 		}
 

--- a/src/composables/useSidebarNavigation.js
+++ b/src/composables/useSidebarNavigation.js
@@ -22,11 +22,7 @@ export function useSidebarNavigation() {
 		const items = [{ label: 'Capital Region', level: 'start' }]
 
 		if (currentLevel.value === 'postalCode' || currentLevel.value === 'building') {
-			const code = postalCode.value
-			const zone = nameOfZone.value
-			let postalLabel
-			if (code && zone) postalLabel = `${code} ${zone}`
-			else postalLabel = zone || code || 'Area'
+			const postalLabel = [postalCode.value, nameOfZone.value].filter(Boolean).join(' ') || 'Area'
 			items.push({ label: postalLabel, level: 'postalCode' })
 		}
 


### PR DESCRIPTION
Closes #711

## Summary

`App.vue` toolbar header and the `useSidebarNavigation` composable both read `globalStore.postalCode` (camelCase). The store property is `postalcode` (lowercase), so the access resolved to `undefined` and the template emitted the literal string "undefined" before the zone name, e.g. `undefined Helsinki Keskusta - Etu-Töölö`.

## What changed

- `src/App.vue`: read `globalStore.postalcode` and guard the `locationLabel` template.
- `src/composables/useSidebarNavigation.js`: same casing fix + guarded breadcrumb label.

## What test now hardens

`tests/e2e/audit-2026-W19/postal-code-breadcrumb.spec.ts` (US-03) already uses hard `expect(banner).not.toContainText(/\bundefined\b/i)` and `expect(sidebar).not.toContainText(/\bundefined\b/i)`. Those will go green once this lands and stay loud against future regressions.

The `tests/e2e/audit-2026-W19/user-journeys.spec.ts` regression contract has no `expect.soft` tied to #711 (it's covered by the dedicated spec above), so no graduation is needed.

## Test plan

- [ ] Local: `bunx playwright test tests/e2e/audit-2026-W19/postal-code-breadcrumb.spec.ts --reporter=line`
- [ ] Beta: navigate to `00100`, confirm toolbar + sidebar header read `00100 Helsinki Keskusta - Etu-Töölö` with no `undefined` prefix.
