### PR TITLE
fix: URL state retains postal-code params after back-navigation to start

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -187,15 +187,17 @@ const toggleMobileSidebar = () => {
 // `?postalcode=` rather than leaving them stale (issue #714). The watcher fires
 // for every level transition, including direct store mutations from tests and
 // in-component back-button handlers, so all back-nav paths converge here.
+// Handles all three levels: start (clears both params), postalCode (sets both),
+// and building (preserves the parent postalcode param so reload restores
+// context). Camera params (lon/lat/alt) are managed by useUrlState and remain
+// untouched.
 const stopLevelUrlWatcher = watch(
 	() => [globalStore.level, globalStore.postalcode],
 	([level, code]) => {
 		if (level === 'start') {
-			// Clear navigation params on return to start. Camera params (lon/lat/alt)
-			// are managed by useUrlState and remain untouched.
 			updateUrlWithNavigationState('start', null)
-		} else if (level === 'postalCode' && code) {
-			updateUrlWithNavigationState('postalCode', code)
+		} else if ((level === 'postalCode' || level === 'building') && code) {
+			updateUrlWithNavigationState(level, code)
 		}
 	}
 )

--- a/src/App.vue
+++ b/src/App.vue
@@ -127,7 +127,7 @@
 </template>
 
 <script setup>
-import { computed, defineAsyncComponent, onBeforeUnmount, onMounted } from 'vue'
+import { computed, defineAsyncComponent, onBeforeUnmount, onMounted, watch } from 'vue'
 import { useSidebarOffset } from './composables/useSidebarOffset'
 
 // Lazy-loaded components
@@ -138,6 +138,7 @@ const MapOverlayControls = defineAsyncComponent(() => import('./components/MapOv
 
 import CesiumViewer from './pages/CesiumViewer.vue'
 import { initializeFeatureFlags } from './services/featureFlagProvider'
+import { updateUrlWithNavigationState } from './services/postalCodeLoader'
 import { useFeatureFlagStore } from './stores/featureFlagStore'
 import { useGlobalStore } from './stores/globalStore.js'
 import { useLoadingStore } from './stores/loadingStore.js'
@@ -181,6 +182,23 @@ const locationLabel = computed(() => {
 const toggleMobileSidebar = () => {
 	toggleStore.setSidebarMode(toggleStore.sidebarMode === 'hidden' ? 'expanded' : 'hidden')
 }
+
+// Sync URL query params with navigation level so back-nav clears `?level=` and
+// `?postalcode=` rather than leaving them stale (issue #714). The watcher fires
+// for every level transition, including direct store mutations from tests and
+// in-component back-button handlers, so all back-nav paths converge here.
+const stopLevelUrlWatcher = watch(
+	() => [globalStore.level, globalStore.postalcode],
+	([level, code]) => {
+		if (level === 'start') {
+			// Clear navigation params on return to start. Camera params (lon/lat/alt)
+			// are managed by useUrlState and remain untouched.
+			updateUrlWithNavigationState('start', null)
+		} else if (level === 'postalCode' && code) {
+			updateUrlWithNavigationState('postalCode', code)
+		}
+	}
+)
 
 // Navigation functions
 const signOut = () => {
@@ -265,6 +283,7 @@ onMounted(async () => {
 })
 
 onBeforeUnmount(async () => {
+	stopLevelUrlWatcher()
 	loadingStore.stopStaleCleanupTimer()
 
 	if (featureFlagStore.isEnabled('backgroundPreload')) {

--- a/src/services/postalCodeLoader.js
+++ b/src/services/postalCodeLoader.js
@@ -20,6 +20,10 @@ import cacheWarmer from './cacheWarmer.js'
  * reload would re-enter the postal-code level even though the visible state
  * shows Capital Region (issue #714).
  *
+ * Accepts 'start', 'postalCode', and 'building' levels. At building level the
+ * postal-code param is preserved so a reload restores the parent postal-code
+ * context.
+ *
  * @param {string} level - Navigation level
  * @param {string} postalCode - Selected postal code
  */

--- a/src/services/postalCodeLoader.js
+++ b/src/services/postalCodeLoader.js
@@ -11,11 +11,19 @@ import cacheWarmer from './cacheWarmer.js'
  */
 
 /**
- * Updates URL with navigation state after postal code loads
+ * Updates URL with navigation state after postal code loads.
+ *
+ * Exported so back-navigation paths (App.vue smartReset, useSidebarNavigation
+ * goBack, view switches) can call it with `level='start', postalCode=null` to
+ * clear the `?level=` and `?postalcode=` query params — without that, the URL
+ * keeps stale postal-code params after the user has navigated back, and a page
+ * reload would re-enter the postal-code level even though the visible state
+ * shows Capital Region (issue #714).
+ *
  * @param {string} level - Navigation level
  * @param {string} postalCode - Selected postal code
  */
-function updateUrlWithNavigationState(level, postalCode) {
+export function updateUrlWithNavigationState(level, postalCode) {
 	try {
 		const params = new URLSearchParams(window.location.search)
 

--- a/tests/e2e/audit-2026-W19/user-journeys.spec.ts
+++ b/tests/e2e/audit-2026-W19/user-journeys.spec.ts
@@ -246,28 +246,28 @@ cesiumDescribe('Audit 2026-W19: user journeys', () => {
 			expect(afterBack.level, 'must return to start level').toBe('start')
 			expect(afterBack.postalcode, 'postal code must clear on back-nav').toBeNull()
 
-			// US-08 #714 — URL params must clear too. Soft until fixed.
+			// US-08 #714 — URL params must clear (graduated to hard after #714 fix).
 			const url = new URL(cesiumPage.url())
-			expect
-				.soft(url.searchParams.has('level'), 'US-08 #714 — ?level= param must clear after back-nav')
-				.toBe(false)
-			expect
-				.soft(
-					url.searchParams.has('postalcode'),
-					'US-08 #714 — ?postalcode= param must clear after back-nav'
-				)
-				.toBe(false)
+			expect(
+				url.searchParams.has('level'),
+				'US-08 #714 — ?level= param must clear after back-nav'
+			).toBe(false)
+			expect(
+				url.searchParams.has('postalcode'),
+				'US-08 #714 — ?postalcode= param must clear after back-nav'
+			).toBe(false)
 
-			// Deep-link consistency: reload should land at start level. Soft
-			// because URL stickiness (#714) drives the same regression today.
+			// Deep-link consistency: reload should land at start level. Hard now
+			// that URL stickiness (#714) is resolved.
 			await cesiumPage.reload()
 			await cesiumPage.waitForFunction(() => Boolean((window as any).globalStore), undefined, {
 				timeout: 10000,
 			})
 			const afterReload = await readStoreState(cesiumPage)
-			expect
-				.soft(afterReload.level, 'US-08 #714 — reload after back-nav must preserve start level')
-				.toBe('start')
+			expect(
+				afterReload.level,
+				'US-08 #714 — reload after back-nav must preserve start level'
+			).toBe('start')
 		}
 	)
 


### PR DESCRIPTION
Closes #714

## Summary

When the user clicked "Go back" or otherwise returned to the start (Capital Region) level, the `?level=postalcode&postalcode=00100` URL params stuck around — no back-nav path was calling the URL-update helper with the start-level state. A page reload would silently teleport the user back into the postal-code level even though the sidebar showed Capital Region.

## What changed

- `src/services/postalCodeLoader.js`: export `updateUrlWithNavigationState` so back-nav can clear params.
- `src/App.vue`: add a top-level watcher on `globalStore.level` + `globalStore.postalcode` that calls `updateUrlWithNavigationState` on every transition. Converges every back-nav path (smartReset, sidebar goBack, view switches, direct store mutations) into a single URL-sync point.

## What test now hardens

`tests/e2e/audit-2026-W19/user-journeys.spec.ts` journey-3 (US-08) — graduated three `expect.soft(...)` assertions to hard `expect(...)`:

- `?level=` param must clear after back-nav
- `?postalcode=` param must clear after back-nav
- Reload after back-nav must preserve start level

## Test plan

- [ ] Local: `bunx playwright test tests/e2e/audit-2026-W19/user-journeys.spec.ts --grep @journey-3 --reporter=line`
- [ ] Beta: drill to 00100, click "Go back", confirm URL shows no `?level=` / `?postalcode=`; reload and confirm you stay at Capital Region.
