### PR TITLE
fix: ANALYSIS tab missing Heat Histogram / NDVI Analysis / Building Scatter Plot at postal-code level

### DIFF
--- a/src/pages/ControlPanel.vue
+++ b/src/pages/ControlPanel.vue
@@ -133,8 +133,16 @@
 							</p>
 							<div class="analysis-buttons">
 								<template v-if="currentLevel === 'postalCode'">
+									<!-- Heat Distribution, NDVI Vegetation, and Building Analysis surface
+										 their UI as soon as the feature flag is enabled. Previously these
+										 were gated on `heatHistogramData.length > 0` / `hasNDVIData`, which
+										 meant the buttons never appeared until the corresponding dataset
+										 had already been loaded — leaving the Analysis tab silently
+										 incomplete (issue #712). The button's @click handler triggers data
+										 load, so a missing dataset is a runtime concern for the chart
+										 component, not a discoverability concern for the button. -->
 									<v-btn
-										v-if="heatHistogramData && heatHistogramData.length > 0 && featureFlagStore.isEnabled('heatHistogram')"
+										v-if="featureFlagStore.isEnabled('heatHistogram')"
 										block
 										variant="outlined"
 										prepend-icon="mdi-chart-histogram"
@@ -170,7 +178,7 @@
 										Building Analysis
 									</v-btn>
 									<v-btn
-										v-if="hasNDVIData && featureFlagStore.isEnabled('ndviAnalysis')"
+										v-if="featureFlagStore.isEnabled('ndviAnalysis')"
 										block
 										variant="outlined"
 										prepend-icon="mdi-leaf"

--- a/src/pages/ControlPanel.vue
+++ b/src/pages/ControlPanel.vue
@@ -133,14 +133,7 @@
 							</p>
 							<div class="analysis-buttons">
 								<template v-if="currentLevel === 'postalCode'">
-									<!-- Heat Distribution, NDVI Vegetation, and Building Analysis surface
-										 their UI as soon as the feature flag is enabled. Previously these
-										 were gated on `heatHistogramData.length > 0` / `hasNDVIData`, which
-										 meant the buttons never appeared until the corresponding dataset
-										 had already been loaded — leaving the Analysis tab silently
-										 incomplete (issue #712). The button's @click handler triggers data
-										 load, so a missing dataset is a runtime concern for the chart
-										 component, not a discoverability concern for the button. -->
+									<!-- Analysis buttons gate on the feature flag only; data loads on click (#712). -->
 									<v-btn
 										v-if="featureFlagStore.isEnabled('heatHistogram')"
 										block
@@ -442,10 +435,8 @@ const breadcrumbItems = computed(() =>
 
 const adaptationTab = ref('centers')
 
-const heatHistogramData = computed(() => propsStore.heatHistogramData)
 const statsIndex = computed(() => propsStore.statsIndex)
 const showSosEco = computed(() => socioEconomicsStore.data && heatExposureStore.data)
-const hasNDVIData = computed(() => toggleStore.ndvi)
 
 const hasAvailableAnalysis = computed(() => {
 	if (currentLevel.value === 'start') return false

--- a/tests/e2e/audit-2026-W19/user-journeys.spec.ts
+++ b/tests/e2e/audit-2026-W19/user-journeys.spec.ts
@@ -8,10 +8,13 @@
  *
  * Soft vs. hard assertions:
  *   - `expect.soft(...)` is used for contracts tied to an open issue
- *     (#679, #681, #711, #712, #713, #714, #715). The soft form surfaces
- *     every broken contract in a single run instead of bailing on the first.
- *     When an issue closes, the matching soft assertion graduates to a hard
+ *     (#679, #681, #713, #715). The soft form surfaces every broken
+ *     contract in a single run instead of bailing on the first. When an
+ *     issue closes, the matching soft assertion graduates to a hard
  *     `expect` so the next regression is loud.
+ *   - #711 lives in postal-code-breadcrumb.spec.ts (already hard).
+ *   - #712 has graduated to hard — analysis-tab buttons must be visible.
+ *   - #714 has graduated to hard — URL params must clear on back-nav.
  *   - Plain `expect(...)` is used for structural pre/postconditions that
  *     must hold for the journey to make sense (e.g. Cesium ready, store
  *     state transitioned to the expected level).
@@ -181,34 +184,26 @@ cesiumDescribe('Audit 2026-W19: user journeys', () => {
 				.not.toMatch(/\b0\s+properties\b/i)
 
 			// Heat Distribution / NDVI Vegetation / Building Analysis buttons
-			// live on the Analysis tab. Switch tabs before asserting so the
-			// soft contracts fail for the *right* reason (#712 data/flag gates,
-			// not "wrong tab active").
+			// live on the Analysis tab. Switch tabs before asserting.
 			await cesiumPage.getByRole('tab', { name: 'Analysis' }).click()
 
-			// US-04 #712 — Heat Distribution button must be reachable.
-			await expect
-				.soft(
-					cesiumPage.getByRole('button', { name: 'Heat Distribution' }),
-					'US-04 #712 — Heat Distribution button must be reachable from ControlPanel'
-				)
-				.toBeVisible()
+			// US-04 #712 — Heat Distribution button must be reachable (graduated to hard).
+			await expect(
+				cesiumPage.getByRole('button', { name: 'Heat Distribution' }),
+				'US-04 #712 — Heat Distribution button must be reachable from ControlPanel'
+			).toBeVisible()
 
-			// US-05 #712 — NDVI Vegetation button must be reachable.
-			await expect
-				.soft(
-					cesiumPage.getByRole('button', { name: 'NDVI Vegetation' }),
-					'US-05 #712 — NDVI Vegetation button must be reachable at postal-code level'
-				)
-				.toBeVisible()
+			// US-05 #712 — NDVI Vegetation button must be reachable (graduated to hard).
+			await expect(
+				cesiumPage.getByRole('button', { name: 'NDVI Vegetation' }),
+				'US-05 #712 — NDVI Vegetation button must be reachable at postal-code level'
+			).toBeVisible()
 
-			// US-06 #712 — Building Analysis (scatter plot) button must be reachable.
-			await expect
-				.soft(
-					cesiumPage.getByRole('button', { name: 'Building Analysis' }),
-					'US-06 #712 — Building Analysis (scatter) button must be reachable at postal-code level'
-				)
-				.toBeVisible()
+			// US-06 #712 — Building Analysis (scatter plot) button must be reachable (graduated to hard).
+			await expect(
+				cesiumPage.getByRole('button', { name: 'Building Analysis' }),
+				'US-06 #712 — Building Analysis (scatter) button must be reachable at postal-code level'
+			).toBeVisible()
 		}
 	)
 


### PR DESCRIPTION
Closes #712

## Summary

At postal-code level the Analysis tab only rendered three of the six advertised tools — Heat Distribution and NDVI Vegetation were missing, and Building Analysis sometimes too. The three buttons had data-presence gates (`heatHistogramData.length > 0`, `hasNDVIData`) that would only become true after the user had already clicked the button to load the data. Classic chicken-and-egg.

## What changed

- `src/pages/ControlPanel.vue`: drop the data-presence checks on the Heat Distribution and NDVI Vegetation `v-if` guards. The feature flag (`heatHistogram`, `ndviAnalysis`, `buildingScatterPlot` — all default-true per `flagMetadata.ts`) is now the sole gate. Data loads when the button is clicked.

The four `flagMetadata.ts` analysis flags (`heatHistogram`, `buildingScatterPlot`, `ndviAnalysis`, `socioeconomicViz`) all have `fallbackDefault: true`, so even when GOFF is unreachable (see #715) the buttons render.

## What test now hardens

`tests/e2e/audit-2026-W19/user-journeys.spec.ts` journey-2 (US-04 / US-05 / US-06) — graduated three `expect.soft(...)` assertions to hard `expect(...)`:

- Heat Distribution button must be visible at postal-code level
- NDVI Vegetation button must be visible at postal-code level
- Building Analysis button must be visible at postal-code level

## Test plan

- [ ] Local: `bunx playwright test tests/e2e/audit-2026-W19/user-journeys.spec.ts --grep @journey-2 --reporter=line`
- [ ] Beta: drill to `00100`, open the Analysis tab, confirm all six tools surface (Heat Distribution, Socioeconomics, Land Cover, Building Analysis, NDVI Vegetation — plus whichever others are flag-enabled).
