### PR TITLE
fix: AreaProperties stays empty at postal-code level

### DIFF
--- a/src/components/AreaProperties.vue
+++ b/src/components/AreaProperties.vue
@@ -145,6 +145,7 @@
 <script setup>
 import { computed, ref, watch } from 'vue'
 import { eventBus } from '../services/eventEmitter'
+import { postalCodeIndex } from '../services/postalCodeIndex.js'
 import { useGlobalStore } from '../stores/globalStore'
 import logger from '../utils/logger.js'
 
@@ -159,28 +160,22 @@ const copyFeedbackText = ref('Copied!')
 // map click, `globalStore.pickedEntity` is null and AreaProperties renders
 // the empty "Click on areas to view properties" state. Look up the postal-
 // code polygon entity directly from the index so the panel still populates.
-const fallbackPostalCodeEntity = ref(null)
-
-watch(
-	[() => globalStore.level, () => globalStore.postalcode, () => globalStore.pickedEntity],
-	async ([level, postalcode, picked]) => {
-		// Only fall back at postal-code level with no clicked entity.
-		if (level !== 'postalCode' || !postalcode || picked) {
-			fallbackPostalCodeEntity.value = null
-			return
-		}
-
-		try {
-			const { postalCodeIndex } = await import('../services/postalCodeIndex.js')
-			const entity = postalCodeIndex.getByPostalCode(postalcode)
-			fallbackPostalCodeEntity.value = entity ?? null
-		} catch (error) {
-			logger.warn('[AreaProperties] Failed to look up postal code entity:', error?.message || error)
-			fallbackPostalCodeEntity.value = null
-		}
-	},
-	{ immediate: true }
-)
+//
+// postalCodeIndex is imported synchronously: it's a leaf-node utility with
+// only a logger dependency, so there's no circular-import risk, and a sync
+// lookup avoids a stale-data window where the old postal-code's properties
+// would briefly render before the dynamic import resolved.
+const fallbackPostalCodeEntity = computed(() => {
+	if (globalStore.level !== 'postalCode' || !globalStore.postalcode || globalStore.pickedEntity) {
+		return null
+	}
+	try {
+		return postalCodeIndex.getByPostalCode(globalStore.postalcode) ?? null
+	} catch (error) {
+		logger.warn('[AreaProperties] Failed to look up postal code entity:', error?.message || error)
+		return null
+	}
+})
 
 const effectiveEntity = computed(() => globalStore.pickedEntity || fallbackPostalCodeEntity.value)
 

--- a/src/components/AreaProperties.vue
+++ b/src/components/AreaProperties.vue
@@ -154,6 +154,36 @@ const openPanels = ref([])
 const showCopyFeedback = ref(false)
 const copyFeedbackText = ref('Copied!')
 
+// Fallback entity for postal-code level. Issue #713: when the user reached
+// the postal code via search / URL / programmatic navigation rather than a
+// map click, `globalStore.pickedEntity` is null and AreaProperties renders
+// the empty "Click on areas to view properties" state. Look up the postal-
+// code polygon entity directly from the index so the panel still populates.
+const fallbackPostalCodeEntity = ref(null)
+
+watch(
+	[() => globalStore.level, () => globalStore.postalcode, () => globalStore.pickedEntity],
+	async ([level, postalcode, picked]) => {
+		// Only fall back at postal-code level with no clicked entity.
+		if (level !== 'postalCode' || !postalcode || picked) {
+			fallbackPostalCodeEntity.value = null
+			return
+		}
+
+		try {
+			const { postalCodeIndex } = await import('../services/postalCodeIndex.js')
+			const entity = postalCodeIndex.getByPostalCode(postalcode)
+			fallbackPostalCodeEntity.value = entity ?? null
+		} catch (error) {
+			logger.warn('[AreaProperties] Failed to look up postal code entity:', error?.message || error)
+			fallbackPostalCodeEntity.value = null
+		}
+	},
+	{ immediate: true }
+)
+
+const effectiveEntity = computed(() => globalStore.pickedEntity || fallbackPostalCodeEntity.value)
+
 // Category definitions with property matchers
 const CATEGORIES = {
 	location: {
@@ -322,7 +352,7 @@ function formatValue(value) {
 
 // Extract all properties from entity
 const allProperties = computed(() => {
-	const entity = globalStore.pickedEntity
+	const entity = effectiveEntity.value
 	if (!entity?._properties) return []
 
 	const props = []
@@ -454,9 +484,9 @@ async function copyAllProperties() {
 	}
 }
 
-// Reset panels when entity changes
+// Reset panels when the effective entity changes
 watch(
-	() => globalStore.pickedEntity,
+	() => effectiveEntity.value,
 	() => {
 		openPanels.value = []
 		searchQuery.value = ''

--- a/src/services/featurepicker/index.js
+++ b/src/services/featurepicker/index.js
@@ -235,8 +235,21 @@ export default class FeaturePicker {
 	 * @private
 	 */
 	setNameOfZone() {
-		setNameOfZoneHelper(this.store.postalcode, this.propStore.postalCodeData, (name) =>
-			this.store.setNameOfZone(name)
+		setNameOfZoneHelper(
+			this.store.postalcode,
+			this.propStore.postalCodeData,
+			(name) => this.store.setNameOfZone(name),
+			{
+				// Issue #713 — populate AreaProperties when entering postal-code level
+				// via search / URL (no map click). Only set when no entity is already
+				// picked, so a click that selected a more specific entity isn't
+				// overwritten.
+				setPickedEntityIfEmpty: (entity) => {
+					if (!this.store.pickedEntity) {
+						this.store.setPickedEntity(entity)
+					}
+				},
+			}
 		)
 	}
 

--- a/src/services/featurepicker/index.js
+++ b/src/services/featurepicker/index.js
@@ -235,8 +235,9 @@ export default class FeaturePicker {
 	 * @private
 	 */
 	setNameOfZone() {
+		const targetPostalCode = this.store.postalcode
 		setNameOfZoneHelper(
-			this.store.postalcode,
+			targetPostalCode,
 			this.propStore.postalCodeData,
 			(name) => this.store.setNameOfZone(name),
 			{
@@ -249,6 +250,9 @@ export default class FeaturePicker {
 						this.store.setPickedEntity(entity)
 					}
 				},
+				// Race guard: drop the deferred state update if a newer navigation
+				// has already replaced the current postal code in the store.
+				getCurrentPostalCode: () => this.store.postalcode,
 			}
 		)
 	}

--- a/src/services/postalCodeLoader.js
+++ b/src/services/postalCodeLoader.js
@@ -475,6 +475,18 @@ export function setNameOfZone(postalCode, _postalCodeData, setNameCallback, opti
 			const entity = postalCodeIndex.getByPostalCode(postalCode)
 			if (!entity || !entity._properties) return
 
+			// Guard against late-arriving resolutions for an outdated postal code:
+			// if the caller passes `getCurrentPostalCode`, skip the state update when
+			// the in-flight postalCode no longer matches the active one. This protects
+			// the rapid-click case where a stale .then() could otherwise overwrite the
+			// newer postal code's nameOfZone / pickedEntity.
+			if (
+				typeof options.getCurrentPostalCode === 'function' &&
+				options.getCurrentPostalCode() !== postalCode
+			) {
+				return
+			}
+
 			if (entity._properties._nimi && typeof entity._properties._nimi._value !== 'undefined') {
 				setNameCallback(entity._properties._nimi._value)
 			}

--- a/src/services/postalCodeLoader.js
+++ b/src/services/postalCodeLoader.js
@@ -454,23 +454,33 @@ export async function loadPostalCodeWithParallelStrategy(
  * Sets the name of the current zone from postal code data
  * Uses PostalCodeIndex for O(1) lookup instead of O(n) linear search.
  *
+ * Also populates the global store's `pickedEntity` from the index when no
+ * entity is currently picked. This means the Details-tab AreaProperties
+ * panel renders zone stats even when the user reached the postal code via
+ * search / URL deep-link / programmatic navigation rather than clicking the
+ * polygon on the map (issue #713). When the user *does* click a polygon,
+ * entityPicker.js sets a more specific entity and we leave that alone.
+ *
  * @param {string} postalCode - Postal code to find name for
  * @param {Object} _postalCodeData - Postal code data from propStore (unused, kept for API compatibility)
  * @param {Function} setNameCallback - Callback to set zone name in store
+ * @param {Object} [options] - Optional callbacks
+ * @param {Function} [options.setPickedEntityIfEmpty] - Receives the polygon entity; the global store action will be invoked only when no entity is currently set.
  * @returns {void}
  */
-export function setNameOfZone(postalCode, _postalCodeData, setNameCallback) {
+export function setNameOfZone(postalCode, _postalCodeData, setNameCallback, options = {}) {
 	// Import dynamically to avoid circular dependencies
 	import('./postalCodeIndex.js')
 		.then(({ postalCodeIndex }) => {
 			const entity = postalCodeIndex.getByPostalCode(postalCode)
-			if (
-				entity &&
-				entity._properties &&
-				entity._properties._nimi &&
-				typeof entity._properties._nimi._value !== 'undefined'
-			) {
+			if (!entity || !entity._properties) return
+
+			if (entity._properties._nimi && typeof entity._properties._nimi._value !== 'undefined') {
 				setNameCallback(entity._properties._nimi._value)
+			}
+
+			if (typeof options.setPickedEntityIfEmpty === 'function') {
+				options.setPickedEntityIfEmpty(entity)
 			}
 		})
 		.catch((error) => {

--- a/tests/e2e/audit-2026-W19/user-journeys.spec.ts
+++ b/tests/e2e/audit-2026-W19/user-journeys.spec.ts
@@ -8,12 +8,13 @@
  *
  * Soft vs. hard assertions:
  *   - `expect.soft(...)` is used for contracts tied to an open issue
- *     (#679, #681, #713, #715). The soft form surfaces every broken
- *     contract in a single run instead of bailing on the first. When an
- *     issue closes, the matching soft assertion graduates to a hard
- *     `expect` so the next regression is loud.
+ *     (#679, #681, #715). The soft form surfaces every broken contract in
+ *     a single run instead of bailing on the first. When an issue closes,
+ *     the matching soft assertion graduates to a hard `expect` so the next
+ *     regression is loud.
  *   - #711 lives in postal-code-breadcrumb.spec.ts (already hard).
  *   - #712 has graduated to hard — analysis-tab buttons must be visible.
+ *   - #713 has graduated to hard — AreaProperties must populate at postal-code level.
  *   - #714 has graduated to hard — URL params must clear on back-nav.
  *   - Plain `expect(...)` is used for structural pre/postconditions that
  *     must hold for the journey to make sense (e.g. Cesium ready, store
@@ -165,25 +166,19 @@ cesiumDescribe('Audit 2026-W19: user journeys', () => {
 				'TimelineCompact must be attached at postal-code level'
 			).toBeAttached()
 
-			// US-07 #713 — Area Properties heading + content live on the Details
-			// tab. Soft-assert visibility (heading must be present) and then
-			// soft-assert the panel body isn't "0 properties" — the empty-panel
-			// regression that #713 tracks.
+			// US-07 #713 — Area Properties heading + content live on the Details tab
+			// (graduated to hard after the #713 fix).
 			await cesiumPage.getByRole('tab', { name: 'Details' }).click()
 			const areaPropertiesHeading = cesiumPage.getByText('Area Properties', { exact: false })
-			await expect
-				.soft(
-					areaPropertiesHeading,
-					'US-07 #713 — Area Properties heading must be visible at postal-code level'
-				)
-				.toBeVisible()
+			await expect(
+				areaPropertiesHeading,
+				'US-07 #713 — Area Properties heading must be visible at postal-code level'
+			).toBeVisible()
 			const detailsTabBody = await cesiumPage.locator('.tab-content').first().textContent()
-			expect
-				.soft(
-					detailsTabBody ?? '',
-					'US-07 #713 — Area Properties content must not be empty at postal-code level'
-				)
-				.not.toMatch(/\b0\s+properties\b/i)
+			expect(
+				detailsTabBody ?? '',
+				'US-07 #713 — Area Properties content must not be empty at postal-code level'
+			).not.toMatch(/\b0\s+properties\b/i)
 
 			// Heat Distribution / NDVI Vegetation / Building Analysis buttons
 			// live on the Analysis tab. Switch tabs before asserting.


### PR DESCRIPTION
Closes #713

## Summary

After navigating to a postal code via search or URL deep-link, the DETAILS tab showed `0 properties for selected postal code` and the static prompt "Click on areas to view properties". Paavo + pygeoapi requests succeeded — they just never bound to UI because `AreaProperties.vue` read `globalStore.pickedEntity` exclusively, and that's only set when the user clicks a polygon on the map.

## What changed

Two-pronged fix so both interaction paths populate the panel:

- `src/components/AreaProperties.vue`: introduce a fallback that looks up the postal-code polygon entity from `postalCodeIndex` when no entity is picked. The new `effectiveEntity` computed combines `pickedEntity` (click path) and the index fallback (search/URL/store path) — `allProperties` reads from it.
- `src/services/postalCodeLoader.js` + `src/services/featurepicker/index.js`: when the loader flow runs `setNameOfZone` (real `loadPostalCode()` navigation), opportunistically seed `pickedEntity` from the index too — but only when it's currently null, so a real click that selected a more specific entity isn't overwritten.

## What test now hardens

`tests/e2e/audit-2026-W19/user-journeys.spec.ts` journey-2 (US-07) — graduated two `expect.soft(...)` assertions to hard `expect(...)`:

- Area Properties heading must be visible at postal-code level
- `.tab-content` body must not match `\b0 properties\b`

## Test plan

- [ ] Local: `bunx playwright test tests/e2e/audit-2026-W19/user-journeys.spec.ts --grep @journey-2 --reporter=line`
- [ ] Beta: search `00100`, open DETAILS, confirm chips populate (Postal, Area, Heat, etc.) and the empty-state message is gone.
