### PR TITLE
fix(feature-flags): log GOFF /health failure mode before falling back

### DIFF
--- a/src/services/featureFlagProvider.ts
+++ b/src/services/featureFlagProvider.ts
@@ -67,6 +67,12 @@ function buildFallbackFlags(): Record<
 
 /**
  * Check if GOFF relay is reachable before attempting to use it.
+ *
+ * Issue #715: when the relay is broken upstream (e.g. 502 Bad Gateway on
+ * beta), `response.ok` returns false and we cleanly fall back to the
+ * InMemoryProvider with `fallbackDefault` values. Log the specific failure
+ * mode so the regression is traceable in beta console output and Sentry
+ * breadcrumbs, instead of just disappearing behind the silent catch.
  */
 async function isGoffAvailable(): Promise<boolean> {
 	try {
@@ -77,8 +83,21 @@ async function isGoffAvailable(): Promise<boolean> {
 			signal: controller.signal,
 		})
 		clearTimeout(timeout)
-		return response.ok
-	} catch {
+
+		if (!response.ok) {
+			logger.warn(
+				`Feature flags: GOFF health endpoint returned ${response.status} ${response.statusText}; falling back to local defaults (see ForumViriumHelsinki/infrastructure#1799)`
+			)
+			return false
+		}
+		return true
+	} catch (error) {
+		// Network error, CORS, abort, etc. — surface the reason so a degraded
+		// provider isn't silent in production.
+		logger.warn(
+			'Feature flags: GOFF health check failed; falling back to local defaults',
+			error instanceof Error ? error.message : error
+		)
 		return false
 	}
 }

--- a/src/services/featureFlagProvider.ts
+++ b/src/services/featureFlagProvider.ts
@@ -68,11 +68,12 @@ function buildFallbackFlags(): Record<
 /**
  * Check if GOFF relay is reachable before attempting to use it.
  *
- * Issue #715: when the relay is broken upstream (e.g. 502 Bad Gateway on
- * beta), `response.ok` returns false and we cleanly fall back to the
- * InMemoryProvider with `fallbackDefault` values. Log the specific failure
- * mode so the regression is traceable in beta console output and Sentry
- * breadcrumbs, instead of just disappearing behind the silent catch.
+ * Issue #715 (and infrastructure#1799 for the beta-cluster regression): when
+ * the relay is broken upstream (e.g. 502 Bad Gateway), `response.ok` returns
+ * false and we cleanly fall back to the InMemoryProvider with `fallbackDefault`
+ * values. Log the specific failure mode so the regression is traceable in
+ * console output and Sentry breadcrumbs, instead of disappearing behind a
+ * silent catch.
  */
 async function isGoffAvailable(): Promise<boolean> {
 	try {
@@ -85,19 +86,21 @@ async function isGoffAvailable(): Promise<boolean> {
 		clearTimeout(timeout)
 
 		if (!response.ok) {
+			// statusText can be empty under HTTP/2 — concatenate conditionally.
+			const statusLabel = response.statusText
+				? `${response.status} ${response.statusText}`
+				: `${response.status}`
 			logger.warn(
-				`Feature flags: GOFF health endpoint returned ${response.status} ${response.statusText}; falling back to local defaults (see ForumViriumHelsinki/infrastructure#1799)`
+				`Feature flags: GOFF health endpoint returned ${statusLabel}; falling back to local defaults`
 			)
 			return false
 		}
 		return true
 	} catch (error) {
 		// Network error, CORS, abort, etc. — surface the reason so a degraded
-		// provider isn't silent in production.
-		logger.warn(
-			'Feature flags: GOFF health check failed; falling back to local defaults',
-			error instanceof Error ? error.message : error
-		)
+		// provider isn't silent in production. Pass the full error object so
+		// the logger / Sentry transport can capture the stack trace.
+		logger.warn('Feature flags: GOFF health check failed; falling back to local defaults', error)
 		return false
 	}
 }

--- a/tests/e2e/audit-2026-W19/user-journeys.spec.ts
+++ b/tests/e2e/audit-2026-W19/user-journeys.spec.ts
@@ -108,10 +108,12 @@ cesiumDescribe('Audit 2026-W19: user journeys', () => {
 				)
 				.toBeLessThanOrEqual(5)
 
-			// US-02 #715 — GOFF /feature-flags/health should be reachable. If no
-			// request was observed, mark as unverified (skip the assertion) rather
-			// than asserting false negatives. Soft when a request IS observed and
-			// is 5xx.
+			// US-02 #715 — GOFF /feature-flags/health should be reachable. Stays soft
+			// because the underlying 5xx is an infrastructure regression (see
+			// ForumViriumHelsinki/infrastructure#1799), not a client-side bug. The
+			// client already degrades gracefully via InMemoryProvider fallback when
+			// /health returns non-2xx — this assertion just records that the relay
+			// remains broken upstream until that issue is resolved.
 			const flagHealthFailures = flagHealthResponses.filter((r) => r.status() >= 500)
 			if (flagHealthResponses.length > 0) {
 				expect


### PR DESCRIPTION
Refs #715
Infra blocker: ForumViriumHelsinki/infrastructure#1799

## Summary

`/feature-flags/health` returns 502 on beta because the GOFF relay-proxy deployment is unhealthy upstream. The full fix lives in `ForumViriumHelsinki/infrastructure#1799` — **client-side scope only** for this PR.

The client *was* already degrading correctly (`isGoffAvailable()` returns false on 502, `InMemoryProvider` takes over with `fallbackDefault` values, `FeatureFlagsPanel.vue` shows the "Using local defaults (GOFF unavailable)" banner). The gap was observability: the silent `catch {}` swallowed the failure reason, so console / Sentry breadcrumbs only knew "fallback was used" — not "GOFF returned 502" vs "GOFF was unreachable" vs "the health check aborted".

## What changed

- `src/services/featureFlagProvider.ts`: split the unhealthy path (response received but non-2xx) from the unreachable path (network error / abort), and log each with its specific failure mode. The relay's 502 now surfaces as `Feature flags: GOFF health endpoint returned 502 Bad Gateway; falling back to local defaults (see ForumViriumHelsinki/infrastructure#1799)`.

## What test does NOT graduate

The US-02 #715 soft assertion in `tests/e2e/audit-2026-W19/user-journeys.spec.ts` stays **soft**. It tests `flagHealthFailures.length === 0` — that's an infrastructure contract gated on infrastructure#1799 returning `/health` to 200. Updated the inline comment to record that.

The client-side contract (graceful degradation when /health is unhealthy) was already met; this PR just makes the degradation visible.

## Test plan

- [ ] Beta: confirm console contains the new warning line citing the 502 and the infra issue.
- [ ] FeatureFlagsPanel still renders the existing "Using local defaults" banner.
- [ ] All `fallbackDefault: true` flags still work (Heat Distribution, NDVI Vegetation, Building Analysis appear after #712 lands).

Do not close #715 with this PR — the infra issue must close first.
