### PR TITLE
feat(camera): adaptive zoom altitude based on postal-code bbox

### DIFF
--- a/src/constants/viewport.js
+++ b/src/constants/viewport.js
@@ -9,3 +9,26 @@ export const VIEWPORT = {
 	FOG_START_HEIGHT: 3000, // meters - fog begins appearing
 	FOG_FULL_HEIGHT: 10000, // meters - fog reaches maximum density
 }
+
+/**
+ * Adaptive zoom constants for postal-code camera positioning.
+ * Altitude is derived from the polygon bounding-box diagonal (in meters),
+ * scaled per view-type, then clamped to MIN/MAX to keep sea-adjacent
+ * postal codes (where water inflates the bbox) bounded.
+ */
+export const POSTAL_CODE_ZOOM = {
+	// Multiplier applied to the bbox diagonal length to derive altitude.
+	// ~1.6x diagonal frames the area comfortably with margin in 2D top-down.
+	SCALE_2D: 1.6,
+	// 3D oblique view: camera sits lower and slightly south of center,
+	// so a smaller scale fills the same screen extent.
+	SCALE_3D: 1.1,
+	// Focus (45° pitch) view: between 2D and 3D scales.
+	SCALE_FOCUS: 1.3,
+	// Hard floor — very small postal codes should not zoom in closer than this.
+	MIN_ALTITUDE: 1500, // meters
+	// Hard ceiling — sea-adjacent postal codes with huge water bboxes get clamped.
+	MAX_ALTITUDE: 8000, // meters
+	// Fallback altitude used if bbox cannot be computed (no polygon hierarchy).
+	FALLBACK_ALTITUDE: 3500, // meters
+}

--- a/src/services/camera.js
+++ b/src/services/camera.js
@@ -22,12 +22,13 @@ const EARTH_RADIUS_M = 6371000
  * @private
  */
 function haversineMeters(lon1, lat1, lon2, lat2) {
-	const toRad = (deg) => (deg * Math.PI) / 180
-	const dLat = toRad(lat2 - lat1)
-	const dLon = toRad(lon2 - lon1)
+	const Cesium = getCesium()
+	const dLat = Cesium.Math.toRadians(lat2 - lat1)
+	const dLon = Cesium.Math.toRadians(lon2 - lon1)
+	const lat1Rad = Cesium.Math.toRadians(lat1)
+	const lat2Rad = Cesium.Math.toRadians(lat2)
 	const a =
-		Math.sin(dLat / 2) ** 2 +
-		Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2
+		Math.sin(dLat / 2) ** 2 + Math.cos(lat1Rad) * Math.cos(lat2Rad) * Math.sin(dLon / 2) ** 2
 	return 2 * EARTH_RADIUS_M * Math.asin(Math.sqrt(a))
 }
 
@@ -56,25 +57,19 @@ export function computePostalCodeAltitude(entity, scale) {
 		return POSTAL_CODE_ZOOM.FALLBACK_ALTITUDE
 	}
 
-	let minLon = Infinity
-	let maxLon = -Infinity
-	let minLat = Infinity
-	let maxLat = -Infinity
-
-	for (const position of positions) {
-		const carto = Cesium.Cartographic.fromCartesian(position)
-		const lon = Cesium.Math.toDegrees(carto.longitude)
-		const lat = Cesium.Math.toDegrees(carto.latitude)
-		if (lon < minLon) minLon = lon
-		if (lon > maxLon) maxLon = lon
-		if (lat < minLat) minLat = lat
-		if (lat > maxLat) maxLat = lat
-	}
-
-	if (!Number.isFinite(minLon) || !Number.isFinite(minLat)) {
+	// Cesium.Rectangle.fromCartesianArray returns west/east/south/north in radians and
+	// handles the antimeridian edge case correctly — preferable to a hand-rolled bbox
+	// loop over Cartographic.fromCartesian calls.
+	const rectangle = Cesium.Rectangle.fromCartesianArray(positions)
+	if (!rectangle) {
 		logger.debug('[Camera] Polygon bbox computation failed; using fallback altitude')
 		return POSTAL_CODE_ZOOM.FALLBACK_ALTITUDE
 	}
+
+	const minLon = Cesium.Math.toDegrees(rectangle.west)
+	const maxLon = Cesium.Math.toDegrees(rectangle.east)
+	const minLat = Cesium.Math.toDegrees(rectangle.south)
+	const maxLat = Cesium.Math.toDegrees(rectangle.north)
 
 	const diagonalMeters = haversineMeters(minLon, minLat, maxLon, maxLat)
 	const altitude = diagonalMeters * scale

--- a/src/services/camera.js
+++ b/src/services/camera.js
@@ -1,7 +1,86 @@
+import { POSTAL_CODE_ZOOM } from '../constants/viewport.js'
 import { useGlobalStore } from '../stores/globalStore.js'
 import logger from '../utils/logger.js'
 import { getCesium } from './cesiumProvider.js'
 import { postalCodeIndex } from './postalCodeIndex.js'
+
+/**
+ * Earth radius in meters (mean radius) — used by the haversine helper.
+ * @private
+ */
+const EARTH_RADIUS_M = 6371000
+
+/**
+ * Computes great-circle distance between two lon/lat points in meters
+ * using the haversine formula. Used to derive bbox diagonal length.
+ *
+ * @param {number} lon1 - First point longitude in degrees
+ * @param {number} lat1 - First point latitude in degrees
+ * @param {number} lon2 - Second point longitude in degrees
+ * @param {number} lat2 - Second point latitude in degrees
+ * @returns {number} Distance in meters
+ * @private
+ */
+function haversineMeters(lon1, lat1, lon2, lat2) {
+	const toRad = (deg) => (deg * Math.PI) / 180
+	const dLat = toRad(lat2 - lat1)
+	const dLon = toRad(lon2 - lon1)
+	const a =
+		Math.sin(dLat / 2) ** 2 +
+		Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2
+	return 2 * EARTH_RADIUS_M * Math.asin(Math.sqrt(a))
+}
+
+/**
+ * Computes camera altitude in meters that frames a postal-code polygon nicely.
+ * Derives the polygon's geodesic bounding box, takes its diagonal length,
+ * scales by the per-view-type factor, then clamps to MIN/MAX bounds.
+ *
+ * Falls back to FALLBACK_ALTITUDE if the polygon hierarchy cannot be read
+ * (e.g. mocked entities in tests, missing geometry).
+ *
+ * @param {Object} entity - Cesium postal-code entity (with `polygon.hierarchy`)
+ * @param {number} scale - View-specific multiplier (see POSTAL_CODE_ZOOM.SCALE_*)
+ * @returns {number} Altitude in meters, clamped to [MIN_ALTITUDE, MAX_ALTITUDE]
+ */
+export function computePostalCodeAltitude(entity, scale) {
+	const Cesium = getCesium()
+	const hierarchy = entity?.polygon?.hierarchy
+	const positions =
+		typeof hierarchy?.getValue === 'function'
+			? hierarchy.getValue(Cesium.JulianDate?.now?.())?.positions
+			: hierarchy?.positions
+
+	if (!positions || positions.length === 0) {
+		logger.debug('[Camera] No polygon hierarchy on entity; using fallback altitude')
+		return POSTAL_CODE_ZOOM.FALLBACK_ALTITUDE
+	}
+
+	let minLon = Infinity
+	let maxLon = -Infinity
+	let minLat = Infinity
+	let maxLat = -Infinity
+
+	for (const position of positions) {
+		const carto = Cesium.Cartographic.fromCartesian(position)
+		const lon = Cesium.Math.toDegrees(carto.longitude)
+		const lat = Cesium.Math.toDegrees(carto.latitude)
+		if (lon < minLon) minLon = lon
+		if (lon > maxLon) maxLon = lon
+		if (lat < minLat) minLat = lat
+		if (lat > maxLat) maxLat = lat
+	}
+
+	if (!Number.isFinite(minLon) || !Number.isFinite(minLat)) {
+		logger.debug('[Camera] Polygon bbox computation failed; using fallback altitude')
+		return POSTAL_CODE_ZOOM.FALLBACK_ALTITUDE
+	}
+
+	const diagonalMeters = haversineMeters(minLon, minLat, maxLon, maxLat)
+	const altitude = diagonalMeters * scale
+
+	return Math.min(POSTAL_CODE_ZOOM.MAX_ALTITUDE, Math.max(POSTAL_CODE_ZOOM.MIN_ALTITUDE, altitude))
+}
 
 /**
  * Camera Service
@@ -180,13 +259,16 @@ export default class Camera {
 			return
 		}
 
-		// TODO create function that takes size of postal code area and possibile location by the sea into consideration and sets y and z based on thse values
+		// Adaptive altitude based on the postal-code polygon bbox (#678).
+		// Larger areas zoom out further; smaller dense areas zoom in closer.
+		// Clamped to MIN/MAX so sea-adjacent postal codes don't explode the view.
 		const Cesium = getCesium()
+		const altitude = computePostalCodeAltitude(entity, POSTAL_CODE_ZOOM.SCALE_2D)
 		this.viewer.camera.flyTo({
 			destination: Cesium.Cartesian3.fromDegrees(
 				entity._properties._center_x._value,
 				entity._properties._center_y._value,
-				3500
+				altitude
 			),
 			orientation: {
 				heading: Cesium.Math.toRadians(0.0),
@@ -236,12 +318,14 @@ export default class Camera {
 		}
 
 		// Fly to postal code with 3D perspective
+		// Adaptive altitude (#678) — oblique view uses a smaller scale than 2D top-down.
 		const Cesium = getCesium()
+		const altitude = computePostalCodeAltitude(entity, POSTAL_CODE_ZOOM.SCALE_3D)
 		this.currentFlight = this.viewer.camera.flyTo({
 			destination: Cesium.Cartesian3.fromDegrees(
 				entity._properties._center_x._value,
 				entity._properties._center_y._value - 0.025,
-				2000
+				altitude
 			),
 			orientation: {
 				heading: 0.0,
@@ -441,12 +525,14 @@ export default class Camera {
 		}
 
 		// Fly to postal code area with 2-second animation
+		// Adaptive altitude (#678) — 45° pitch uses a middle-ground scale.
 		const Cesium = getCesium()
+		const altitude = computePostalCodeAltitude(entity, POSTAL_CODE_ZOOM.SCALE_FOCUS)
 		this.viewer.camera.flyTo({
 			destination: Cesium.Cartesian3.fromDegrees(
 				entity._properties._center_x._value,
 				entity._properties._center_y._value - 0.015,
-				2500
+				altitude
 			),
 			orientation: {
 				heading: 0.0,

--- a/tests/unit/services/camera.test.js
+++ b/tests/unit/services/camera.test.js
@@ -1,6 +1,7 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import Camera from '@/services/camera.js'
+import { POSTAL_CODE_ZOOM } from '@/constants/viewport.js'
+import Camera, { computePostalCodeAltitude } from '@/services/camera.js'
 import { useGlobalStore } from '@/stores/globalStore.js'
 
 // Mock Cesium additional methods - will be initialized in beforeEach
@@ -20,6 +21,8 @@ vi.mock('@/services/postalCodeIndex', () => ({
 }))
 
 // Mock cesiumProvider
+// `Cartographic.fromCartesian` is configured per-test where bbox math matters.
+// Default mock returns a fixed value sufficient for the rotate/position tests.
 vi.mock('@/services/cesiumProvider', () => ({
 	getCesium: vi.fn(() => ({
 		Cartesian3: {
@@ -39,6 +42,9 @@ vi.mock('@/services/cesiumProvider', () => ({
 				latitude: 1.0,
 				height: 1000,
 			})),
+		},
+		JulianDate: {
+			now: vi.fn(() => ({})),
 		},
 	})),
 }))
@@ -143,12 +149,13 @@ describe('Camera service', () => {
 			mockGetByPostalCode.mockReturnValue(mockEntity)
 		})
 
-		it('should fly to postal code area in 2D view', () => {
+		it('should fly to postal code area in 2D view with fallback altitude when polygon is missing', () => {
+			// Entity has no polygon hierarchy, so computePostalCodeAltitude returns FALLBACK_ALTITUDE.
 			camera.switchTo2DView()
 
 			expect(mockGetByPostalCode).toHaveBeenCalledWith('12345')
 			expect(mockFlyTo).toHaveBeenCalledWith({
-				destination: { x: 24.95, y: 60.17, z: 3500 },
+				destination: { x: 24.95, y: 60.17, z: POSTAL_CODE_ZOOM.FALLBACK_ALTITUDE },
 				orientation: {
 					heading: expect.any(Number),
 					pitch: expect.any(Number), // -90 degrees in radians
@@ -190,12 +197,13 @@ describe('Camera service', () => {
 			mockViewer.camera.position.clone = vi.fn(() => ({ x: 100, y: 200, z: 300 }))
 		})
 
-		it('should fly to postal code area in 3D view', () => {
+		it('should fly to postal code area in 3D view with fallback altitude when polygon is missing', () => {
+			// Entity has no polygon hierarchy, so computePostalCodeAltitude returns FALLBACK_ALTITUDE.
 			camera.switchTo3DView()
 
 			expect(mockGetByPostalCode).toHaveBeenCalledWith('12345')
 			expect(mockFlyTo).toHaveBeenCalledWith({
-				destination: { x: 24.95, y: 60.145, z: 2000 }, // y - 0.025
+				destination: { x: 24.95, y: 60.145, z: POSTAL_CODE_ZOOM.FALLBACK_ALTITUDE }, // y - 0.025
 				orientation: {
 					heading: 0.0,
 					pitch: expect.any(Number), // -35 degrees in radians
@@ -866,6 +874,133 @@ describe('Camera service', () => {
 				// Should not accumulate state
 				expect(camera.previousCameraState).toBeDefined()
 			})
+		})
+	})
+
+	/**
+	 * Adaptive zoom altitude tests (#678).
+	 * Verifies that the bbox-diagonal altitude calculation scales appropriately
+	 * with postal-code area size and clamps to MIN/MAX bounds.
+	 */
+	describe('computePostalCodeAltitude (#678)', () => {
+		// Build a mock entity whose `polygon.hierarchy.getValue().positions` matches
+		// a sequence of cartographic points we control via Cartographic.fromCartesian.
+		function entityWithCorners(corners) {
+			return {
+				polygon: {
+					hierarchy: {
+						getValue: () => ({ positions: corners.map((_, i) => ({ _markerIndex: i })) }),
+					},
+				},
+			}
+		}
+
+		/**
+		 * Configure the cesiumProvider mock so that fromCartesian returns the
+		 * cartographic point indexed by `_markerIndex` on the marker.
+		 * The helper converts back to degrees via `Cesium.Math.toDegrees(radians)`,
+		 * so the cartographic value must be supplied in radians.
+		 */
+		async function stubCartographic(corners) {
+			const { getCesium } = await import('@/services/cesiumProvider')
+			const cesium = getCesium()
+			cesium.Cartographic.fromCartesian.mockImplementation((marker) => {
+				const { lon, lat } = corners[marker._markerIndex]
+				return {
+					longitude: (lon * Math.PI) / 180,
+					latitude: (lat * Math.PI) / 180,
+					height: 0,
+				}
+			})
+		}
+
+		it('returns fallback altitude when entity has no polygon hierarchy', () => {
+			const entity = {}
+			const altitude = computePostalCodeAltitude(entity, POSTAL_CODE_ZOOM.SCALE_2D)
+			expect(altitude).toBe(POSTAL_CODE_ZOOM.FALLBACK_ALTITUDE)
+		})
+
+		it('returns fallback altitude when positions array is empty', () => {
+			const entity = {
+				polygon: { hierarchy: { getValue: () => ({ positions: [] }) } },
+			}
+			const altitude = computePostalCodeAltitude(entity, POSTAL_CODE_ZOOM.SCALE_2D)
+			expect(altitude).toBe(POSTAL_CODE_ZOOM.FALLBACK_ALTITUDE)
+		})
+
+		it('clamps tiny postal codes to MIN_ALTITUDE', async () => {
+			// ~100 m diagonal — should clamp to MIN_ALTITUDE regardless of scale.
+			const corners = [
+				{ lon: 24.95, lat: 60.17 },
+				{ lon: 24.9505, lat: 60.1705 },
+				{ lon: 24.951, lat: 60.171 },
+				{ lon: 24.95, lat: 60.171 },
+			]
+			await stubCartographic(corners)
+			const altitude = computePostalCodeAltitude(
+				entityWithCorners(corners),
+				POSTAL_CODE_ZOOM.SCALE_2D
+			)
+			expect(altitude).toBe(POSTAL_CODE_ZOOM.MIN_ALTITUDE)
+		})
+
+		it('clamps huge sea-adjacent postal codes to MAX_ALTITUDE', async () => {
+			// ~50 km diagonal (simulating a coastal area where the bbox includes water).
+			const corners = [
+				{ lon: 24.5, lat: 60.0 },
+				{ lon: 25.0, lat: 60.3 },
+			]
+			await stubCartographic(corners)
+			const altitude = computePostalCodeAltitude(
+				entityWithCorners(corners),
+				POSTAL_CODE_ZOOM.SCALE_2D
+			)
+			expect(altitude).toBe(POSTAL_CODE_ZOOM.MAX_ALTITUDE)
+		})
+
+		it('scales medium postal codes within [MIN, MAX] proportionally to bbox diagonal', async () => {
+			// ~3 km diagonal — should land inside the clamp window.
+			const corners = [
+				{ lon: 24.95, lat: 60.17 },
+				{ lon: 24.99, lat: 60.19 },
+			]
+			await stubCartographic(corners)
+			const altitude = computePostalCodeAltitude(
+				entityWithCorners(corners),
+				POSTAL_CODE_ZOOM.SCALE_2D
+			)
+			expect(altitude).toBeGreaterThan(POSTAL_CODE_ZOOM.MIN_ALTITUDE)
+			expect(altitude).toBeLessThan(POSTAL_CODE_ZOOM.MAX_ALTITUDE)
+		})
+
+		it('3D scale produces a lower altitude than 2D scale for the same bbox', async () => {
+			const corners = [
+				{ lon: 24.95, lat: 60.17 },
+				{ lon: 24.99, lat: 60.19 },
+			]
+			await stubCartographic(corners)
+			const entity = entityWithCorners(corners)
+			const altitude2D = computePostalCodeAltitude(entity, POSTAL_CODE_ZOOM.SCALE_2D)
+			const altitude3D = computePostalCodeAltitude(entity, POSTAL_CODE_ZOOM.SCALE_3D)
+			expect(altitude3D).toBeLessThan(altitude2D)
+		})
+
+		it('accepts static positions array (no getValue function)', async () => {
+			const corners = [
+				{ lon: 24.95, lat: 60.17 },
+				{ lon: 24.99, lat: 60.19 },
+			]
+			await stubCartographic(corners)
+			const entity = {
+				polygon: {
+					hierarchy: {
+						positions: corners.map((_, i) => ({ _markerIndex: i })),
+					},
+				},
+			}
+			const altitude = computePostalCodeAltitude(entity, POSTAL_CODE_ZOOM.SCALE_2D)
+			expect(altitude).toBeGreaterThan(POSTAL_CODE_ZOOM.MIN_ALTITUDE)
+			expect(altitude).toBeLessThan(POSTAL_CODE_ZOOM.MAX_ALTITUDE)
 		})
 	})
 })

--- a/tests/unit/services/camera.test.js
+++ b/tests/unit/services/camera.test.js
@@ -46,6 +46,22 @@ vi.mock('@/services/cesiumProvider', () => {
 				height: 1000,
 			})),
 		},
+		// Mirrors Cesium.Rectangle.fromCartesianArray by delegating to Cartographic.fromCartesian
+		// — tests configure that stub per-case, so the bbox math threads through cleanly.
+		Rectangle: {
+			fromCartesianArray: vi.fn((cartesians) => {
+				if (!cartesians || cartesians.length === 0) return undefined
+				const cartographics = cartesians.map((c) => cesiumStub.Cartographic.fromCartesian(c))
+				const lons = cartographics.map((c) => c.longitude)
+				const lats = cartographics.map((c) => c.latitude)
+				return {
+					west: Math.min(...lons),
+					east: Math.max(...lons),
+					south: Math.min(...lats),
+					north: Math.max(...lats),
+				}
+			}),
+		},
 		JulianDate: {
 			now: vi.fn(() => ({})),
 		},

--- a/tests/unit/services/camera.test.js
+++ b/tests/unit/services/camera.test.js
@@ -23,8 +23,11 @@ vi.mock('@/services/postalCodeIndex', () => ({
 // Mock cesiumProvider
 // `Cartographic.fromCartesian` is configured per-test where bbox math matters.
 // Default mock returns a fixed value sufficient for the rotate/position tests.
-vi.mock('@/services/cesiumProvider', () => ({
-	getCesium: vi.fn(() => ({
+// IMPORTANT: getCesium() must return a *stable* object so per-test
+// `mockImplementation` overrides on Cartographic.fromCartesian persist across
+// the helper's internal calls to getCesium().
+vi.mock('@/services/cesiumProvider', () => {
+	const cesiumStub = {
 		Cartesian3: {
 			fromDegrees: vi.fn((lon, lat, alt) => ({ x: lon, y: lat, z: alt })),
 		},
@@ -46,8 +49,9 @@ vi.mock('@/services/cesiumProvider', () => ({
 		JulianDate: {
 			now: vi.fn(() => ({})),
 		},
-	})),
-}))
+	}
+	return { getCesium: vi.fn(() => cesiumStub) }
+})
 
 describe('Camera service', () => {
 	let camera


### PR DESCRIPTION
## Summary

- Camera zoom altitude now adapts to each postal-code's polygon bbox diagonal instead of the hardcoded 3500 m
- Scale factors per view (2D / 3D / focus) and clamped to `[1500m, 8000m]` so sea-adjacent / large rural codes don't blow out the view
- New `computePostalCodeAltitude(entity, scale)` helper centralises the math; constants live in `src/constants/viewport.js`

## Test plan

- [x] Unit tests added — 7 new cases covering fallback, MIN/MAX clamping, mid-range scaling, 2D-vs-3D comparison, static-positions path
- [x] `bun run lint` clean
- [x] `bun run test:unit` — 726 pass, 4 pre-existing skips, 0 failures
- [ ] Visual smoke in dev mode across small/medium/large postal codes (reviewer)

Fixes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>