### PR TITLE
fix(cesium): guard viewer-property access against destroyed instances

### DIFF
--- a/src/composables/useCameraControls.js
+++ b/src/composables/useCameraControls.js
@@ -43,6 +43,12 @@ export function useCameraControls(viewer, onCameraSettled, onUrlUpdate = null) {
 			return
 		}
 
+		// Idempotent re-registration: if a previous handler exists, remove it before
+		// attaching the replacement so retry / re-init paths don't stack listeners.
+		if (moveEndHandler && !viewer.isDestroyed?.()) {
+			viewer.camera.moveEnd.removeEventListener(moveEndHandler)
+		}
+
 		moveEndHandler = () => {
 			// Clear any pending timeout
 			if (cameraMoveTimeout) {

--- a/src/composables/useCameraControls.js
+++ b/src/composables/useCameraControls.js
@@ -27,6 +27,7 @@ import logger from '../utils/logger.js'
  */
 export function useCameraControls(viewer, onCameraSettled, onUrlUpdate = null) {
 	let cameraMoveTimeout = null
+	let moveEndHandler = null
 	const DEBOUNCE_DELAY_MS = TIMING.CAMERA_DEBOUNCE_MS // Wait 1500ms after camera stops moving to prevent blinking
 
 	/**
@@ -42,7 +43,7 @@ export function useCameraControls(viewer, onCameraSettled, onUrlUpdate = null) {
 			return
 		}
 
-		viewer.camera.moveEnd.addEventListener(() => {
+		moveEndHandler = () => {
 			// Clear any pending timeout
 			if (cameraMoveTimeout) {
 				clearTimeout(cameraMoveTimeout)
@@ -50,6 +51,9 @@ export function useCameraControls(viewer, onCameraSettled, onUrlUpdate = null) {
 
 			// Set new timeout
 			cameraMoveTimeout = setTimeout(() => {
+				// Bail if the viewer was destroyed during the debounce window —
+				// otherwise onCameraSettled / onUrlUpdate would dereference a null scene.
+				if (!viewer || viewer.isDestroyed?.()) return
 				logger.debug('[useCameraControls] 📷 Camera movement ended, checking viewport state...')
 				if (onCameraSettled) {
 					onCameraSettled().catch((error) => {
@@ -62,7 +66,8 @@ export function useCameraControls(viewer, onCameraSettled, onUrlUpdate = null) {
 					onUrlUpdate()
 				}
 			}, DEBOUNCE_DELAY_MS)
-		})
+		}
+		viewer.camera.moveEnd.addEventListener(moveEndHandler)
 
 		logger.debug(
 			'[useCameraControls] ✅ Camera moveEnd listener added with',
@@ -72,8 +77,9 @@ export function useCameraControls(viewer, onCameraSettled, onUrlUpdate = null) {
 	}
 
 	/**
-	 * Cleans up camera timeout if active.
-	 * Should be called in onBeforeUnmount to prevent memory leaks.
+	 * Cleans up camera timeout and removes the moveEnd subscription.
+	 * Should be called in onBeforeUnmount to prevent memory leaks and
+	 * post-destroy scene access.
 	 *
 	 * @returns {void}
 	 */
@@ -81,8 +87,12 @@ export function useCameraControls(viewer, onCameraSettled, onUrlUpdate = null) {
 		if (cameraMoveTimeout) {
 			clearTimeout(cameraMoveTimeout)
 			cameraMoveTimeout = null
-			logger.debug('[useCameraControls] 🧹 Camera timeout cleared')
 		}
+		if (moveEndHandler && viewer && !viewer.isDestroyed?.()) {
+			viewer.camera.moveEnd.removeEventListener(moveEndHandler)
+		}
+		moveEndHandler = null
+		logger.debug('[useCameraControls] 🧹 Camera moveEnd listener and timeout cleared')
 	}
 
 	return {

--- a/src/composables/useViewerInitialization.js
+++ b/src/composables/useViewerInitialization.js
@@ -183,6 +183,11 @@ export function useViewerInitialization() {
 		// Guard against access after viewer.destroy() — the listener can outlive the
 		// viewer instance on hot-reload or route swap, which previously surfaced as
 		// `Cannot read properties of null (reading 'scene')` in Sentry.
+		// Idempotent re-registration: retryInit may call initViewer twice, so the
+		// previous listener must be removed before the new one is attached.
+		if (visibilityChangeHandler) {
+			document.removeEventListener('visibilitychange', visibilityChangeHandler)
+		}
 		visibilityChangeHandler = () => {
 			if (!viewer.value || viewer.value.isDestroyed?.()) return
 
@@ -213,6 +218,8 @@ export function useViewerInitialization() {
 			viewer.value.destroy()
 		}
 		viewer.value = null
+		// Clear the store reference so other services don't keep a stale viewer.
+		store.setCesiumViewer(null)
 	}
 
 	/**

--- a/src/composables/useViewerInitialization.js
+++ b/src/composables/useViewerInitialization.js
@@ -54,6 +54,10 @@ export function useViewerInitialization() {
 	let Camera = null
 	let Graphics = null
 
+	// Captured handler for cleanup — visibilitychange fires globally, so the listener
+	// must be removed when the viewer is torn down to avoid post-destroy scene access.
+	let visibilityChangeHandler = null
+
 	/**
 	 * Initializes the Cesium viewer with dynamic module loading.
 	 * Loads Cesium library and dependencies asynchronously to prevent blocking initial render.
@@ -175,9 +179,12 @@ export function useViewerInitialization() {
 		const camera = new Camera()
 		camera.init()
 
-		// Optimize CPU usage: pause rendering when tab is hidden
-		document.addEventListener('visibilitychange', () => {
-			if (!viewer.value) return
+		// Optimize CPU usage: pause rendering when tab is hidden.
+		// Guard against access after viewer.destroy() — the listener can outlive the
+		// viewer instance on hot-reload or route swap, which previously surfaced as
+		// `Cannot read properties of null (reading 'scene')` in Sentry.
+		visibilityChangeHandler = () => {
+			if (!viewer.value || viewer.value.isDestroyed?.()) return
 
 			if (document.hidden) {
 				viewer.value.scene.requestRenderMode = true
@@ -187,7 +194,25 @@ export function useViewerInitialization() {
 				viewer.value.scene.requestRender()
 				logger.debug('[useViewerInitialization] ▶ Rendering resumed (tab visible)')
 			}
-		})
+		}
+		document.addEventListener('visibilitychange', visibilityChangeHandler)
+	}
+
+	/**
+	 * Tears down the viewer and removes globally-registered listeners.
+	 * Safe to call multiple times; idempotent.
+	 *
+	 * @returns {void}
+	 */
+	const destroyViewer = () => {
+		if (visibilityChangeHandler) {
+			document.removeEventListener('visibilitychange', visibilityChangeHandler)
+			visibilityChangeHandler = null
+		}
+		if (viewer.value && !viewer.value.isDestroyed?.()) {
+			viewer.value.destroy()
+		}
+		viewer.value = null
 	}
 
 	/**
@@ -284,5 +309,6 @@ export function useViewerInitialization() {
 		addPostalCodes,
 		addAttribution,
 		retryInit,
+		destroyViewer,
 	}
 }

--- a/src/composables/useViewportLoading.js
+++ b/src/composables/useViewportLoading.js
@@ -226,11 +226,11 @@ export function useViewportLoading(viewer, getCamera, getFeaturepicker) {
 	 * Watch for changes to viewport streaming feature flag
 	 * Dynamically enables/disables tile-based viewport loading at runtime.
 	 */
-	watch(
+	const stopViewportStreamingWatch = watch(
 		() => featureFlagStore.isEnabled('viewportStreaming'),
 		async (newValue, _oldValue) => {
-			if (!viewer?.value) {
-				logger.warn('[useViewportLoading] Viewer not initialized, cannot toggle viewport streaming')
+			if (!viewer?.value || viewer.value.isDestroyed?.()) {
+				logger.warn('[useViewportLoading] Viewer not ready, cannot toggle viewport streaming')
 				return
 			}
 
@@ -257,9 +257,13 @@ export function useViewportLoading(viewer, getCamera, getFeaturepicker) {
 	 * - When viewport streaming is enabled: uses viewportBuildingLoader methods
 	 * - When viewport streaming is disabled: uses Datasource to hide/show postal code buildings
 	 */
-	watch(
+	const stopGrid250mWatch = watch(
 		() => toggleStore.grid250m,
 		async (gridEnabled) => {
+			// Guard against post-destroy access — Datasource.changeDataSourceShowByName
+			// reads cesiumViewer.dataSources, which is the dataSources null-deref signature in Sentry.
+			if (!viewer?.value || viewer.value.isDestroyed?.()) return
+
 			if (gridEnabled) {
 				// Grid turned ON - hide all buildings
 				logger.debug('[useViewportLoading] 250m grid enabled, hiding buildings')
@@ -291,6 +295,11 @@ export function useViewportLoading(viewer, getCamera, getFeaturepicker) {
 	)
 
 	onBeforeUnmount(async () => {
+		// Stop the watchers before tearing down loaders — otherwise a final tick can
+		// fire async work against a destroyed viewer.
+		stopViewportStreamingWatch()
+		stopGrid250mWatch()
+
 		// Clean up viewport building loader if initialized
 		if (viewportBuildingLoader) {
 			await viewportBuildingLoader.shutdown()

--- a/src/pages/CesiumViewer.vue
+++ b/src/pages/CesiumViewer.vue
@@ -198,6 +198,7 @@ export default {
 			addPostalCodes,
 			addAttribution,
 			retryInit: baseRetryInit,
+			destroyViewer,
 		} = viewerInit
 
 		// Data loading composable (auto-loads on mount)
@@ -341,6 +342,9 @@ export default {
 				fogCleanup()
 			}
 			cleanupEntityPicking()
+			// Tears down the visibilitychange listener and viewer instance so the
+			// composable's globals don't leak across hot-reload or route swaps.
+			destroyViewer()
 		})
 
 		return {


### PR DESCRIPTION
## Summary

Recurring `Cannot read properties of null (reading 'creditDisplay' | 'dataSources')` cluster — 14 Sentry fingerprints, ~81 events since 2026-02-18. Follow-up to #590 where one fingerprint was fixed but the broader lifecycle leak persisted.

Three high-impact subscriptions identified by the W19 audit (full audit in issue comments) — all fire async work after `viewer.destroy()`:

| File | Leak | Fix |
|---|---|---|
| `useViewerInitialization.js` | global `visibilitychange` listener never removed; reads `viewer.scene.requestRenderMode` | Capture handler ref; expose `destroyViewer()`; guard body with `viewer.isDestroyed?.()` |
| `useCameraControls.js` | `camera.moveEnd` listener never removed; debounce-fired callback reads scene | Capture handler ref; remove on cleanup; guard the setTimeout body |
| `useViewportLoading.js` | two `watch()` calls without stop-handles; grid250m watcher calls `Datasource.changeDataSourceShowByName` → reads `viewer.dataSources` | Capture stop-handles; call in `onBeforeUnmount`; guard watcher body with `viewer.isDestroyed?.()` |

These are the three subscriptions whose callbacks match the exact Sentry signatures. The audit identifies 11 more defence-in-depth sites (viewportBuildingLoader RAF chains, graphics.js `$subscribe` leak, datasource.js bulk callers, etc.) — those are intentionally **out of scope** for this PR to keep the diff reviewable. They can be tracked as a follow-up.

## Test plan

- [x] Pre-commit hooks (biome check, conventional-commit) pass
- [ ] CI: lint + unit + typecheck + accessibility (reviewer)
- [ ] Manual smoke: rapid route swap (start → postal code → start) and tab visibility flip; confirm no `creditDisplay` / `dataSources` errors in console
- [ ] 7-day Sentry watch: confirm R4C-CESIUM-VIEWER-1X / 1Y / 1V / 1R / 1S / 1M / 1K / 1F / 1D / 19 / 1B / 1E / 1P / 1H stop firing

## Follow-ups (intentionally not in this PR)

The audit in #739 comments lists files 4–14 with `isDestroyed?.()` guards needed for full defence in depth. Worth a separate refactor PR.

Fixes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>