### PR TITLE
fix: building tooltip text invisible in dark mode

### DIFF
--- a/src/components/BuildingInformation.vue
+++ b/src/components/BuildingInformation.vue
@@ -116,13 +116,13 @@ export default {
 			position: 'absolute',
 			top: `${mousePosition.value.y + 15}px`,
 			left: `${mousePosition.value.x + 15}px`,
-			background: 'rgba(30, 30, 30, 0.95)',
-			color: 'white',
+			background: 'rgba(var(--v-theme-surface), 0.95)',
+			color: 'rgb(var(--v-theme-on-surface))',
 			padding: '12px',
 			borderRadius: '8px',
 			pointerEvents: 'none',
 			backdropFilter: 'blur(8px)',
-			border: '1px solid rgba(255, 255, 255, 0.1)',
+			border: '1px solid rgba(var(--v-theme-on-surface), 0.12)',
 		}))
 
 		/**
@@ -456,7 +456,7 @@ export default {
 	align-items: center;
 	gap: 8px;
 	padding-bottom: 8px;
-	border-bottom: 1px solid rgba(var(--v-theme-surface), 0.1);
+	border-bottom: 1px solid rgba(var(--v-theme-on-surface), 0.12);
 }
 
 .building-icon {
@@ -465,7 +465,7 @@ export default {
 
 .building-title {
 	font-weight: 600;
-	color: rgb(var(--v-theme-surface));
+	color: rgb(var(--v-theme-on-surface));
 	font-size: 13px;
 	letter-spacing: 0.3px;
 }
@@ -492,7 +492,7 @@ export default {
 }
 
 .data-value {
-	color: rgb(var(--v-theme-surface));
+	color: rgb(var(--v-theme-on-surface));
 	font-weight: 400;
 	flex: 1;
 	word-wrap: break-word;
@@ -512,17 +512,17 @@ export default {
 /* High contrast mode support */
 @media (prefers-contrast: high) {
 	.building-tooltip {
-		background: rgb(var(--v-theme-on-surface)) !important;
-		border: 2px solid #ffffff;
+		background: rgb(var(--v-theme-surface)) !important;
+		border: 2px solid rgb(var(--v-theme-on-surface));
 	}
 
 	.building-title,
 	.data-value {
-		color: rgb(var(--v-theme-surface));
+		color: rgb(var(--v-theme-on-surface));
 	}
 
 	.temp-value {
-		color: rgb(var(--v-theme-surface));
+		color: rgb(var(--v-theme-on-surface));
 	}
 }
 

--- a/src/components/BuildingInformation.vue
+++ b/src/components/BuildingInformation.vue
@@ -513,7 +513,7 @@ export default {
 @media (prefers-contrast: high) {
 	.building-tooltip {
 		background: rgb(var(--v-theme-surface)) !important;
-		border: 2px solid rgb(var(--v-theme-on-surface));
+		border: 2px solid rgb(var(--v-theme-on-surface)) !important;
 	}
 
 	.building-title,


### PR DESCRIPTION
## Summary

Building hover tooltips rendered dark text on a dark background when the system theme was set to dark mode (reported on macOS).

**Root cause:** `BuildingInformation.vue` mixed two color systems:

- The tooltip *container* set its background via a JS inline style with **hardcoded** dark colors (`rgba(30, 30, 30, 0.95)` + `color: 'white'`).
- The *inner text* (`.building-title`, `.data-value`) used `color: rgb(var(--v-theme-surface))`.

`--v-theme-surface` is the background color variable, not a foreground color. In light mode `surface` is near-white, which happened to render correctly against the hardcoded dark background. In dark mode `surface` flips to dark, so the text became dark-on-dark.

**Fix:** Use themed variables on both sides:

- Container background → `rgba(var(--v-theme-surface), 0.95)`
- Text → `rgb(var(--v-theme-on-surface))`
- Borders → `rgba(var(--v-theme-on-surface), 0.12)`
- The `prefers-contrast: high` media query had the same inverted semantics and is corrected the same way.

Box shadow is intentionally left as a hardcoded `rgba(0, 0, 0, 0.4)` per the project's CSS theming exception list (shadows work fine in both themes).

No tracking issue exists; reported directly. Nothing to auto-close.

## Test plan

- [ ] Hover a building in **light mode** → tooltip readable (dark text on light glassmorphic surface)
- [ ] Hover a building in **dark mode** → tooltip readable (light text on dark glassmorphic surface)
- [ ] Enable system "Increase Contrast" / `prefers-contrast: high` in both themes → tooltip has opaque background and stronger border, text remains readable
- [ ] Existing tooltip positioning, blur, and ARIA attributes unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01Avnzp8avbbBmNuCDxoSBGc)_