### PR TITLE
fix(propsStore): remove deprecated Cesium-entity fields to close DataCloneError surface

### DIFF
--- a/docs/architecture/ARCHITECTURE_DIAGRAM.md
+++ b/docs/architecture/ARCHITECTURE_DIAGRAM.md
@@ -224,9 +224,8 @@ Any of these operations trigger the error:
 
 | Issue                                       | Location                            | Impact                     | Severity |
 | ------------------------------------------- | ----------------------------------- | -------------------------- | -------- |
-| Non-serializable Cesium entities in store   | propsStore.setTreeEntities()        | DataCloneError             | CRITICAL |
-| Non-serializable Cesium datasource in store | propsStore.setBuildingsDatasource() | DataCloneError             | CRITICAL |
+| Non-serializable Cesium entities in store   | propsStore.setTreeEntities()        | DataCloneError             | Resolved (fields removed; entities live in `cesiumEntityManager`) |
+| Non-serializable Cesium datasource in store | propsStore.setBuildingsDatasource() | DataCloneError             | Resolved (fields removed; entities live in `cesiumEntityManager`) |
 | Unsafe private property access              | NearbyTreeArea.vue:204              | API breakage risk          | HIGH     |
 | Mutating Cesium entity properties           | NearbyTreeArea.vue:240,299          | Data corruption risk       | HIGH     |
 | Unsafe private property access              | tree.js:300                         | API breakage risk          | HIGH     |
-| Missing markRaw() for entities              | propsStore.scatterPlotEntities      | Potential reactivity issue | MEDIUM   |

--- a/docs/investigations/tree-rendering/DATACLONE_ERROR_ANALYSIS.md
+++ b/docs/investigations/tree-rendering/DATACLONE_ERROR_ANALYSIS.md
@@ -1,5 +1,11 @@
 # Tree Toggle DataCloneError Analysis
 
+> **Resolved (GitHub #679).** Cesium entities have been moved out of Pinia into the
+> non-reactive registry at `src/services/cesiumEntityManager.js`. The deprecated
+> `propsStore.treeEntities` and `propsStore.buildingsDatasource` fields (and their setters)
+> have been removed. This document is retained for historical context — the root-cause
+> analysis no longer reflects the current code.
+
 ## Summary
 
 The DataCloneError is caused by Cesium entities (with non-serializable internal properties) being stored in the Pinia `propsStore` and then being passed to Web Workers. While `markRaw()` is correctly used for some properties, the entities contain internal Cesium properties that cannot be serialized.

--- a/docs/investigations/tree-rendering/ISSUE_QUICK_REFERENCE.md
+++ b/docs/investigations/tree-rendering/ISSUE_QUICK_REFERENCE.md
@@ -1,5 +1,11 @@
 # Tree Toggle DataCloneError - Quick Reference
 
+> **Resolved (GitHub #679).** Cesium entities are no longer stored in Pinia. The non-reactive
+> registry lives in `src/services/cesiumEntityManager.js`; `src/services/tree.js` extracts
+> serializable tree data into `propsStore` and registers live entities with the manager. The
+> deprecated `propsStore.treeEntities` / `propsStore.buildingsDatasource` fields (and their
+> setters) have been removed. The analysis below is preserved for historical context.
+
 ## The Error
 
 ```

--- a/docs/investigations/tree-rendering/README.md
+++ b/docs/investigations/tree-rendering/README.md
@@ -1,5 +1,10 @@
 # Tree Rendering Investigation
 
+> **Resolved (GitHub #679).** Cesium entities now live in a non-reactive registry at
+> `src/services/cesiumEntityManager.js`, and the deprecated `propsStore.treeEntities` /
+> `propsStore.buildingsDatasource` fields have been removed. Documents in this folder are
+> preserved as historical record of the investigation.
+
 Investigation into tree rendering issues in the R4C Cesium Viewer, focusing on DataClone errors and toggle functionality problems.
 
 ## Documents

--- a/src/main.js
+++ b/src/main.js
@@ -69,11 +69,9 @@ pinia.use(
 		// Cesium objects contain non-serializable properties (functions, circular refs, getters)
 		// that cannot be cloned for postMessage() calls to Sentry servers
 		stateTransformer: (state, store) => {
-			// For propsStore, exclude deprecated Cesium entity properties
+			// For propsStore, exclude Cesium entity/datasource properties that remain on the store
 			if (store.$id === 'props') {
 				const {
-					treeEntities: _treeEntities,
-					buildingsDatasource: _buildingsDatasource,
 					postalCodeData: _postalCodeData,
 					heatFloodVulnerabilityEntity: _heatFloodVulnerabilityEntity,
 					...serializable

--- a/src/stores/propsStore.js
+++ b/src/stores/propsStore.js
@@ -29,8 +29,6 @@ import { markRaw } from 'vue'
  * @property {Map|null} treeAreasByBuildingId - Map of building IDs to tree area calculations (serializable)
  * @property {Array|null} treeData - Serializable tree data (kohde_id, p_ala_m2) for analysis
  * @property {Map|null} buildingData - Serializable building data (id -> {heatExposure, area_m2}) for analysis
- * @property {Array|null} treeEntities - Cesium tree entity references (DEPRECATED - use cesiumEntityManager)
- * @property {Object|null} buildingsDatasource - Cesium buildings data source reference (DEPRECATED - use cesiumEntityManager)
  * @property {Array|null} postalcodeHeatTimeseries - Postal code heat time-series data
  * @property {Array|null} buildingHeatTimeseries - Building-level heat time-series data
  * @property {Object|null} heatFloodVulnerabilityEntity - Selected entity for vulnerability analysis
@@ -50,8 +48,6 @@ export const usePropsStore = defineStore('props', {
 		treeAreasByBuildingId: null,
 		treeData: null,
 		buildingData: null,
-		treeEntities: null,
-		buildingsDatasource: null,
 		postalcodeHeatTimeseries: null,
 		buildingHeatTimeseries: null,
 		heatFloodVulnerabilityEntity: null,
@@ -180,26 +176,6 @@ export const usePropsStore = defineStore('props', {
 		 */
 		setBuildingData(buildingData) {
 			this.buildingData = buildingData
-		},
-		/**
-		 * Sets tree entity references for analysis
-		 * @param {Array<Object>} entities - Cesium tree canopy entities
-		 * @deprecated Use setTreeData() and cesiumEntityManager instead
-		 * @note Uses markRaw to prevent Cesium entities from becoming reactive,
-		 *       which would cause DataCloneError in Web Workers
-		 */
-		setTreeEntities(entities) {
-			this.treeEntities = markRaw(entities)
-		},
-		/**
-		 * Sets buildings data source reference
-		 * @param {Object} datasource - Cesium buildings data source
-		 * @deprecated Use setBuildingData() and cesiumEntityManager instead
-		 * @note Uses markRaw to prevent Cesium datasource from becoming reactive,
-		 *       which would cause DataCloneError in Web Workers
-		 */
-		setBuildingsDatasource(datasource) {
-			this.buildingsDatasource = markRaw(datasource)
 		},
 		/**
 		 * Sets postal code-level heat exposure time-series data


### PR DESCRIPTION
Closes #679.

## Summary

The DataCloneError fix has substantially landed already — Cesium entities flow through the non-reactive registry at `src/services/cesiumEntityManager.js`, `tree.js` extracts serializable `treeData` / `buildingData` into the store, and `NearbyTreeArea.vue` reads serializable data + looks up live entities by id. What remained were **dead, deprecated APIs in `propsStore`** that the issue explicitly flagged as risky: if anything ever called `setTreeEntities()` or `setBuildingsDatasource()` again, the crash would come back. They had no callers (verified with grep), only a defensive destructure in the Sentry state transformer.

This PR removes the dead surface so it can't be misused.

## Changes

- `src/stores/propsStore.js` — remove deprecated `treeEntities` / `buildingsDatasource` state fields, their `setTreeEntities()` / `setBuildingsDatasource()` setters, and the matching JSDoc typedef entries. `markRaw` import retained (still used by `setPostalCodeData` / `setHeatFloodVulnerability`).
- `src/main.js` — Sentry `stateTransformer` no longer destructures the removed `props` fields; still strips the Cesium refs that remain on the store (`postalCodeData`, `heatFloodVulnerabilityEntity`).
- `docs/investigations/tree-rendering/{README,ISSUE_QUICK_REFERENCE,DATACLONE_ERROR_ANALYSIS}.md` — short "Resolved (#679)" banner at the top pointing to `cesiumEntityManager.js`. Historical content preserved.
- `docs/architecture/ARCHITECTURE_DIAGRAM.md` — risk table updated: the two CRITICAL rows mention "Resolved (fields removed; entities live in `cesiumEntityManager`)"; the stale `scatterPlotEntities` row (field was already gone) deleted.

## Verification

- `grep` for `setTreeEntities` / `setBuildingsDatasource` / `\.treeEntities` / `\.buildingsDatasource` across `src/` and `tests/` — only unrelated hits remain (`Tree.resetTreeEntities()` and `cesiumEntityManager.treeEntitiesById`, both unrelated).
- `bun run lint` — clean (`Checked 166 files in 785ms. No fixes applied.`).
- `bun run build` — `✓ built in 7.67s`. Warnings (`protobufjs` direct eval, Cesium chunk size, `BuildingInformation.vue` static+dynamic import overlap) are pre-existing and unrelated.
- No `propsStore` unit tests exist, so nothing to run there.

## Test plan

- [ ] CI passes (lint, build, e2e if applicable)
- [ ] Manual smoke test: toggle the Trees layer at postal-code level — verify the nearby-tree-area chart still renders and entity highlights still apply (the manager-backed path)
- [ ] Sentry capture from a dev session shows no error and no Cesium objects in `props` store snapshot

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mee3wM2tutUAB7mbZUKMYC)_