### PR TITLE
refactor(building): per-tile abort signals for parallel building+heat fetch (#681)

### DIFF
--- a/src/services/building/buildingLoader.js
+++ b/src/services/building/buildingLoader.js
@@ -215,11 +215,16 @@ export class BuildingLoader {
 				})
 			}
 
-			// Clear tracking on successful load
-			this._currentLoadingLayerId = null
-			this._currentHeatLayerId = null
-			this._heatAbortController = null
-			this._currentLoadingToken = null
+			// Clear tracking on successful load — guard against late arrivals
+			// (a previous load that resolved after a newer one started would
+			// otherwise clear the newer load's AbortController and IDs, breaking
+			// subsequent cancellation)
+			if (this._currentLoadingToken === loadToken) {
+				this._currentLoadingLayerId = null
+				this._currentHeatLayerId = null
+				this._heatAbortController = null
+				this._currentLoadingToken = null
+			}
 
 			return entities
 		} catch (error) {

--- a/src/services/building/buildingLoader.js
+++ b/src/services/building/buildingLoader.js
@@ -37,6 +37,10 @@ export class BuildingLoader {
 		this.unifiedLoader = unifiedLoader
 		/** @type {string|null} Currently loading layer ID for cancellation */
 		this._currentLoadingLayerId = null
+		/** @type {string|null} Currently loading heat layer ID for cancellation */
+		this._currentHeatLayerId = null
+		/** @type {AbortController|null} AbortController for the in-flight heat-data fetch */
+		this._heatAbortController = null
 		/** @type {symbol|null} Unique per-invocation token used to detect stale loads */
 		this._currentLoadingToken = null
 	}
@@ -53,7 +57,8 @@ export class BuildingLoader {
 
 	/**
 	 * Cancels the current building load operation.
-	 * Aborts in-flight network requests via unifiedLoader's AbortController.
+	 * Aborts in-flight network requests via unifiedLoader's AbortController for the
+	 * building layer, and via the per-tile heat AbortController for the heat-data fetch.
 	 * Safe to call even if no load is in progress.
 	 *
 	 * @returns {void}
@@ -64,6 +69,15 @@ export class BuildingLoader {
 			this.unifiedLoader.cancelLoading(this._currentLoadingLayerId)
 			this._currentLoadingLayerId = null
 		}
+		if (this._heatAbortController) {
+			logger.debug(
+				'[BuildingLoader] Aborting in-flight heat-data fetch for:',
+				this._currentHeatLayerId
+			)
+			this._heatAbortController.abort()
+			this._heatAbortController = null
+		}
+		this._currentHeatLayerId = null
 		this._currentLoadingToken = null
 	}
 
@@ -108,6 +122,15 @@ export class BuildingLoader {
 		this._currentLoadingLayerId = layerId
 		this._currentLoadingToken = loadToken
 
+		// Per-tile AbortController for the heat-data fetch.
+		// cancelCurrentLoad() calls abort() on this controller so the in-flight
+		// network request is cancelled immediately when the user navigates away,
+		// rather than waiting for the response to arrive and then discarding it.
+		const heatLayerId = `heat_${targetPostalCode}`
+		const heatAbortController = new AbortController()
+		this._currentHeatLayerId = heatLayerId
+		this._heatAbortController = heatAbortController
+
 		try {
 			// Configure building data fetch
 			const buildingConfig = {
@@ -128,7 +151,7 @@ export class BuildingLoader {
 			logger.debug('[HelsinkiBuilding] Initiating parallel fetch for buildings and heat data')
 			const [buildingResult, heatResult] = await Promise.allSettled([
 				this.unifiedLoader.loadLayer(buildingConfig),
-				this.urbanheatService.getHeatData(targetPostalCode),
+				this.urbanheatService.getHeatData(targetPostalCode, { signal: heatAbortController.signal }),
 			])
 
 			if (this._isStale(loadToken)) return []
@@ -194,6 +217,8 @@ export class BuildingLoader {
 
 			// Clear tracking on successful load
 			this._currentLoadingLayerId = null
+			this._currentHeatLayerId = null
+			this._heatAbortController = null
 			this._currentLoadingToken = null
 
 			return entities
@@ -201,6 +226,8 @@ export class BuildingLoader {
 			// Clear tracking on error (but not on cancellation - already cleared)
 			if (this._currentLoadingToken === loadToken) {
 				this._currentLoadingLayerId = null
+				this._currentHeatLayerId = null
+				this._heatAbortController = null
 				this._currentLoadingToken = null
 			}
 			logger.error('[HelsinkiBuilding] Error loading buildings:', error)

--- a/src/services/urbanheat.js
+++ b/src/services/urbanheat.js
@@ -51,12 +51,23 @@ export default class Urbanheat {
 	 * This method can be called in parallel with building data fetching.
 	 *
 	 * @param {string} postalCode - Postal code to fetch heat data for
-	 * @returns {Promise<Object|null>} Heat data GeoJSON or null if unavailable
+	 * @param {Object} [options={}] - Optional fetch options
+	 * @param {AbortSignal} [options.signal] - AbortSignal to cancel the in-flight request.
+	 *   When the signal fires, the fetch is aborted and null is returned silently
+	 *   (same treatment as the stale-token path in BuildingLoader).
+	 * @returns {Promise<Object|null>} Heat data GeoJSON or null if unavailable or aborted
 	 */
-	async getHeatData(postalCode) {
+	async getHeatData(postalCode, { signal } = {}) {
+		// If the caller already aborted before we even start, return null immediately.
+		if (signal?.aborted) {
+			logger.debug('[UrbanHeat] Heat data fetch aborted before start for:', postalCode)
+			return null
+		}
+
 		try {
+			const layerId = `heat_${postalCode}`
 			const heatConfig = {
-				layerId: `heat_${postalCode}`,
+				layerId,
 				url: this.urlStore.urbanHeatHelsinki(postalCode),
 				type: 'geojson',
 				options: {
@@ -68,11 +79,40 @@ export default class Urbanheat {
 				},
 			}
 
+			// If a signal is provided, abort the unifiedLoader layer when it fires.
+			// unifiedLoader owns its own AbortController per layerId; calling cancelLoading()
+			// aborts that controller immediately so the network request is freed.
+			let abortListener = null
+			if (signal) {
+				abortListener = () => {
+					unifiedLoader.cancelLoading(layerId)
+				}
+				signal.addEventListener('abort', abortListener, { once: true })
+			}
+
 			logger.debug('[UrbanHeat] 🌡️ Fetching heat data for postal code:', postalCode)
-			const heatData = await unifiedLoader.loadLayer(heatConfig)
-			logger.debug('[UrbanHeat] ✅ Heat data loaded:', heatData?.features?.length || 0, 'features')
-			return heatData
+			try {
+				const heatData = await unifiedLoader.loadLayer(heatConfig)
+				logger.debug(
+					'[UrbanHeat] ✅ Heat data loaded:',
+					heatData?.features?.length || 0,
+					'features'
+				)
+				return heatData
+			} finally {
+				// Always clean up the abort listener to avoid leaking it if the signal
+				// outlives this fetch (e.g. the load completes before cancellation fires).
+				if (signal && abortListener) {
+					signal.removeEventListener('abort', abortListener)
+				}
+			}
 		} catch (error) {
+			// AbortError means the caller cancelled the load — treat as a silent no-op
+			// (same as the stale-token path in BuildingLoader: return null, don't log as error).
+			if (error?.name === 'AbortError' || signal?.aborted) {
+				logger.debug('[UrbanHeat] Heat data fetch aborted for:', postalCode)
+				return null
+			}
 			logger.warn('[UrbanHeat] ⚠️ Failed to fetch heat data for', postalCode, ':', error.message)
 			return null
 		}


### PR DESCRIPTION
Closes #681

## Summary

- **`buildingLoader.js`**: Added `_heatAbortController` and `_currentHeatLayerId` fields. A new `AbortController` is created per `loadBuildings()` invocation and its `signal` is passed to `urbanheat.getHeatData()`. `cancelCurrentLoad()` now calls `abort()` on this controller immediately — freeing network bandwidth as soon as the user navigates away, rather than waiting for the response to arrive and discard it via the stale-token path.
- **`urbanheat.js`**: `getHeatData()` accepts an optional `{ signal }` second parameter (backwards-compatible default `{} = {}`). When the signal fires, an abort listener calls `unifiedLoader.cancelLoading(layerId)` to abort the underlying fetch. AbortError and pre-aborted signals are treated as silent no-ops (returns `null`), matching the existing stale-token path. The listener is removed in a `finally` block to prevent leaks.
- **`unifiedLoader.js`**: Not modified — the existing per-layerId `AbortController` and `cancelLoading()` mechanism is the correct abort path; no changes needed.

## Why

The W19 audit landed `_loadToken` staleness detection and per-layerId abort in `unifiedLoader`, which mitigated the acute race condition. The remaining gap: `cancelCurrentLoad()` did not abort the in-flight heat-data network request — it only aborted the building-data fetch and discarded the heat result on arrival. This PR closes that gap by wiring a per-tile `AbortController` through the heat-data path so cancellation is immediate at the network layer.

See #681 for full context.

## Test plan

- [x] `bun run lint` — passes clean (Biome, no new violations)
- [x] `bunx vitest run --reporter=dot` — 799 passed, 4 pre-existing skips, 0 failures
- [ ] Manual repro: navigate to a postal code, immediately click a second postal code while heat data is loading — confirm Network tab shows the first heat request cancelled (status: `(cancelled)`), and the second postal code renders correctly without stale heat data
- [ ] Confirm no error toasts appear on rapid postal-code switching (AbortError is swallowed silently)

No unit tests currently cover `buildingLoader` or `urbanheat.getHeatData` directly — that gap is pre-existing and out of scope for this refactor.