### PR TITLE
fix(cesium): apply isDestroyed guards to W19 audit-residue files (#761)

### DIFF
--- a/src/components/BuildingInformation.vue
+++ b/src/components/BuildingInformation.vue
@@ -314,7 +314,9 @@ export default {
 				const endPosition = event.endPosition
 				mousePosition.value = { x: endPosition.x, y: endPosition.y }
 
-				if (buildingStore.buildingFeatures && viewer) {
+				// Guard against the viewer being torn down between the event and
+				// the deferred RAF tick — viewer.scene.pick() throws on a destroyed viewer.
+				if (buildingStore.buildingFeatures && viewer && !viewer.isDestroyed?.()) {
 					const Cesium = getCesium()
 					const pickedEntity = viewer.scene.pick(
 						new Cesium.Cartesian2(endPosition.x, endPosition.y)
@@ -336,7 +338,12 @@ export default {
 		 * @returns {void}
 		 */
 		const registerMouseMoveHandler = () => {
-			if (handlerRegistered.value || !viewer || !viewer.screenSpaceEventHandler) {
+			if (
+				handlerRegistered.value ||
+				!viewer ||
+				viewer.isDestroyed?.() ||
+				!viewer.screenSpaceEventHandler
+			) {
 				logger.debug('[BuildingInformation] ⚠️ Cannot register handler:', {
 					alreadyRegistered: handlerRegistered.value,
 					hasViewer: Boolean(viewer),
@@ -361,6 +368,13 @@ export default {
 		 */
 		const unregisterMouseMoveHandler = () => {
 			if (!handlerRegistered.value || !viewer || !viewer.screenSpaceEventHandler) {
+				return
+			}
+
+			// If the viewer is already destroyed, the input action is gone too —
+			// flip the flag and bail rather than calling into a teardown-stale handler.
+			if (viewer.isDestroyed?.()) {
+				handlerRegistered.value = false
 				return
 			}
 

--- a/src/composables/useFogEffect.js
+++ b/src/composables/useFogEffect.js
@@ -115,6 +115,7 @@ export function useFogEffect(viewer) {
 	 * Called on camera change events with debouncing.
 	 */
 	const updateOverlayFromAltitude = () => {
+		if (!viewer || viewer.isDestroyed?.()) return
 		if (!viewer?.camera?.positionCartographic || !overlayElement) return
 
 		const altitude = viewer.camera.positionCartographic.height
@@ -169,8 +170,10 @@ export function useFogEffect(viewer) {
 			updateDebounceTimeout = null
 		}
 
-		if (viewer?.camera && cameraChangedHandler) {
+		if (viewer?.camera && !viewer.isDestroyed?.() && cameraChangedHandler) {
 			viewer.camera.changed.removeEventListener(cameraChangedHandler)
+			cameraChangedHandler = null
+		} else {
 			cameraChangedHandler = null
 		}
 

--- a/src/services/building/buildingFilter.js
+++ b/src/services/building/buildingFilter.js
@@ -153,7 +153,7 @@ export class BuildingFilter {
 		}
 
 		// Request render after batch updates
-		if (this.viewer) {
+		if (this.viewer && !this.viewer.isDestroyed?.()) {
 			this.viewer.scene.requestRender()
 		}
 
@@ -245,7 +245,7 @@ export class BuildingFilter {
 		}
 
 		// Request render after batch updates if there were changes
-		if (hasChanges && this.viewer) {
+		if (hasChanges && this.viewer && !this.viewer.isDestroyed?.()) {
 			this.viewer.scene.requestRender()
 		}
 

--- a/src/services/camera.js
+++ b/src/services/camera.js
@@ -410,11 +410,9 @@ export default class Camera {
 	 * @returns {void}
 	 */
 	setCameraView(longitude, latitude) {
-		const store = useGlobalStore()
-		const viewer = store.cesiumViewer
-		if (!viewer || viewer.isDestroyed?.()) return
+		if (!this.viewer || this.viewer.isDestroyed?.()) return
 		const Cesium = getCesium()
-		viewer.camera.setView({
+		this.viewer.camera.setView({
 			destination: Cesium.Cartesian3.fromDegrees(longitude, latitude - 0.0065, 500.0),
 			orientation: {
 				heading: 0.0,

--- a/src/services/camera.js
+++ b/src/services/camera.js
@@ -125,7 +125,7 @@ export default class Camera {
 	 * Stores position and orientation for use if flight is cancelled.
 	 */
 	captureCurrentState() {
-		if (!this.viewer) {
+		if (!this.viewer || this.viewer.isDestroyed?.()) {
 			logger.warn('[Camera] Cannot capture camera state: Viewer not initialized')
 			return
 		}
@@ -151,7 +151,7 @@ export default class Camera {
 			return
 		}
 
-		if (!this.viewer) {
+		if (!this.viewer || this.viewer.isDestroyed?.()) {
 			logger.warn('[Camera] Cannot restore camera state: Viewer not initialized')
 			return
 		}
@@ -217,6 +217,7 @@ export default class Camera {
 	 * @returns {void}
 	 */
 	init() {
+		if (!this.viewer || this.viewer.isDestroyed?.()) return
 		const Cesium = getCesium()
 		this.viewer.camera.setView({
 			destination: Cesium.Cartesian3.fromDegrees(24.945, 60.17, 2800),
@@ -237,7 +238,7 @@ export default class Camera {
 	 */
 	switchTo2DView() {
 		// Guard: Check viewer is initialized
-		if (!this.viewer || !this.viewer.dataSources) {
+		if (!this.viewer || this.viewer.isDestroyed?.() || !this.viewer.dataSources) {
 			logger.warn('[Camera] Cannot switch to 2D view: Viewer not initialized')
 			return
 		}
@@ -284,7 +285,7 @@ export default class Camera {
 	 */
 	switchTo3DView() {
 		// Guard: Check viewer is initialized
-		if (!this.viewer || !this.viewer.dataSources) {
+		if (!this.viewer || this.viewer.isDestroyed?.() || !this.viewer.dataSources) {
 			logger.warn('[Camera] Cannot switch to 3D view: Viewer not initialized')
 			return
 		}
@@ -343,6 +344,7 @@ export default class Camera {
 	 * @returns {void}
 	 */
 	switchTo3DGrid() {
+		if (!this.viewer || this.viewer.isDestroyed?.()) return
 		if (this.store.level === 'start') {
 			this.flyCamera3D(24.991745, 60.045, 12000)
 		} else {
@@ -385,6 +387,7 @@ export default class Camera {
 	 * @returns {void}
 	 */
 	flyCamera3D(lat, long, z) {
+		if (!this.viewer || this.viewer.isDestroyed?.()) return
 		const Cesium = getCesium()
 		this.viewer.camera.flyTo({
 			destination: Cesium.Cartesian3.fromDegrees(lat, long, z),
@@ -407,9 +410,11 @@ export default class Camera {
 	 * @returns {void}
 	 */
 	setCameraView(longitude, latitude) {
-		const Cesium = getCesium()
 		const store = useGlobalStore()
-		store.cesiumViewer.camera.setView({
+		const viewer = store.cesiumViewer
+		if (!viewer || viewer.isDestroyed?.()) return
+		const Cesium = getCesium()
+		viewer.camera.setView({
 			destination: Cesium.Cartesian3.fromDegrees(longitude, latitude - 0.0065, 500.0),
 			orientation: {
 				heading: 0.0,
@@ -427,6 +432,7 @@ export default class Camera {
 	 * @returns {void}
 	 */
 	zoom(multiplier) {
+		if (!this.viewer || this.viewer.isDestroyed?.()) return
 		if (multiplier > 1) {
 			// Zoom in: move camera closer to ground
 			this.viewer.camera.zoomIn(
@@ -447,6 +453,7 @@ export default class Camera {
 	 * @returns {void}
 	 */
 	setHeading(headingInDegrees, reduceMotion = false) {
+		if (!this.viewer || this.viewer.isDestroyed?.()) return
 		const Cesium = getCesium()
 		const orientation = {
 			heading: Cesium.Math.toRadians(headingInDegrees),
@@ -474,6 +481,7 @@ export default class Camera {
 	 * Resets the camera orientation to face North with a default pitch.
 	 */
 	resetNorth() {
+		if (!this.viewer || this.viewer.isDestroyed?.()) return
 		const Cesium = getCesium()
 		this.viewer.camera.flyTo({
 			destination: this.viewer.camera.position,
@@ -496,7 +504,7 @@ export default class Camera {
 	 */
 	focusOnPostalCode(postalCode) {
 		// Guard: Check viewer is initialized
-		if (!this.viewer) {
+		if (!this.viewer || this.viewer.isDestroyed?.()) {
 			logger.warn('[Camera] Cannot focus on postal code: Viewer not initialized')
 			return
 		}
@@ -548,6 +556,7 @@ export default class Camera {
 	 * @returns {void}
 	 */
 	rotate180Degrees() {
+		if (!this.viewer || this.viewer.isDestroyed?.()) return
 		const Cesium = getCesium()
 		const camera = this.viewer.camera
 		const scene = this.viewer.scene
@@ -614,6 +623,7 @@ export default class Camera {
 	 * @returns {Object|null} { west, south, east, north } in degrees, or null if no ellipsoid intersection
 	 */
 	getViewportRectangle() {
+		if (!this.viewer || this.viewer.isDestroyed?.()) return null
 		const Cesium = getCesium()
 		const camera = this.viewer.camera
 		const canvas = this.viewer.scene.canvas

--- a/src/services/datasource.js
+++ b/src/services/datasource.js
@@ -25,7 +25,9 @@ export default class DataSource {
 	 * @returns {void}
 	 */
 	showAllDataSources() {
-		this.store.cesiumViewer.dataSources._dataSources.forEach((dataSource) => {
+		const viewer = this.store.cesiumViewer
+		if (!viewer || viewer.isDestroyed?.()) return
+		viewer.dataSources._dataSources.forEach((dataSource) => {
 			logVisibilityChange(
 				'datasource',
 				dataSource.name,
@@ -46,7 +48,9 @@ export default class DataSource {
 	 * @returns {Promise<void>}
 	 */
 	async changeDataSourceShowByName(name, show) {
-		this.store.cesiumViewer.dataSources._dataSources.forEach((dataSource) => {
+		const viewer = this.store.cesiumViewer
+		if (!viewer || viewer.isDestroyed?.()) return
+		viewer.dataSources._dataSources.forEach((dataSource) => {
 			if (dataSource.name.startsWith(name)) {
 				logVisibilityChange(
 					'datasource',
@@ -68,9 +72,11 @@ export default class DataSource {
 	 * @returns {Promise<void>}
 	 */
 	async removeDataSourcesAndEntities() {
-		await this.store.cesiumViewer.dataSources.removeAll()
+		const viewer = this.store.cesiumViewer
+		if (!viewer || viewer.isDestroyed?.()) return
+		await viewer.dataSources.removeAll()
 		// Remove all entities directly added to the viewer
-		await this.store.cesiumViewer.entities.removeAll()
+		await viewer.entities.removeAll()
 	}
 
 	/**
@@ -80,7 +86,9 @@ export default class DataSource {
 	 * @returns {Cesium.DataSource|undefined} The matching data source, or undefined if not found
 	 */
 	getDataSourceByName(name) {
-		return this.store.cesiumViewer.dataSources._dataSources.find((ds) => ds.name === name)
+		const viewer = this.store.cesiumViewer
+		if (!viewer || viewer.isDestroyed?.()) return undefined
+		return viewer.dataSources._dataSources.find((ds) => ds.name === name)
 	}
 
 	/**
@@ -382,7 +390,9 @@ export default class DataSource {
 	 * @returns {Promise<void>} Promise that resolves when operation completes
 	 */
 	async removeDuplicateDataSources() {
-		const dataSources = this.store.cesiumViewer.dataSources._dataSources
+		const viewer = this.store.cesiumViewer
+		if (!viewer || viewer.isDestroyed?.()) return
+		const dataSources = viewer.dataSources._dataSources
 		const uniqueDataSources = {}
 
 		// Track first occurrence of each uniquely named data source
@@ -399,13 +409,13 @@ export default class DataSource {
 		}
 
 		// Clear all existing data sources
-		this.store.cesiumViewer.dataSources.removeAll()
+		viewer.dataSources.removeAll()
 
 		// Re-add only unique data sources
 		const addPromises = []
 		for (const name in uniqueDataSources) {
 			const dataSource = uniqueDataSources[name].dataSource
-			const addPromise = this.store.cesiumViewer.dataSources.add(dataSource)
+			const addPromise = viewer.dataSources.add(dataSource)
 			addPromises.push(addPromise)
 		}
 
@@ -421,12 +431,14 @@ export default class DataSource {
 	 * @returns {Promise<void>}
 	 */
 	async removeDataSourceByName(name) {
+		const viewer = this.store.cesiumViewer
+		if (!viewer || viewer.isDestroyed?.()) return
 		// Find the data source named 'MajorDistricts' in the viewer
 		const majorDistrictsDataSource = this.getDataSourceByName(name)
 
 		// If the data source is found, remove it
 		if (majorDistrictsDataSource) {
-			this.store.cesiumViewer.dataSources.remove(majorDistrictsDataSource, true)
+			viewer.dataSources.remove(majorDistrictsDataSource, true)
 		}
 	}
 }

--- a/src/services/graphics.js
+++ b/src/services/graphics.js
@@ -28,6 +28,7 @@ export default class Graphics {
 		this.viewer = null
 		this.scene = null
 		this._supportDetected = false
+		this._unsubscribe = null
 	}
 
 	/**
@@ -46,6 +47,7 @@ export default class Graphics {
 		// Apply settings will trigger lazy detection
 		requestIdleCallback(
 			() => {
+				if (!this.viewer || this.viewer.isDestroyed?.()) return
 				this.detectSupport()
 				this.applyGraphicsSettings()
 			},
@@ -177,8 +179,9 @@ export default class Graphics {
 	 * Set up reactive watchers for graphics settings
 	 */
 	setupWatchers() {
-		// Watch for MSAA changes
-		this.graphicsStore.$subscribe((mutation, _state) => {
+		// Watch for MSAA changes — store stop fn so destroy() can release it
+		this._unsubscribe = this.graphicsStore.$subscribe((mutation, _state) => {
+			if (!this.viewer || this.viewer.isDestroyed?.()) return
 			// mutation.events may be undefined for single-change mutations
 			const events = Array.isArray(mutation.events) ? mutation.events : []
 
@@ -195,6 +198,19 @@ export default class Graphics {
 				this.applyAmbientOcclusionSettings()
 			}
 		})
+	}
+
+	/**
+	 * Release the Pinia subscription so callbacks stop firing after teardown.
+	 * Owner must call this from onBeforeUnmount / destroyViewer paths.
+	 */
+	destroy() {
+		if (this._unsubscribe) {
+			this._unsubscribe()
+			this._unsubscribe = null
+		}
+		this.viewer = null
+		this.scene = null
 	}
 
 	/**

--- a/src/services/traveltime.js
+++ b/src/services/traveltime.js
@@ -89,6 +89,7 @@ export default class Traveltime {
 			features: [],
 		}
 
+		if (!this.viewer || this.viewer.isDestroyed?.()) return
 		const dataSources = this.viewer.dataSources.getByName('TravelTimeGrid')
 
 		if (dataSources?.length > 0) {
@@ -181,6 +182,7 @@ export default class Traveltime {
 	 * - Eye offset: Elevated above ground for visibility
 	 */
 	async addTravelLabelDataSource(data) {
+		if (!this.viewer || this.viewer.isDestroyed?.()) return
 		const Cesium = getCesium()
 
 		try {
@@ -230,6 +232,7 @@ export default class Traveltime {
 	 * - Eye offset: Elevated for visibility
 	 */
 	markCurrentLocation(entity) {
+		if (!this.viewer || this.viewer.isDestroyed?.()) return
 		const Cesium = getCesium()
 		const hierarchy = entity.polygon.hierarchy.getValue().positions
 

--- a/src/services/viewportBuildingLoader.js
+++ b/src/services/viewportBuildingLoader.js
@@ -330,7 +330,7 @@ export default class ViewportBuildingLoader {
 	 * @private
 	 */
 	updateCameraVelocity() {
-		if (!this.viewer) return
+		if (!this.viewer || this.viewer.isDestroyed?.()) return
 
 		const Cesium = getCesium()
 		const cameraCartographic = this.viewer.camera.positionCartographic
@@ -361,8 +361,8 @@ export default class ViewportBuildingLoader {
 	 * @returns {Promise<void>}
 	 */
 	async updateViewport() {
-		if (!this.viewer) {
-			logger.warn('[ViewportBuildingLoader] Viewer not initialized')
+		if (!this.viewer || this.viewer.isDestroyed?.()) {
+			logger.warn('[ViewportBuildingLoader] Viewer not initialized or destroyed')
 			return
 		}
 
@@ -425,6 +425,7 @@ export default class ViewportBuildingLoader {
 	 * @returns {Object|null} {west, south, east, north} in degrees, or null if viewport cannot be determined
 	 */
 	getViewportBounds() {
+		if (!this.viewer || this.viewer.isDestroyed?.()) return null
 		try {
 			const Cesium = getCesium()
 			// Lazily initialize scratch rectangle
@@ -1038,10 +1039,15 @@ export default class ViewportBuildingLoader {
 					)
 				}
 
-				// Request render
-				if (this.viewer) {
-					this.viewer.scene.requestRender()
+				// Bail out of the animation loop if the viewer was destroyed
+				// while the fade-in chain was scheduled.
+				if (!this.viewer || this.viewer.isDestroyed?.()) {
+					resolve()
+					return
 				}
+
+				// Request render
+				this.viewer.scene.requestRender()
 
 				if (step < FADE_CONFIG.STEPS) {
 					// Schedule next frame with stepDuration delay


### PR DESCRIPTION
Closes #761

## Summary

Defence-in-depth follow-up to PR #758. Adds `viewer.isDestroyed?.()` guards to the 7 callback paths surfaced by the W19 audit (one commit per file for attributable Sentry-signature diff).

| File | Pattern guarded |
|------|---|
| `src/services/datasource.js` | 5 bulk callers (`showAllDataSources`, `changeDataSourceShowByName`, `removeDataSourcesAndEntities`, `getDataSourceByName`, etc.) |
| `src/services/camera.js` | 10 `this.viewer` accesses (capture/restore, init, switch2D/3D, switch3DGrid, flyCamera3D, setCameraView) |
| `src/services/graphics.js` | `requestIdleCallback` callback + previously-leaked `graphicsStore.$subscribe` (now saves stop fn, exposes `destroy()`) |
| `src/services/traveltime.js` | `addTravelTimeLabels`, `addTravelLabelDataSource`, `markCurrentLocation` (3 viewer accesses) |
| `src/services/building/buildingFilter.js` | 2 `viewer.scene.requestRender` calls (filterBuildings + showAllBuildings) |
| `src/composables/useFogEffect.js` | debounced setTimeout altitude callback + cleanup hardening |
| `src/services/viewportBuildingLoader.js` | `updateCameraVelocity`, `updateViewport`, `getViewportBounds`, fade-in RAF chain |
| `src/components/BuildingInformation.vue` | RAF-deferred `viewer.scene.pick` + register/unregister handlers |

## Why

Sentry signatures R4C-CESIUM-VIEWER-1X/1Y/1V/1R/1S/1M/1K/1F/1D/19/1B/1E/1P/1H all share the same root cause: callbacks that capture the viewer and fire after `destroyViewer()` (rapid route swap, visibility flip, HMR reload). PR #758 closed the top-3; this PR closes the long-tail residue identified in the W19 audit so subsequent navigation patterns can't reintroduce the same DataCloneError class.

The `graphics.js` change is the only structural addition: the previously-undetached `$subscribe` is now released via a new `destroy()` method.

## Test plan

- [x] `bun run lint` — clean (166 files, no fixes applied)
- [ ] Manual smoke: rapid route swap (Capital Region → Postal Code → back) + visibility flip on layer toggles. No console errors on teardown.
- [ ] 7-day Sentry watch on the 1X/1Y/1V/1R/1S/1M/1K/1F/1D/19/1B/1E/1P/1H signature cluster post-merge. Residual fingerprints should stop firing.

## Notes

- One commit per file as called for in #761 so the Sentry diff can be attributed per-callback.
- `graphics.js` adds a `destroy()` method — call sites that own a `Graphics` instance should call it in `onBeforeUnmount`. Wired-up in this PR scope: out of scope (existing call sites already rely on garbage collection; the new method is opt-in).
- No changes to `buildingLoader.js`, `unifiedLoader.js`, or `urbanheat.js` (those are owned by the parallel #681 PR #774).

---
**Update 2026-05-25**: Addressed @gemini-code-assist review feedback with commit `refactor(camera): use this.viewer in setCameraView for consistency` (6363ee7).