### PR TITLE
fix(scatterplot): guard against null scatterPlotEntities (#776)

### DIFF
--- a/src/components/HSYScatterplot.vue
+++ b/src/components/HSYScatterplot.vue
@@ -94,6 +94,8 @@ export default {
 			// Get entities from cesiumEntityManager instead of propsStore
 			const entities = cesiumEntityManager.getAllBuildingEntities()
 
+			if (!Array.isArray(entities)) return
+
 			entities.forEach((entity) => {
 				let addData = true
 


### PR DESCRIPTION
## Summary

Closes #776. Adds a defensive `Array.isArray()` guard before iterating the entity list inside `processEntitiesForHSYScatterPlot` so the `REGIONS4CLIMATE-28` Sentry `TypeError: Cannot read properties of null (reading 'forEach')` stops firing.

Call site fixed: `src/components/HSYScatterplot.vue` (around the `entities.forEach(...)` invocation). The Sentry stacktrace points at `propsStore.scatterPlotEntities` on `1.22.3`; on `main` the same iteration has since moved to `cesiumEntityManager.getAllBuildingEntities()`. The hydration race is the same shape — `mounted` can fire before building data is ready — so a single null/array guard at the iteration point removes the production crash without changing behaviour when entities are present.

The follow-up items from the triage issue (initialise the store to `[]`, watch the store transition instead of relying on `mounted`) are intentionally out of scope for this minimal fix.

## Test plan

- [x] `bun run lint` passes
- [x] `bun run build` produces a clean bundle
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>