### PR TITLE
fix(helpers): drop verifyViewModeSelection Strategy 3 dead PINIA ref (#781)

### DIFF
--- a/tests/e2e/helpers/test-helpers.ts
+++ b/tests/e2e/helpers/test-helpers.ts
@@ -915,13 +915,16 @@ export class AccessibilityTestHelpers {
 					// Strategy 2: Check aria-pressed attribute
 					if (button?.getAttribute('aria-pressed') === 'true') return true
 
-					// Strategy 3: Check Pinia store state (most reliable)
-					const pinia = (window as any).__PINIA__
-					if (pinia?.state?.value?.global) {
-						const currentView = pinia.state.value.global.currentView
-						// Map viewMode to store values
-						if (targetMode === 'capitalRegionView' && currentView === 'capitalRegion') return true
-						if (targetMode === 'gridView' && currentView === 'grid') return true
+					// Strategy 3: Check globalStore state directly (most reliable)
+					// The app exposes the live Pinia globalStore as window.globalStore
+					// (see src/main.js). The store field is `view`, not `currentView`.
+					const store = (window as any).globalStore
+					if (store) {
+						const view = store.view
+						// Map viewMode to store values (see src/components/ViewModeCompact.vue:
+						// setView('capitalRegion') / setView('grid'))
+						if (targetMode === 'capitalRegionView' && view === 'capitalRegion') return true
+						if (targetMode === 'gridView' && view === 'grid') return true
 					}
 
 					return false


### PR DESCRIPTION
## Summary

Closes #781. Likely unblocks #784 on next CI run.

`verifyViewModeSelection` Strategy 3 was polling `window.__PINIA__` — never exposed by the app. The real Pinia exposure is `window.globalStore` (see `.claude/rules/testing.md`). Strategy 3 therefore consumed the full polling budget on every failing call, on top of Strategies 1/2's own failures, which is exactly the symptom in #784 (tablet cross-view nav timeout).

**Approach: Option B (rewrite, not delete).** Strategy 3 is documented as "most reliable" because it bypasses DOM/Vuetify timing and reads the store directly — a genuinely distinct fallback path. Rewrote it to read `window.globalStore.view` (the real exposure from `src/main.js:167`) and corrected the field name (`view`, not `currentView` — see `src/stores/globalStore.js:75`). The value mapping (`capitalRegionView` → `'capitalRegion'`, `gridView` → `'grid'`) matches the dispatches in `src/components/ViewModeCompact.vue:75,108`.

## Test plan

- [x] `bun run lint` passes
- [x] Biome check on the helper file passes
- [x] No `verifyViewModeSelection` callers broken (signature unchanged — still `(viewMode, timeout?) => Promise<boolean>`)
- [ ] Tablet a11y green on CI (this is the real verification — #784 should clear or improve)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>