### PR TITLE
fix(compat): safe fallback for requestIdleCallback on iOS Safari/Firefox (#777)

### DIFF
--- a/src/composables/useDataLoading.js
+++ b/src/composables/useDataLoading.js
@@ -9,6 +9,7 @@ import cacheWarmer from '../services/cacheWarmer.js'
 import { useGlobalStore } from '../stores/globalStore.js'
 import { useHeatExposureStore } from '../stores/heatExposureStore.js'
 import { useSocioEconomicsStore } from '../stores/socioEconomicsStore.js'
+import { requestIdle } from '../utils/idle.js'
 import logger from '../utils/logger.js'
 
 /**
@@ -65,31 +66,21 @@ export function useDataLoading(shouldAutoLoad = true) {
 
 	/**
 	 * Starts background cache warming for critical data.
-	 * Uses requestIdleCallback to run during browser idle time.
-	 * Falls back to setTimeout for browsers without requestIdleCallback.
+	 * Uses requestIdle to run during browser idle time (with WebKit/iOS-safe fallback).
 	 *
 	 * @returns {void}
 	 */
 	const startCacheWarming = () => {
 		// Start cache warming in background (non-blocking)
-		// Uses requestIdleCallback to run during browser idle time
-		if (typeof requestIdleCallback !== 'undefined') {
-			requestIdleCallback(
-				() => {
-					cacheWarmer.warmCriticalData().catch((error) => {
-						logger.error('[useDataLoading] Failed to warm critical cache data:', error)
-					})
-				},
-				{ timeout: 2000 }
-			) // 2 second timeout
-		} else {
-			// Fallback for browsers without requestIdleCallback
-			setTimeout(() => {
+		// Uses requestIdle to run during browser idle time
+		requestIdle(
+			() => {
 				cacheWarmer.warmCriticalData().catch((error) => {
 					logger.error('[useDataLoading] Failed to warm critical cache data:', error)
 				})
-			}, 1000)
-		}
+			},
+			{ timeout: 2000 }
+		) // 2 second timeout
 
 		logger.debug('[useDataLoading] 🔥 Cache warming started')
 	}

--- a/src/services/building/buildingStyler.js
+++ b/src/services/building/buildingStyler.js
@@ -13,6 +13,7 @@ import { usePropsStore } from '../../stores/propsStore.js'
 import { useToggleStore } from '../../stores/toggleStore.js'
 import { processBatchAdaptive } from '../../utils/batchProcessor.js'
 import { calculateBuildingHeight } from '../../utils/entityStyling.js'
+import { requestIdle } from '../../utils/idle.js'
 import { getCesium } from '../cesiumProvider.js'
 import { logVisibilityChange } from '../visibilityLogger.js'
 
@@ -265,11 +266,7 @@ export class BuildingStyler {
 		// Process heat timeseries asynchronously to avoid blocking UI
 		await new Promise((resolve) => {
 			filterHeatTimeseries(buildingProps)
-			if (requestIdleCallback) {
-				requestIdleCallback(resolve)
-			} else {
-				setTimeout(resolve, 0)
-			}
+			requestIdle(resolve)
 		})
 
 		// Set tree area if tree layer is visible and data exists

--- a/src/services/cacheWarmer.js
+++ b/src/services/cacheWarmer.js
@@ -38,6 +38,7 @@ import { useFeatureFlagStore } from '../stores/featureFlagStore'
 import { useGlobalStore } from '../stores/globalStore.js'
 import { useToggleStore } from '../stores/toggleStore.js'
 import { useURLStore } from '../stores/urlStore.js'
+import { requestIdle } from '../utils/idle.js'
 import logger from '../utils/logger.js'
 import { encodeURLParam, validatePostalCode } from '../utils/validators.js'
 import unifiedLoader from './unifiedLoader.js'
@@ -281,30 +282,19 @@ class CacheWarmer {
 		logger.debug('[CacheWarmer] Warming', postalCodesToWarm.length, 'nearby postal codes')
 
 		// Warm in background with low priority
-		// Use requestIdleCallback to run during browser idle time
+		// Use requestIdle to run during browser idle time (with WebKit/iOS-safe fallback)
 		postalCodesToWarm.forEach((postalCode) => {
-			if (typeof requestIdleCallback !== 'undefined') {
-				requestIdleCallback(
-					async () => {
-						try {
-							await this.warmBuildingsForPostalCode(postalCode)
-						} catch (_error) {
-							// Silent fail for predictive warming
-							console.debug(`[CacheWarmer] Predictive warming failed for ${postalCode}`)
-						}
-					},
-					{ timeout: 5000 }
-				) // 5 second timeout
-			} else {
-				// Fallback for browsers without requestIdleCallback
-				setTimeout(async () => {
+			requestIdle(
+				async () => {
 					try {
 						await this.warmBuildingsForPostalCode(postalCode)
 					} catch (_error) {
+						// Silent fail for predictive warming
 						console.debug(`[CacheWarmer] Predictive warming failed for ${postalCode}`)
 					}
-				}, 100)
-			}
+				},
+				{ timeout: 5000 }
+			) // 5 second timeout
 		})
 	}
 

--- a/src/services/graphics.js
+++ b/src/services/graphics.js
@@ -1,5 +1,6 @@
 import { useGlobalStore } from '../stores/globalStore.js'
 import { useGraphicsStore } from '../stores/graphicsStore.js'
+import { requestIdle } from '../utils/idle.js'
 import logger from '../utils/logger.js'
 import { getCesium } from './cesiumProvider.js'
 
@@ -45,7 +46,7 @@ export default class Graphics {
 
 		// Defer hardware detection until actually needed
 		// Apply settings will trigger lazy detection
-		requestIdleCallback(
+		requestIdle(
 			() => {
 				if (!this.viewer || this.viewer.isDestroyed?.()) return
 				this.detectSupport()

--- a/src/services/hsybuilding.js
+++ b/src/services/hsybuilding.js
@@ -5,6 +5,7 @@ import { useGlobalStore } from '../stores/globalStore.js'
 import { usePropsStore } from '../stores/propsStore.js'
 import { useToggleStore } from '../stores/toggleStore.js'
 import { useURLStore } from '../stores/urlStore.js'
+import { requestIdle } from '../utils/idle.js'
 import logger from '../utils/logger.js'
 import Building from './building.js'
 import { cesiumEntityManager } from './cesiumEntityManager.js'
@@ -486,9 +487,7 @@ export default class HSYBuilding {
 				}
 
 				// Yield after each feature for responsive UI
-				await new Promise((resolve) =>
-					requestIdleCallback ? requestIdleCallback(resolve) : setTimeout(resolve, 0)
-				)
+				await new Promise((resolve) => requestIdle(resolve))
 			}
 
 			// Show progress for large datasets

--- a/src/services/loadingCoordinator.js
+++ b/src/services/loadingCoordinator.js
@@ -38,6 +38,7 @@
 
 import { useGlobalStore } from '../stores/globalStore.js'
 import { useLoadingStore } from '../stores/loadingStore.js'
+import { requestIdle } from '../utils/idle.js'
 import logger from '../utils/logger.js'
 import unifiedLoader from './unifiedLoader.js'
 
@@ -412,14 +413,11 @@ class LoadingCoordinator {
 	 * @private
 	 */
 	scheduleBackgroundLoading(backgroundConfigs) {
-		// Use requestIdleCallback or setTimeout for background loading
+		// Use requestIdle for background loading (with WebKit/iOS-safe fallback)
 		const scheduleNext = (configs, index = 0) => {
 			if (index >= configs.length) return
 
-			const scheduleFunction =
-				window.requestIdleCallback || ((callback) => setTimeout(callback, 1000))
-
-			scheduleFunction(async () => {
+			requestIdle(async () => {
 				try {
 					const config = configs[index]
 					logger.debug(`Background loading: ${config.layerId}`)

--- a/src/services/othernature.js
+++ b/src/services/othernature.js
@@ -1,5 +1,6 @@
 import { useGlobalStore } from '../stores/globalStore.js'
 import { useURLStore } from '../stores/urlStore.js'
+import { requestIdle } from '../utils/idle.js'
 import logger from '../utils/logger.js'
 import { getCesium } from './cesiumProvider.js'
 import Datasource from './datasource.js'
@@ -89,13 +90,7 @@ export default class Othernature {
 
 				// Yield control after each batch to prevent UI blocking
 				if (i + batchSize < entities.length) {
-					await new Promise((resolve) => {
-						if (window.requestIdleCallback) {
-							requestIdleCallback(resolve)
-						} else {
-							setTimeout(resolve, 0)
-						}
-					})
+					await new Promise((resolve) => requestIdle(resolve))
 				}
 			}
 

--- a/src/services/progressiveLoader.js
+++ b/src/services/progressiveLoader.js
@@ -60,6 +60,7 @@
  *
  * @class ProgressiveLoader
  */
+import { requestIdle } from '../utils/idle.js'
 import logger from '../utils/logger.js'
 
 class ProgressiveLoader {
@@ -351,13 +352,7 @@ class ProgressiveLoader {
 			}
 
 			// Yield control to prevent UI blocking
-			await new Promise((resolve) => {
-				if (window.requestIdleCallback) {
-					requestIdleCallback(resolve, { timeout: 50 })
-				} else {
-					setTimeout(resolve, 0)
-				}
-			})
+			await new Promise((resolve) => requestIdle(resolve, { timeout: 50 }))
 		}
 
 		logger.debug(`✅ Progressive processing complete: ${processedFeatures} features`)

--- a/src/services/unifiedLoader.js
+++ b/src/services/unifiedLoader.js
@@ -36,6 +36,7 @@
  */
 
 import { useLoadingStore } from '../stores/loadingStore.js'
+import { requestIdle } from '../utils/idle.js'
 import cacheService from './cacheService.js'
 import progressiveLoader from './progressiveLoader.js'
 
@@ -424,13 +425,7 @@ class UnifiedLoader {
 
 			// Yield control to prevent UI blocking
 			if (i + batchSize < features.length) {
-				await new Promise((resolve) => {
-					if (window.requestIdleCallback) {
-						requestIdleCallback(resolve)
-					} else {
-						setTimeout(resolve, 0)
-					}
-				})
+				await new Promise((resolve) => requestIdle(resolve))
 			}
 		}
 	}

--- a/src/services/urbanheat.js
+++ b/src/services/urbanheat.js
@@ -2,6 +2,7 @@ import { useBuildingStore } from '../stores/buildingStore.js'
 import { useGlobalStore } from '../stores/globalStore.js'
 import { usePropsStore } from '../stores/propsStore.js'
 import { useURLStore } from '../stores/urlStore.js'
+import { requestIdle } from '../utils/idle.js'
 import logger from '../utils/logger.js'
 import { cesiumEntityManager } from './cesiumEntityManager.js'
 import Datasource from './datasource.js'
@@ -326,9 +327,7 @@ const setAttributesFromApiToBuilding = async (properties, features) => {
 
 		// Yield control to prevent UI blocking after each batch
 		if (i + batchSize < features.length) {
-			await new Promise((resolve) =>
-				requestIdleCallback ? requestIdleCallback(resolve) : setTimeout(resolve, 0)
-			)
+			await new Promise((resolve) => requestIdle(resolve))
 		}
 	}
 }

--- a/src/services/vegetation.js
+++ b/src/services/vegetation.js
@@ -1,5 +1,6 @@
 import { useGlobalStore } from '../stores/globalStore.js'
 import { useURLStore } from '../stores/urlStore.js'
+import { requestIdle } from '../utils/idle.js'
 import logger from '../utils/logger.js'
 import { getCesium } from './cesiumProvider.js'
 import Datasource from './datasource.js'
@@ -89,13 +90,7 @@ export default class Vegetation {
 
 				// Yield control after each batch to prevent UI blocking
 				if (i + batchSize < entities.length) {
-					await new Promise((resolve) => {
-						if (window.requestIdleCallback) {
-							requestIdleCallback(resolve)
-						} else {
-							setTimeout(resolve, 0)
-						}
-					})
+					await new Promise((resolve) => requestIdle(resolve))
 				}
 			}
 

--- a/src/services/viewportBuildingLoader.js
+++ b/src/services/viewportBuildingLoader.js
@@ -42,6 +42,7 @@ import {
 	DEFAULT_BUILDING_HEIGHT,
 	FLOOR_HEIGHT,
 } from '../utils/entityStyling.js'
+import { cancelIdle, requestIdle } from '../utils/idle.js'
 import logger from '../utils/logger.js'
 import { getCesium } from './cesiumProvider.js'
 import Datasource from './datasource.js'
@@ -866,7 +867,7 @@ export default class ViewportBuildingLoader {
 			}
 
 			if (i + batchSize < entities.length) {
-				await new Promise((resolve) => requestIdleCallback(resolve))
+				await new Promise((resolve) => requestIdle(resolve))
 			}
 		}
 	}
@@ -1413,7 +1414,7 @@ export default class ViewportBuildingLoader {
 		// Don't start if queue is empty
 		if (this.prefetchQueue.length === 0) return
 
-		this.prefetchHandle = requestIdleCallback(
+		this.prefetchHandle = requestIdle(
 			(deadline) => this.processPrefetchQueue(deadline),
 			{ timeout: 5000 } // Process within 5 seconds even if not idle
 		)
@@ -1448,7 +1449,7 @@ export default class ViewportBuildingLoader {
 
 		// Continue if more tiles and not cancelled
 		if (this.prefetchQueue.length > 0 && !this.prefetchCancelled) {
-			this.prefetchHandle = requestIdleCallback((deadline) => this.processPrefetchQueue(deadline), {
+			this.prefetchHandle = requestIdle((deadline) => this.processPrefetchQueue(deadline), {
 				timeout: 5000,
 			})
 		} else {
@@ -1516,7 +1517,7 @@ export default class ViewportBuildingLoader {
 		this.prefetchQueue = []
 
 		if (this.prefetchHandle) {
-			cancelIdleCallback(this.prefetchHandle)
+			cancelIdle(this.prefetchHandle)
 			this.prefetchHandle = null
 		}
 

--- a/src/utils/batchProcessor.js
+++ b/src/utils/batchProcessor.js
@@ -21,6 +21,8 @@
  * @module utils/batchProcessor
  */
 
+import { requestIdle } from './idle.js'
+
 // Frame budget constants
 const FRAME_BUDGET_MS = 16.67 // 60fps target
 const MIN_BATCH_SIZE = 5
@@ -40,12 +42,9 @@ async function yieldToMain() {
 		if ('scheduler' in globalThis && 'yield' in globalThis.scheduler) {
 			// Modern browsers with Scheduler API (Chrome 115+)
 			globalThis.scheduler.yield().then(resolve)
-		} else if (typeof requestIdleCallback === 'function') {
-			// Fallback to requestIdleCallback
-			requestIdleCallback(resolve, { timeout: 50 })
 		} else {
-			// Final fallback for older browsers
-			setTimeout(resolve, 0)
+			// Fallback to requestIdleCallback (with WebKit/iOS-safe setTimeout shim)
+			requestIdle(resolve, { timeout: 50 })
 		}
 	})
 }

--- a/src/utils/idle.js
+++ b/src/utils/idle.js
@@ -1,0 +1,92 @@
+/**
+ * Idle Callback Compatibility Helper
+ *
+ * Cross-browser-safe wrappers around `requestIdleCallback` /
+ * `cancelIdleCallback`. `requestIdleCallback` is not implemented on WebKit
+ * (Safari, iOS Safari, Firefox iOS — all share the WebKit engine), so referencing
+ * the identifier directly throws `ReferenceError: Can't find variable:
+ * requestIdleCallback`. Use these helpers instead of touching the global API.
+ *
+ * Usage:
+ *   import { requestIdle, cancelIdle } from '@/utils/idle.js'
+ *
+ *   const handle = requestIdle(() => doWork(), { timeout: 2000 })
+ *   cancelIdle(handle)
+ *
+ *   // Yielding inside a batch loop:
+ *   await new Promise((resolve) => requestIdle(resolve))
+ *
+ * Fallback behavior:
+ * - Calls `setTimeout(cb, 1)` when the browser lacks `requestIdleCallback`.
+ *   The callback receives a stub `IdleDeadline`-shaped object so call sites
+ *   that read `deadline.timeRemaining()` keep working.
+ *
+ * Notes:
+ * - We use `setTimeout` (not `requestAnimationFrame`) because all call sites
+ *   in this codebase use idle callbacks for low-priority background work
+ *   (cache warming, prefetching, deferred init, batch-yield). `setTimeout`
+ *   does not block the browser the way an rAF-based fallback could in
+ *   render-sensitive loops.
+ * - No global polyfill (`window.requestIdleCallback = ...`) is installed —
+ *   keep the shim local and explicit, mirroring the pattern used by the
+ *   `logger` utility.
+ *
+ * @module utils/idle
+ */
+
+/**
+ * Detects native `requestIdleCallback` support at call time (not module-load
+ * time) so test harnesses like `vi.stubGlobal` can inject/remove the global
+ * between test cases.
+ *
+ * @returns {boolean}
+ */
+function hasNativeIdle() {
+	return typeof globalThis !== 'undefined' && typeof globalThis.requestIdleCallback === 'function'
+}
+
+/**
+ * Schedule `callback` to run during browser idle time, or via `setTimeout`
+ * when the platform does not implement `requestIdleCallback` (WebKit/iOS).
+ *
+ * @param {(deadline: IdleDeadline) => void} callback - Function invoked when idle.
+ * @param {{ timeout?: number }} [options] - Same shape as the native API.
+ * @returns {number} Handle that can be passed to {@link cancelIdle}.
+ */
+export function requestIdle(callback, options) {
+	if (hasNativeIdle()) {
+		return globalThis.requestIdleCallback(callback, options)
+	}
+	// WebKit fallback: invoke via setTimeout with a stub deadline so call sites
+	// using `deadline.timeRemaining()` / `deadline.didTimeout` keep working.
+	return setTimeout(() => {
+		callback({
+			didTimeout: false,
+			timeRemaining: () => 0,
+		})
+	}, 1)
+}
+
+/**
+ * Cancel a handle previously returned by {@link requestIdle}.
+ *
+ * Falls back to `clearTimeout` when the platform lacks `cancelIdleCallback`
+ * (the matching fallback for {@link requestIdle}'s `setTimeout` shim).
+ *
+ * @param {number} handle - Handle returned by `requestIdle`.
+ * @returns {void}
+ */
+export function cancelIdle(handle) {
+	if (handle === null || handle === undefined) return
+	if (
+		typeof globalThis !== 'undefined' &&
+		typeof globalThis.cancelIdleCallback === 'function' &&
+		hasNativeIdle()
+	) {
+		globalThis.cancelIdleCallback(handle)
+		return
+	}
+	clearTimeout(handle)
+}
+
+export default requestIdle

--- a/tests/unit/utils/idle.test.js
+++ b/tests/unit/utils/idle.test.js
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cancelIdle, requestIdle } from '@/utils/idle.js'
+
+describe('idle utilities', () => {
+	afterEach(() => {
+		vi.restoreAllMocks()
+		vi.unstubAllGlobals()
+	})
+
+	describe('requestIdle', () => {
+		it('delegates to native requestIdleCallback when available', () => {
+			const native = vi.fn((_cb, _opts) => 42)
+			vi.stubGlobal('requestIdleCallback', native)
+
+			const callback = vi.fn()
+			const handle = requestIdle(callback, { timeout: 2000 })
+
+			expect(native).toHaveBeenCalledTimes(1)
+			expect(native).toHaveBeenCalledWith(callback, { timeout: 2000 })
+			expect(handle).toBe(42)
+		})
+
+		it('falls back to setTimeout when requestIdleCallback is undefined (iOS/WebKit)', () => {
+			vi.stubGlobal('requestIdleCallback', undefined)
+			vi.useFakeTimers()
+
+			const callback = vi.fn()
+			const handle = requestIdle(callback)
+
+			// Handle should be a timer id (number-like — Node returns Timeout object,
+			// browsers return number; both are truthy and clearable).
+			expect(handle).toBeDefined()
+			expect(callback).not.toHaveBeenCalled()
+
+			vi.runAllTimers()
+
+			expect(callback).toHaveBeenCalledTimes(1)
+			const deadline = callback.mock.calls[0][0]
+			expect(deadline).toBeDefined()
+			expect(deadline.didTimeout).toBe(false)
+			expect(typeof deadline.timeRemaining).toBe('function')
+			expect(deadline.timeRemaining()).toBe(0)
+
+			vi.useRealTimers()
+		})
+
+		it('does not throw when requestIdleCallback is not defined at all', () => {
+			// Simulate iOS where the identifier is genuinely missing — the helper
+			// must not reference the bare identifier or it would throw ReferenceError.
+			vi.stubGlobal('requestIdleCallback', undefined)
+			expect(() => requestIdle(() => {})).not.toThrow()
+		})
+	})
+
+	describe('cancelIdle', () => {
+		it('delegates to native cancelIdleCallback when both APIs are available', () => {
+			const native = vi.fn((_cb) => 99)
+			const cancel = vi.fn()
+			vi.stubGlobal('requestIdleCallback', native)
+			vi.stubGlobal('cancelIdleCallback', cancel)
+
+			const handle = requestIdle(() => {})
+			cancelIdle(handle)
+
+			expect(cancel).toHaveBeenCalledWith(99)
+		})
+
+		it('falls back to clearTimeout when cancelIdleCallback is missing', () => {
+			vi.stubGlobal('requestIdleCallback', undefined)
+			vi.stubGlobal('cancelIdleCallback', undefined)
+			const clearSpy = vi.spyOn(globalThis, 'clearTimeout')
+
+			const handle = requestIdle(() => {})
+			cancelIdle(handle)
+
+			expect(clearSpy).toHaveBeenCalledWith(handle)
+		})
+
+		it('is a no-op for null/undefined handles', () => {
+			vi.stubGlobal('cancelIdleCallback', vi.fn())
+			expect(() => cancelIdle(null)).not.toThrow()
+			expect(() => cancelIdle(undefined)).not.toThrow()
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Closes #777. `requestIdleCallback` is not defined on Safari (incl. iOS) or Firefox iOS — all WebKit-engine browsers — causing `ReferenceError: Can't find variable: requestIdleCallback` at viewer init time (Sentry: REGIONS4CLIMATE-2E). The viewer fails to initialise and the user sees a blank/broken page on iOS.

### Approach

**Centralized helper** at `src/utils/idle.js`. The codebase had **15 call sites across 13 files** (services, composables, batch processor), several of which used the unsafe bare-identifier form (`if (requestIdleCallback)` / `requestIdleCallback ? ...`) — referencing the bare identifier throws `ReferenceError` on iOS even inside a feature-detect check. Per-call shims would have repeated the same 5-line pattern 15 times; a single helper keeps the surface area small and mirrors the project's existing `logger` utility pattern (no global polyfill, local import only).

The helper:
- Wraps both `requestIdleCallback` and `cancelIdleCallback`.
- Falls back to `setTimeout(cb, 1)` / `clearTimeout(handle)` — `setTimeout` is fine here because every call site uses idle callbacks for low-priority background work (cache warming, prefetching, deferred init, batch-yield), not for frame-perf-sensitive rendering loops.
- Invokes the callback with a stub `IdleDeadline`-shaped object (`{ didTimeout: false, timeRemaining: () => 0 }`) so call sites that read `deadline.timeRemaining()` keep working (e.g. `viewportBuildingLoader.processPrefetchQueue`).
- Detects native support at call time (not module-load), so `vi.stubGlobal('requestIdleCallback', ...)` continues to work in unit tests.

### Files changed

- **New**: `src/utils/idle.js` — `requestIdle` / `cancelIdle` helpers
- **New**: `tests/unit/utils/idle.test.js` — 6 tests covering native delegation, iOS fallback, cancel paths
- **Migrated to helper** (13 files):
  - `src/services/graphics.js` — the file in the Sentry stack trace
  - `src/utils/batchProcessor.js`
  - `src/composables/useDataLoading.js`
  - `src/services/urbanheat.js`
  - `src/services/cacheWarmer.js`
  - `src/services/loadingCoordinator.js`
  - `src/services/progressiveLoader.js`
  - `src/services/hsybuilding.js`
  - `src/services/viewportBuildingLoader.js` (3 `requestIdleCallback` + 1 `cancelIdleCallback`)
  - `src/services/vegetation.js`
  - `src/services/othernature.js`
  - `src/services/unifiedLoader.js`
  - `src/services/building/buildingStyler.js`

## Test plan

- [x] `bun run lint` passes (`biome check src/` — 167 files clean)
- [x] `bun run build` produces a clean production bundle
- [x] `bun run test:unit` — 759 passed / 4 skipped (was 753 + 6 new idle tests)
- [ ] Manual smoke on iOS Safari simulator / Firefox iOS (CI is Chromium-only — recommend running once before merge to confirm REGIONS4CLIMATE-2E no longer fires on iOS)
- [ ] CI green
- [ ] After merge: auto-resolve REGIONS4CLIMATE-2E in Sentry per the issue's investigation checklist

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>