### PR TITLE
test(a11y): skip .switch-container assertion on mobile viewport (#143)

### DIFF
--- a/tests/e2e/accessibility/building-filters.spec.ts
+++ b/tests/e2e/accessibility/building-filters.spec.ts
@@ -219,7 +219,18 @@ cesiumDescribe('Building Filters Accessibility', () => {
 
 		cesiumTest(
 			'should change label to "Only social & healthcare buildings" in Helsinki view',
-			async ({ cesiumPage }) => {
+			async ({ cesiumPage }, testInfo) => {
+				// .switch-container is unmounted on mobile viewport (375x667), not just CSS-hidden.
+				// Use toBeAttached() checks which fail on mobile. Skip on mobile; desktop/tablet
+				// viewports have the element and can assert. See #143, PR #791 follow-up.
+				if (testInfo.project.name === 'accessibility-mobile') {
+					testInfo.skip(
+						true,
+						'.switch-container is unmounted on mobile viewport; covered by desktop/tablet matrix'
+					)
+					return
+				}
+
 				// Pin to capital region view — previous test ("should NOT show Public
 				// Buildings in Grid view") navigates to grid and back, but state-leak across
 				// tests means `.switch-container` may not be present without an explicit nav.
@@ -558,28 +569,42 @@ cesiumDescribe('Building Filters Accessibility', () => {
 	})
 
 	cesiumTest.describe('Building Filter Accessibility', () => {
-		cesiumTest('should have consistent styling for all filter toggles', async ({ cesiumPage }) => {
-			// Check that all visible filters have consistent structure
-			const filterToggles = cesiumPage
-				.locator('.switch-container')
-				.filter({ has: cesiumPage.locator('input[type="checkbox"]') })
-			const count = await filterToggles.count()
+		cesiumTest(
+			'should have consistent styling for all filter toggles',
+			async ({ cesiumPage }, testInfo) => {
+				// .switch-container is unmounted on mobile viewport (375x667), so count will be 0.
+				// Skip on mobile; desktop/tablet viewports have the elements and can assert.
+				// See #143, PR #791 follow-up.
+				if (testInfo.project.name === 'accessibility-mobile') {
+					testInfo.skip(
+						true,
+						'.switch-container is unmounted on mobile viewport; covered by desktop/tablet matrix'
+					)
+					return
+				}
 
-			expect(count).toBeGreaterThanOrEqual(2) // Should have at least 2 filter toggles
+				// Check that all visible filters have consistent structure
+				const filterToggles = cesiumPage
+					.locator('.switch-container')
+					.filter({ has: cesiumPage.locator('input[type="checkbox"]') })
+				const count = await filterToggles.count()
 
-			for (let i = 0; i < count; i++) {
-				const toggle = filterToggles.nth(i)
+				expect(count).toBeGreaterThanOrEqual(2) // Should have at least 2 filter toggles
 
-				// Each should have a switch and label
-				const switchElement = toggle.locator('.switch')
-				const label = toggle.locator('.label')
+				for (let i = 0; i < count; i++) {
+					const toggle = filterToggles.nth(i)
 
-				if (await switchElement.isVisible()) {
-					await expect(switchElement).toBeVisible()
-					await expect(label).toBeVisible()
+					// Each should have a switch and label
+					const switchElement = toggle.locator('.switch')
+					const label = toggle.locator('.label')
+
+					if (await switchElement.isVisible()) {
+						await expect(switchElement).toBeVisible()
+						await expect(label).toBeVisible()
+					}
 				}
 			}
-		})
+		)
 
 		cesiumTest('should support keyboard navigation for filter toggles', async ({ cesiumPage }) => {
 			// Tab through the interface to reach filter controls with safety measures

--- a/tests/e2e/accessibility/building-filters.spec.ts
+++ b/tests/e2e/accessibility/building-filters.spec.ts
@@ -35,7 +35,22 @@ cesiumDescribe('Building Filters Accessibility', () => {
 	cesiumTest.use({ tag: ['@accessibility', '@e2e'] })
 	let helpers: AccessibilityTestHelpers
 
-	cesiumTest.beforeEach(async ({ cesiumPage }) => {
+	cesiumTest.beforeEach(async ({ cesiumPage }, testInfo) => {
+		// The entire Building Filters section is unmounted (not just CSS-hidden) on
+		// the accessibility-mobile project (375x667). Every test in this file asserts
+		// on filter visibility (`.switch-container`, "Building Filters", "Tall
+		// Buildings", "Public Buildings", "Pre-2018"), so none are applicable on
+		// mobile. Skip the entire suite there; desktop (1920x1080) and tablet
+		// (768x1024) viewports continue to cover the matrix.
+		// See #143, PR #791 follow-up.
+		if (testInfo.project.name === 'accessibility-mobile') {
+			testInfo.skip(
+				true,
+				'Building filters are unmounted on mobile viewport; covered by desktop/tablet matrix'
+			)
+			return
+		}
+
 		helpers = new AccessibilityTestHelpers(cesiumPage)
 		// Cesium is already initialized by the fixture
 
@@ -219,18 +234,8 @@ cesiumDescribe('Building Filters Accessibility', () => {
 
 		cesiumTest(
 			'should change label to "Only social & healthcare buildings" in Helsinki view',
-			async ({ cesiumPage }, testInfo) => {
-				// .switch-container is unmounted on mobile viewport (375x667), not just CSS-hidden.
-				// Use toBeAttached() checks which fail on mobile. Skip on mobile; desktop/tablet
-				// viewports have the element and can assert. See #143, PR #791 follow-up.
-				if (testInfo.project.name === 'accessibility-mobile') {
-					testInfo.skip(
-						true,
-						'.switch-container is unmounted on mobile viewport; covered by desktop/tablet matrix'
-					)
-					return
-				}
-
+			async ({ cesiumPage }) => {
+				// Mobile skip is handled by the top-level beforeEach hook.
 				// Pin to capital region view — previous test ("should NOT show Public
 				// Buildings in Grid view") navigates to grid and back, but state-leak across
 				// tests means `.switch-container` may not be present without an explicit nav.
@@ -569,42 +574,29 @@ cesiumDescribe('Building Filters Accessibility', () => {
 	})
 
 	cesiumTest.describe('Building Filter Accessibility', () => {
-		cesiumTest(
-			'should have consistent styling for all filter toggles',
-			async ({ cesiumPage }, testInfo) => {
-				// .switch-container is unmounted on mobile viewport (375x667), so count will be 0.
-				// Skip on mobile; desktop/tablet viewports have the elements and can assert.
-				// See #143, PR #791 follow-up.
-				if (testInfo.project.name === 'accessibility-mobile') {
-					testInfo.skip(
-						true,
-						'.switch-container is unmounted on mobile viewport; covered by desktop/tablet matrix'
-					)
-					return
-				}
+		cesiumTest('should have consistent styling for all filter toggles', async ({ cesiumPage }) => {
+			// Mobile skip is handled by the top-level beforeEach hook.
+			// Check that all visible filters have consistent structure
+			const filterToggles = cesiumPage
+				.locator('.switch-container')
+				.filter({ has: cesiumPage.locator('input[type="checkbox"]') })
+			const count = await filterToggles.count()
 
-				// Check that all visible filters have consistent structure
-				const filterToggles = cesiumPage
-					.locator('.switch-container')
-					.filter({ has: cesiumPage.locator('input[type="checkbox"]') })
-				const count = await filterToggles.count()
+			expect(count).toBeGreaterThanOrEqual(2) // Should have at least 2 filter toggles
 
-				expect(count).toBeGreaterThanOrEqual(2) // Should have at least 2 filter toggles
+			for (let i = 0; i < count; i++) {
+				const toggle = filterToggles.nth(i)
 
-				for (let i = 0; i < count; i++) {
-					const toggle = filterToggles.nth(i)
+				// Each should have a switch and label
+				const switchElement = toggle.locator('.switch')
+				const label = toggle.locator('.label')
 
-					// Each should have a switch and label
-					const switchElement = toggle.locator('.switch')
-					const label = toggle.locator('.label')
-
-					if (await switchElement.isVisible()) {
-						await expect(switchElement).toBeVisible()
-						await expect(label).toBeVisible()
-					}
+				if (await switchElement.isVisible()) {
+					await expect(switchElement).toBeVisible()
+					await expect(label).toBeVisible()
 				}
 			}
-		)
+		})
 
 		cesiumTest('should support keyboard navigation for filter toggles', async ({ cesiumPage }) => {
 			// Tab through the interface to reach filter controls with safety measures


### PR DESCRIPTION
## Summary

Follow-up to PR #791 which used `toBeAttached()` for `.switch-container` checks in `tests/e2e/accessibility/building-filters.spec.ts` on the premise that the element is CSS-hidden on mobile (`d-none d-lg-flex` pattern). Task #143 / W22 friction notes established that the element is actually **unmounted** on the `accessibility-mobile` project (375x667 viewport), not just CSS-hidden — so `toBeAttached()` continues to fail.

## Change

Skip the entire `building-filters.spec.ts` file on `accessibility-mobile` via a top-level `beforeEach` hook. Every test in this file asserts on building-filter visibility (`.switch-container`, the "Building Filters" header, "Tall Buildings", "Public Buildings", "Pre-2018"), all of which are unmounted on mobile — so the centralized skip is the right shape.

Initial commit added per-test `testInfo.skip()` early-returns at the two `.switch-container` call sites. Follow-up (per @gemini-code-assist review) centralized this into the `beforeEach` hook and removed the two duplicates — future filter tests added to this file are now automatically covered.

Desktop (1920x1080) and tablet (768x1024) viewports still assert the full matrix. Pattern documented in `.claude/rules/testing.md` → "Conditional Test Skip in Custom Fixtures".

## Why skip rather than rewrite

`.switch-container` is rendered behind a responsive `v-if`/component-level guard that drops the entire element on mobile breakpoints. There is no equivalent presence assertion that meaningfully runs on mobile — the filter UI is intentionally absent there. Skipping is the right semantic, matching the test pyramid coverage at the breakpoints where the element actually exists.

## Test plan

- [ ] CI: `accessibility-mobile` project skips all tests in `building-filters.spec.ts`.
- [ ] CI: `accessibility-tablet` project runs all tests, passes.
- [ ] CI: `accessibility-desktop` project runs all tests, passes.
- [ ] No regressions in `Mobile Chrome` project (different testMatch).

Refs: #143, PR #791 (the failed-fix this addresses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
