### PR TITLE
test(a11y): bypass check() state-wait for Tall Buildings toggle on desktop (#782)

### DIFF
--- a/tests/e2e/accessibility/building-filters.spec.ts
+++ b/tests/e2e/accessibility/building-filters.spec.ts
@@ -71,20 +71,18 @@ cesiumDescribe('Building Filters Accessibility', () => {
 					.locator('input[type="checkbox"]')
 				await expect(tallBuildingsToggle).toBeVisible()
 
-				// Vuetify v-switch renders the input with opacity:0 covered by the slider thumb,
-				// so Playwright's actionability check is doomed by design (#762). Pass
-				// `force: true` so every attempt uses force-click — without it, the doomed
-				// first attempt blows 5s of the 50s test budget on CI desktop viewport.
-				await helpers.checkWithRetry(tallBuildingsToggle, {
-					elementName: 'Tall Buildings filter',
-					force: true,
-				})
+				// Use `dispatchEvent('click')` instead of `check()` to bypass Playwright's
+				// state-change wait (#782). The Vuetify v-switch input has `opacity:0` under
+				// `.v-switch__thumb`; `check({ force: true })` skips actionability but still
+				// waits for the `checked` attribute to flip — on desktop (1920x1080) the
+				// overlay intercepts the synthetic click, state never flips, and each attempt
+				// burns the full 5s INTERACTION timeout. `dispatchEvent` fires the event and
+				// lets the explicit `toBeChecked()` assertion below verify the flip with its
+				// own timeout, returning fast on success and failing fast on regression.
+				await tallBuildingsToggle.dispatchEvent('click')
 				await expect(tallBuildingsToggle).toBeChecked()
 
-				await helpers.uncheckWithRetry(tallBuildingsToggle, {
-					elementName: 'Tall Buildings filter',
-					force: true,
-				})
+				await tallBuildingsToggle.dispatchEvent('click')
 				await expect(tallBuildingsToggle).not.toBeChecked()
 
 				// Grid-view-hidden assertion lives in "should reset filters when changing views"

--- a/tests/e2e/helpers/test-helpers.ts
+++ b/tests/e2e/helpers/test-helpers.ts
@@ -738,9 +738,16 @@ export class AccessibilityTestHelpers {
 					force: forceAll || attempt > 1,
 				})
 				return
-			} catch {
+			} catch (error) {
 				if (attempt === maxRetries) {
-					throw new Error(`Failed to check ${elementName} toggle after ${maxRetries} attempts`)
+					// Surface the inner Playwright error so callers can distinguish actionability
+					// timeouts from state-change timeouts (#782) instead of seeing a generic
+					// "after N attempts" wrapper.
+					const cause = error instanceof Error ? error : new Error(String(error))
+					throw new Error(
+						`Failed to check ${elementName} toggle after ${maxRetries} attempts: ${cause.message}`,
+						{ cause }
+					)
 				}
 				// Wait with exponential backoff before retry
 				await this.page.waitForTimeout(TEST_TIMEOUTS.RETRY_BACKOFF_INTERACTION * attempt)
@@ -784,9 +791,16 @@ export class AccessibilityTestHelpers {
 					force: forceAll || attempt > 1,
 				})
 				return
-			} catch {
+			} catch (error) {
 				if (attempt === maxRetries) {
-					throw new Error(`Failed to uncheck ${elementName} toggle after ${maxRetries} attempts`)
+					// Surface the inner Playwright error so callers can distinguish actionability
+					// timeouts from state-change timeouts (#782) instead of seeing a generic
+					// "after N attempts" wrapper.
+					const cause = error instanceof Error ? error : new Error(String(error))
+					throw new Error(
+						`Failed to uncheck ${elementName} toggle after ${maxRetries} attempts: ${cause.message}`,
+						{ cause }
+					)
 				}
 				// Wait with exponential backoff before retry
 				await this.page.waitForTimeout(TEST_TIMEOUTS.RETRY_BACKOFF_INTERACTION * attempt)


### PR DESCRIPTION
Fixes #782

## Summary

Closes the remaining `#762` failure mode — the Tall Buildings filter test (`tests/e2e/accessibility/building-filters.spec.ts:47`) timing out at ~57s on `accessibility-desktop` (1920×1080), filed separately as **#782** after PR #773 narrowly closed #762 for tablet+mobile.

## Root cause (per #782)

`check({ force: true })` skips Playwright's *actionability* check but still waits for the input's `checked` attribute to flip after the synthetic click. On desktop, the Vuetify `.v-switch__thumb` overlay intercepts the click, the `checked` attribute never flips, and `check()` keeps waiting to its full 5s `INTERACTION` timeout. Three attempts × 5s = 15s on the check loop alone, plus scroll + Cesium-mock boot, blows the 50s per-test budget.

## Change

Two focused commits:

1. **`c699b13` — `test(a11y): surface inner Playwright error from checkWithRetry/uncheckWithRetry`**
   The helper previously wrapped any failure in a generic `"after N attempts"` message and threw away the inner Playwright error. Now captures the last error as `cause` and includes its message in the wrapper. Makes the *next* a11y flake diagnosable — useful regardless of what fix lands for #782 itself.

2. **`313accd` — `test(a11y): switch Tall Buildings test to dispatchEvent('click') to bypass state-wait`**
   Replace `checkWithRetry`/`uncheckWithRetry` calls in the Tall Buildings test with `tallBuildingsToggle.dispatchEvent('click')`. `dispatchEvent` fires the click handler directly on the input and returns immediately — no actionability check, no state-flip wait. The existing `expect(toBeChecked())` assertion verifies the flip with its own (~5s) timeout: fast on success, fail-fast on regression. No `force` flag plumbing, no retry/backoff scaffolding, no overlay-target DOM gymnastics.

## Expected CI outcome

| Project | Before | After (expected) |
|---|---|---|
| `accessibility-desktop` (1920×1080) | ✗ ~57s exhaust (#782) | ✓ <10s |
| `accessibility-tablet` (768×1024) | ✓ ~30s | ✓ <10s |
| `accessibility-mobile` (375×667) | ✓ ~16s | ✓ <10s |

If the hypothesis is wrong (dispatch doesn't fire Vuetify's switch handler), the `toBeChecked()` assertion fails fast and the surfaced inner-error from commit 1 will tell us which path was taken.

## Why draft

The hypothesis is exactly the one #782 recommended — but it hasn't been validated locally because the failure is desktop-CI-specific (would need to replicate the CI environment's timing). The CI on this PR is the ground-truth verification. Will mark ready-for-review once `accessibility-desktop` shows green on `Tall Buildings filter in non-grid contexts`.

## Test plan

- [ ] CI: \`accessibility-desktop\` Tall Buildings test passes in <15s.
- [ ] CI: \`accessibility-tablet\` and \`accessibility-mobile\` Tall Buildings tests still pass.
- [ ] CI: No regression in the rest of \`building-filters.spec.ts\` (other tests still use \`checkWithRetry\` with \`force: true\` — that path is unchanged).

Refs: PR #773 (prior narrow fix for tablet+mobile), #762 (meta-issue this completes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)