### PR TITLE
feat: VTT flood simulation, per-host concurrency limiter, RRM default-on

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -67,6 +67,12 @@ Vuetify theme is configured in `src/main.js` via `createVuetify()`:
 
 All UI colors use `--v-theme-*` CSS variables — see `code-quality.md` CSS Theming section.
 
+## Cesium Render Mode
+
+`graphicsStore.requestRenderMode` defaults to `true` and is propagated to the live `viewer.scene.requestRenderMode` via the `r4c-request-render-mode` feature flag (wired in `App.vue` after `featureFlagStore.refreshFlags()`). The graphics service `$subscribe` watcher also propagates runtime toggles from `GraphicsQuality.vue` to the live scene.
+
+When RRM is on, Cesium only re-renders when something changes (camera move, entity update, imagery load); when off, the scene re-renders every animation frame at ~60 FPS. On a 3D globe with terrain + buildings + WMS imagery the difference is roughly one CPU core and a hot dGPU — keep RRM on unless a specific feature genuinely needs continuous rendering, and explicitly call `viewer.scene.requestRender()` at any mutation site that would otherwise be visually invisible under RRM (existing camera/entity/imagery hooks already do this).
+
 ## Development Proxy Configuration
 
 Proxy endpoints in development (`vite.config.js`):

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -87,6 +87,16 @@ Primary data from:
 - Statistics Finland
 - Environmental monitoring systems for climate resilience research
 
+### Rate Limits Are Enforced at the Gateway, Not the Service
+
+The "HSY buildings" tiles (`viewport_buildings_hsy_*`) are served by `pygeoapi.dataportal.fi`, not by `kartta.hsy.fi` — the layer name is historical. pygeoapi sits behind an Envoy Gateway `BackendTrafficPolicy` that enforces a per-source-IP rate limit. When debugging HTTP 429s on tile loads:
+
+1. **Check the upstream service first** — `kubectl logs` the pygeoapi pod. If you see only 200s, the cap is being applied by the gateway before requests reach the service.
+2. **Inspect the BackendTrafficPolicy** for the affected route — `kubectl get backendtrafficpolicy -n <ns> <name> -o yaml`. The `spec.rateLimit.local.rules` describe the per-IP budget.
+3. **Distinguish "service overloaded" from "gateway rejecting"**: per-IP buckets mean one dev workstation can produce 940 429s in a session while the service itself is idle. In production each user has their own IP, so the effective limit is per-user, but bursts can still exceed a tight cap on initial viewport load (~30-50 tiles in 1-3 seconds).
+
+The client-side per-host concurrency limiter (`src/services/hostConcurrencyLimiter.js`) caps in-flight count but does not throttle the request rate — a circuit breaker or `Retry-After`-honoring backoff is the right next lever if cap relaxation alone isn't enough.
+
 ## Component Organization
 
 ### Size Guidelines

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -211,6 +211,41 @@ if (store.isProcessing) {
 }
 ```
 
+### Per-Host Concurrency Coordination
+
+Per-request cancellation handles in-flight cleanup; it does **not** coordinate concurrency across many requests sharing a rate-limited upstream. When multiple independent loaders fan out parallel fetches to the same proxy (`/pygeoapi/*`, `/wms/proxy/*`, etc.), use a host-keyed semaphore so the gateway sees a bounded request rate regardless of how many call sites are active.
+
+```javascript
+// ✅ CORRECT: Gate each fetch behind a per-host semaphore
+import { acquireHostSlot, setHostLimit } from '@/services/hostConcurrencyLimiter';
+
+// Optional per-host tuning (defaults to DEFAULT_LIMIT)
+setHostLimit('pygeoapi', 3);
+
+async function fetchWithLimit(url, options) {
+	const release = await acquireHostSlot(url, options.signal);
+	try {
+		return await fetch(url, options);
+	} finally {
+		release(); // idempotent; safe in finally + on retry/return paths
+	}
+}
+```
+
+The limiter keys absolute URLs by `URL.hostname` and relative URLs by their first path segment (matching Vite's proxy buckets). Two callers requesting `/pygeoapi/x` and `/pygeoapi/y` share one budget; a caller to `/wms/proxy/z` has its own. See `src/services/hostConcurrencyLimiter.js`.
+
+**When to reach for it:**
+
+- Multiple loaders fire parallel requests to the same proxy and you're seeing HTTP 429s
+- An upstream's rate limit is enforced at a gateway/WAF, not at the application — concurrency caps in the loader itself can't prevent overload because they're scoped to one loader
+- You want per-host tunability for benchmarking (different upstreams have different real-world limits)
+
+**Edge cases:**
+
+- The releaser must be called in `finally` — a thrown fetch (network error, timeout) leaks a slot otherwise
+- On retry paths, release before sleeping so other waiters can use the slot during backoff
+- Pass the request's `AbortSignal` into `acquireHostSlot` so a queued waiter unblocks promptly when its caller cancels
+
 ## Async/Promise Error Handling
 
 ### Never Use `void` Operator

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ FROM nginx:1.27
 
 # Set default values for nginx environment variables
 ENV VITE_PYGEOAPI_HOST=pygeoapi.dataportal.fi
+# VTT R4C flood simulation API host.
+ENV VITE_VTT_API_HOST=130.188.4.230
 # DNS resolver: "auto" means detect from /etc/resolv.conf at startup
 # This works in both Docker (127.0.0.11) and Kubernetes (kube-dns ClusterIP)
 ENV NGINX_DNS_RESOLVER=auto

--- a/flags.goff.yaml
+++ b/flags.goff.yaml
@@ -1,0 +1,298 @@
+# Feature Flags Configuration for R4C Cesium Viewer
+# Provider: GO Feature Flag (https://gofeatureflag.org)
+# Documentation: https://gofeatureflag.org/docs/configure_flag/flag_format
+#
+# This file is the canonical, app-owned source for the GOFF flag definitions
+# consumed by R4C Cesium Viewer. The production GOFF relay reads its config
+# from the ConfigMap at:
+#   infrastructure/argocd/apps/templates/internal-tools/feature-flags-config.yaml
+# Keep this file and the ConfigMap's `r4c-*` section in sync when changing
+# flag rules — changes to either must land alongside the other.
+#
+# For local development, the InMemoryProvider in src/services/featureFlagProvider.ts
+# builds its fallback from `fallbackDefault` in src/constants/flagMetadata.ts,
+# not from this file. To test against a real GOFF relay locally:
+#
+#   docker run -p 1031:1031 \
+#     -v $(pwd)/flags.goff.yaml:/goff/flags.yaml \
+#     gofeatureflag/go-feature-flag:latest
+#
+# Targeting conventions:
+#   - `domain eq "forumvirium.fi"` enables experimental features for FVH staff
+#   - `domain eq "vtt.fi"` enables VTT-internal data layers
+#   - Use `OR` to combine domains for joint-team features
+
+# ============================================================
+# Data Layers
+# ============================================================
+
+r4c-ndvi:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled
+
+r4c-flood-layers:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: disabled
+  targeting:
+    - query: domain eq "forumvirium.fi"
+      variation: enabled
+
+r4c-vtt-flood-simulation:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: disabled
+  targeting:
+    # Gated to FVH + VTT staff while the simulation dataset remains
+    # internal-only. Remove the targeting block once VTT authorises
+    # open publication.
+    - query: domain eq "forumvirium.fi" OR domain eq "vtt.fi"
+      variation: enabled
+
+r4c-grid-250m:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled
+
+r4c-tree-coverage:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled
+
+r4c-land-cover:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled
+
+# ============================================================
+# Graphics & Performance
+# ============================================================
+
+r4c-hdr-rendering:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: disabled
+  targeting:
+    - query: domain eq "forumvirium.fi"
+      variation: enabled
+
+r4c-ambient-occlusion:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: disabled
+  targeting:
+    - query: domain eq "forumvirium.fi"
+      variation: enabled
+
+r4c-msaa-options:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled
+
+r4c-fxaa-options:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled
+
+r4c-request-render-mode:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: disabled
+  targeting:
+    - query: domain eq "forumvirium.fi"
+      variation: enabled
+
+r4c-terrain-3d:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled
+
+r4c-viewport-streaming:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled
+
+r4c-predictive-prefetch:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: disabled
+  targeting:
+    - query: domain eq "forumvirium.fi"
+      variation: enabled
+
+# ============================================================
+# Analysis Tools
+# ============================================================
+
+r4c-heat-histogram:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled
+
+r4c-building-scatter-plot:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled
+
+r4c-cooling-optimizer:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled
+
+r4c-ndvi-analysis:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled
+
+r4c-socioeconomic-viz:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled
+
+# ============================================================
+# UI / UX
+# ============================================================
+
+r4c-control-panel-default:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled
+
+r4c-data-source-status:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled
+
+r4c-loading-performance-info:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: disabled
+  targeting:
+    - query: domain eq "forumvirium.fi"
+      variation: enabled
+
+r4c-background-preload:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: disabled
+  targeting:
+    - query: domain eq "forumvirium.fi"
+      variation: enabled
+
+r4c-map-click-loading-overlay:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: disabled
+
+# ============================================================
+# Integrations
+# ============================================================
+
+r4c-sentry-error-tracking:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled
+
+r4c-digitransit-integration:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled
+
+r4c-background-map-providers:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled
+
+# ============================================================
+# Developer Tools
+# ============================================================
+
+r4c-debug-mode:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: disabled
+
+r4c-cache-visualization:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: disabled
+
+r4c-health-checks:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: disabled
+
+# ============================================================
+# Panel Visibility
+# ============================================================
+
+r4c-show-feature-panel:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: disabled
+  targeting:
+    - query: domain eq "forumvirium.fi"
+      variation: enabled

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -389,14 +389,20 @@ server {
 
     # VTT R4C flood simulation API.
     location /vtt-api {
+        # Accept VITE_VTT_API_HOST with or without a protocol prefix. Without
+        # this normalization, a value like "https://vtt-api.fi" would produce
+        # "https://https://vtt-api.fi" in proxy_pass.
         set $vtt_host "${VITE_VTT_API_HOST}";
         set $vtt_protocol "http";
-        if ($vtt_host ~* "^https://") {
-            set $vtt_protocol "https";
+        if ($vtt_host ~* "^(https?)://(.*)$") {
+            set $vtt_protocol $1;
+            set $vtt_host $2;
         }
 
         # Strip the /vtt-api prefix; the upstream expects /python_api/calc.
-        rewrite ^/vtt-api.*$ /python_api/calc break;
+        # The client appends ?scenario=X&frame=Y so the cache key can rely on
+        # $request_uri alone — $request_body is unreliable during cache lookup.
+        rewrite ^/vtt-api.*$ /python_api/calc?$args break;
         proxy_pass $vtt_protocol://$vtt_host;
         proxy_set_header Host $vtt_host;
 
@@ -405,7 +411,7 @@ server {
         proxy_cache_valid 200 5m;
         proxy_cache_valid 404 30s;
         proxy_cache_methods POST;
-        proxy_cache_key "$request_uri|$request_body";
+        proxy_cache_key "$request_uri";
 
         # The VTT POC can take seconds for a single frame; allow generous timeouts.
         proxy_connect_timeout 10s;

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -386,4 +386,30 @@ server {
         proxy_pass https://api.digitransit.fi;
         rewrite ^/digitransit(.*)$ $1 break;
     }
+
+    # VTT R4C flood simulation API.
+    location /vtt-api {
+        set $vtt_host "${VITE_VTT_API_HOST}";
+        set $vtt_protocol "http";
+        if ($vtt_host ~* "^https://") {
+            set $vtt_protocol "https";
+        }
+
+        # Strip the /vtt-api prefix; the upstream expects /python_api/calc.
+        rewrite ^/vtt-api.*$ /python_api/calc break;
+        proxy_pass $vtt_protocol://$vtt_host;
+        proxy_set_header Host $vtt_host;
+
+        # Same scenario+frame returns the same data, so a short cache is safe.
+        proxy_cache global_cache;
+        proxy_cache_valid 200 5m;
+        proxy_cache_valid 404 30s;
+        proxy_cache_methods POST;
+        proxy_cache_key "$request_uri|$request_body";
+
+        # The VTT POC can take seconds for a single frame; allow generous timeouts.
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -141,6 +141,7 @@ import { initializeFeatureFlags } from './services/featureFlagProvider'
 import { updateUrlWithNavigationState } from './services/postalCodeLoader'
 import { useFeatureFlagStore } from './stores/featureFlagStore'
 import { useGlobalStore } from './stores/globalStore.js'
+import { useGraphicsStore } from './stores/graphicsStore.js'
 import { useLoadingStore } from './stores/loadingStore.js'
 import { useToggleStore } from './stores/toggleStore.js'
 import { useUserStore } from './stores/userStore'
@@ -150,6 +151,7 @@ const toggleStore = useToggleStore()
 const globalStore = useGlobalStore()
 const loadingStore = useLoadingStore()
 const featureFlagStore = useFeatureFlagStore()
+const graphicsStore = useGraphicsStore()
 const userStore = useUserStore()
 
 const { sidebarOffset: timelineOffset } = useSidebarOffset(0)
@@ -265,6 +267,12 @@ onMounted(async () => {
 
 		featureFlagStore.loadOverrides()
 		featureFlagStore.refreshFlags()
+
+		// Apply flag-driven graphics defaults. graphicsStore values flow into
+		// Cesium via useViewerInitialization (init-time) and the graphics
+		// service watcher (runtime). User-driven toggles in GraphicsQuality.vue
+		// still override the flag — last write wins.
+		graphicsStore.setRequestRenderMode(featureFlagStore.isEnabled('requestRenderMode'))
 
 		if (featureFlagStore.isEnabled('backgroundPreload')) {
 			const { default: backgroundPreloader } = await import('./services/backgroundPreloader.js')

--- a/src/components/FloodSimulationPanel.vue
+++ b/src/components/FloodSimulationPanel.vue
@@ -1,0 +1,241 @@
+<template>
+	<div
+		class="vtt-flood-panel"
+		role="region"
+		aria-label="VTT flood simulation controls"
+	>
+		<div class="d-flex align-center mb-2">
+			<v-icon
+				size="small"
+				class="mr-2"
+			>
+				mdi-water
+			</v-icon>
+			<span class="text-subtitle-2">VTT Flood Simulation</span>
+			<v-chip
+				size="x-small"
+				color="warning"
+				class="ml-2"
+				variant="tonal"
+			>
+				VTT / FVH internal
+			</v-chip>
+			<v-spacer />
+			<v-btn
+				icon
+				variant="text"
+				size="x-small"
+				:aria-label="'Close VTT flood simulation panel'"
+				@click="emit('close')"
+			>
+				<v-icon size="small">mdi-close</v-icon>
+			</v-btn>
+		</div>
+
+		<v-select
+			:model-value="store.scenarioId"
+			:items="scenarioItems"
+			item-title="label"
+			item-value="id"
+			label="Scenario"
+			density="compact"
+			variant="outlined"
+			hide-details
+			class="mb-2"
+			@update:model-value="onScenarioChange"
+		/>
+		<div class="text-caption mb-3 vtt-scenario-description">
+			{{ activeScenarioDescription }}
+		</div>
+
+		<div class="d-flex align-center justify-space-between mb-1">
+			<span class="text-caption">Frame</span>
+			<span class="text-caption font-weight-medium">
+				{{ store.frameNumber }} / {{ store.frameCount - 1 }} ({{ store.frameOffsetLabel }})
+			</span>
+		</div>
+		<v-slider
+			:model-value="store.frameNumber"
+			:min="0"
+			:max="store.frameCount - 1"
+			:step="1"
+			color="primary"
+			density="compact"
+			hide-details
+			thumb-label
+			class="mb-2"
+			@update:model-value="onFrameChange"
+		/>
+		<v-text-field
+			:model-value="store.frameNumber"
+			type="number"
+			:min="0"
+			:max="store.frameCount - 1"
+			label="Frame number"
+			density="compact"
+			variant="outlined"
+			hide-details
+			class="mb-3"
+			@update:model-value="onFrameInput"
+		/>
+
+		<p class="text-caption mb-1">View dimension</p>
+		<v-radio-group
+			:model-value="store.dimension"
+			density="compact"
+			hide-details
+			class="mb-2"
+			@update:model-value="store.setDimension"
+		>
+			<v-radio
+				v-for="dim in VTT_DIMENSIONS"
+				:key="dim.key"
+				:value="dim.key"
+				:label="`${dim.label} (${dim.unit})`"
+			/>
+		</v-radio-group>
+
+		<div
+			class="vtt-legend mb-2"
+			role="img"
+			:aria-label="`Legend: blue indicates ${legendMin}, red indicates ${legendMax}`"
+		>
+			<div class="vtt-legend-bar" />
+			<div class="d-flex justify-space-between text-caption">
+				<span>{{ legendMin }} {{ activeDimensionUnit }}</span>
+				<span>{{ legendMax }} {{ activeDimensionUnit }}</span>
+			</div>
+		</div>
+
+		<v-progress-linear
+			v-if="store.isLoading"
+			indeterminate
+			color="primary"
+			class="mb-2"
+		/>
+		<v-alert
+			v-if="store.error"
+			type="warning"
+			density="compact"
+			variant="tonal"
+			class="mb-2"
+			icon="mdi-alert-circle-outline"
+		>
+			{{ store.error }}
+		</v-alert>
+	</div>
+</template>
+
+<script setup>
+import { computed, onMounted, onUnmounted, watch } from 'vue'
+import { VTT_DIMENSIONS, VTT_SCENARIOS } from '../constants/vttFlood.ts'
+import { clearFlood, renderFlood } from '../services/vttFlood.js'
+import { useGlobalStore } from '../stores/globalStore.js'
+import { useVttFloodStore } from '../stores/vttFloodStore.ts'
+import logger from '../utils/logger.js'
+
+const emit = defineEmits(['close'])
+
+const store = useVttFloodStore()
+const globalStore = useGlobalStore()
+
+const scenarioItems = VTT_SCENARIOS.map((s) => ({ id: s.id, label: s.label }))
+
+const activeScenarioDescription = computed(() => {
+	const match = VTT_SCENARIOS.find((s) => s.id === store.scenarioId)
+	return match?.description ?? ''
+})
+
+const activeDimensionMeta = computed(
+	() => VTT_DIMENSIONS.find((d) => d.key === store.dimension) ?? VTT_DIMENSIONS[0]
+)
+const activeDimensionUnit = computed(() => activeDimensionMeta.value.unit)
+
+function formatRange(value) {
+	if (!Number.isFinite(value)) return '—'
+	return Math.abs(value) >= 100 ? value.toFixed(0) : value.toFixed(2)
+}
+
+const legendMin = computed(() => formatRange(store.activeRange.min))
+const legendMax = computed(() => formatRange(store.activeRange.max))
+
+function onScenarioChange(id) {
+	if (id) store.selectScenario(id)
+}
+function onFrameChange(value) {
+	store.setFrame(Number(value))
+}
+function onFrameInput(value) {
+	const n = Number(value)
+	if (!Number.isFinite(n)) return
+	const clamped = Math.max(0, Math.min(store.frameCount - 1, Math.round(n)))
+	store.setFrame(clamped)
+}
+
+// Re-render whenever frame data or selected dimension changes. The component
+// owns Cesium calls; the store stays viewer-agnostic.
+const stopRenderWatcher = watch(
+	() => [store.frame, store.dimension],
+	async ([frame, dimension]) => {
+		const viewer = globalStore.cesiumViewer
+		if (!viewer) return
+		if (!frame) {
+			await clearFlood({ viewer })
+			return
+		}
+		try {
+			await renderFlood({ viewer, frame, dimension })
+		} catch (error) {
+			logger.error('[FloodSimulationPanel] Render failed:', error)
+		}
+	}
+)
+
+onMounted(() => {
+	// Always fetch on first mount so the initial frame appears without an
+	// extra click. Subsequent open/close cycles re-mount the component, which
+	// is fine — the store caches frame data and skips network if scenario+frame
+	// haven't changed (handled via _requestSeq dedup).
+	store.fetchCurrentFrame()
+})
+
+onUnmounted(async () => {
+	stopRenderWatcher()
+	const viewer = globalStore.cesiumViewer
+	if (viewer) {
+		await clearFlood({ viewer })
+	}
+	store.clear()
+})
+</script>
+
+<style scoped>
+.vtt-flood-panel {
+	padding: 12px;
+	border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+	border-radius: 8px;
+	background: rgba(var(--v-theme-surface), 0.6);
+}
+
+.vtt-scenario-description {
+	color: rgba(var(--v-theme-on-surface), 0.7);
+	font-style: italic;
+}
+
+.vtt-legend {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.vtt-legend-bar {
+	height: 8px;
+	border-radius: 4px;
+	background: linear-gradient(
+		to right,
+		rgb(33, 102, 172),
+		rgb(178, 24, 43)
+	);
+	border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+}
+</style>

--- a/src/components/PostalCodeView.vue
+++ b/src/components/PostalCodeView.vue
@@ -224,17 +224,6 @@
 					>
 						Sensor Dashboard
 					</v-btn>
-
-					<v-btn
-						href="https://geo.fvh.fi/r4c/6fkgOUqn3/"
-						target="_blank"
-						variant="outlined"
-						size="small"
-						prepend-icon="mdi-water"
-						style="display: none"
-					>
-						Flood Simulations
-					</v-btn>
 				</div>
 			</div>
 		</v-card-text>

--- a/src/constants/flagMetadata.ts
+++ b/src/constants/flagMetadata.ts
@@ -16,6 +16,7 @@ export type FeatureFlagName =
 	// Data layers
 	| 'ndvi'
 	| 'floodLayers'
+	| 'vttFloodSimulation'
 	| 'grid250m'
 	| 'treeCoverage'
 	| 'landCover'
@@ -94,6 +95,16 @@ export const FLAG_METADATA: FlagMetadataMap = {
 		category: 'data-layers',
 		experimental: true,
 		requiresSupport: false,
+		fallbackDefault: false,
+	},
+	vttFloodSimulation: {
+		goffId: 'r4c-vtt-flood-simulation',
+		label: 'VTT Flood Simulation',
+		description:
+			'VTT R4C flood simulation playback for Laajasalo (FVH/VTT internal — group-gated via GOFF)',
+		category: 'data-layers',
+		experimental: true,
+		requiresSupport: true,
 		fallbackDefault: false,
 	},
 	grid250m: {

--- a/src/constants/vttFlood.ts
+++ b/src/constants/vttFlood.ts
@@ -1,0 +1,131 @@
+/**
+ * @module constants/vttFlood
+ * Constants for the VTT R4C flood-simulation integration.
+ *
+ * Source of truth for scenarios, dimensions, frame budget, and camera target.
+ * The VTT API returns one GeoJSON FeatureCollection per (scenario, frame); the
+ * UI lets users page through frames and switch the property used for colour/
+ * extrusion without re-fetching.
+ */
+
+export interface VttScenario {
+	/** Body field sent to VTT API as scenario_number (string per upstream contract). */
+	readonly id: string
+	readonly label: string
+	readonly description: string
+}
+
+export interface VttDimension {
+	/** Property name on returned GeoJSON Feature.properties. */
+	readonly key: string
+	readonly label: string
+	readonly unit: string
+}
+
+/**
+ * Scenarios mirrored from the standalone POC (API-ver2/index.html).
+ * TODO(vtt-api): replace with a backend discovery call once VTT exposes one.
+ */
+export const VTT_SCENARIOS: readonly VttScenario[] = [
+	{
+		id: '1',
+		label: '80 mm/h cloudburst',
+		description: 'Worst-case 80 mm/h cloudburst (rankkasade)',
+	},
+	{
+		id: '2',
+		label: 'HSY 2019-08-23',
+		description: 'HSY large rainfall event — 60 mm/24h on 2019-08-23',
+	},
+	{
+		id: '3',
+		label: 'July 2025 event',
+		description: 'Large rainfall event 07.07–08.07.2025 — 40 mm/12h',
+	},
+] as const
+
+export const VTT_DIMENSIONS: readonly VttDimension[] = [
+	{ key: 'canopy_air_temperature', label: 'Canopy air temperature', unit: 'K' },
+	{ key: 'overland_water_depth', label: 'Overland water depth', unit: 'm' },
+	{ key: 'transpiration', label: 'Transpiration', unit: 'mm/h' },
+	{ key: 'upper_storage_water_depth', label: 'Upper storage water depth', unit: 'm' },
+] as const
+
+/** Frames available per scenario: 0..288 inclusive (12h × 2.5min steps + t0). */
+export const VTT_FRAME_COUNT = 289
+export const VTT_FRAME_INTERVAL_MINUTES = 2.5
+
+/** Maximum extrusion height for the highest normalized value, in metres. */
+export const VTT_MAX_EXTRUSION_M = 100
+
+/** Constant alpha applied to all rendered cells (per POC). */
+export const VTT_FILL_ALPHA = 0.8
+
+/**
+ * Camera target for the first time the panel is opened — Laajasalo, where the
+ * simulation extent lives. Co-ordinates picked to centre on the southern
+ * Helsinki islands without zooming so far in that the extent is clipped.
+ */
+export const LAAJASALO_CAMERA = {
+	longitude: 25.0419,
+	latitude: 60.1781,
+	/** Eye height in metres. */
+	height: 3500,
+	/** Heading (degrees, 0 = north). */
+	heading: 0,
+	/** Pitch in degrees (-90 = straight down). */
+	pitch: -55,
+} as const
+
+/** Name prefix used for the VTT data source / primitive collection in Cesium. */
+export const VTT_FLOOD_LAYER_NAME = 'VTT-Flood-Simulation'
+
+/** Default proxy endpoint — Vite/nginx forward this to the VTT API. */
+export const VTT_API_PATH = '/vtt-api'
+
+/**
+ * Validate a scenario id against the allow-list above.
+ *
+ * @param id - Untrusted scenario id (typically from user dropdown).
+ * @returns The validated id verbatim.
+ * @throws {Error} If the id is not in {@link VTT_SCENARIOS}.
+ */
+export function validateScenarioId(id: unknown): string {
+	const candidate = typeof id === 'string' ? id : String(id)
+	if (!VTT_SCENARIOS.some((s) => s.id === candidate)) {
+		throw new Error(
+			`Invalid VTT scenario id: "${candidate}". Allowed: ${VTT_SCENARIOS.map((s) => s.id).join(', ')}`
+		)
+	}
+	return candidate
+}
+
+/**
+ * Validate a frame number against the 0..VTT_FRAME_COUNT-1 range.
+ *
+ * @param frame - Untrusted frame index (typically from a slider).
+ * @returns The validated integer.
+ * @throws {Error} If the frame is not a non-negative integer below the limit.
+ */
+export function validateFrameNumber(frame: unknown): number {
+	const n = typeof frame === 'number' ? frame : Number(frame)
+	if (!Number.isInteger(n) || n < 0 || n >= VTT_FRAME_COUNT) {
+		throw new Error(
+			`Invalid VTT frame number: "${String(frame)}". Must be integer in 0..${VTT_FRAME_COUNT - 1}.`
+		)
+	}
+	return n
+}
+
+/**
+ * Format a frame index as a +HH:MM offset from t0.
+ *
+ * @param frame - Frame index in 0..VTT_FRAME_COUNT-1.
+ * @returns Formatted string like "+02:30".
+ */
+export function formatFrameOffset(frame: number): string {
+	const minutes = Math.round(frame * VTT_FRAME_INTERVAL_MINUTES)
+	const hh = Math.floor(minutes / 60)
+	const mm = minutes % 60
+	return `+${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}`
+}

--- a/src/pages/ControlPanel.vue
+++ b/src/pages/ControlPanel.vue
@@ -115,6 +115,24 @@
 						<div class="tab-content">
 							<ViewModeCompact class="mb-3" />
 							<MapControls />
+							<template v-if="featureFlagStore.isEnabled('vttFloodSimulation')">
+								<v-divider class="my-3" />
+								<p class="section-heading">VTT Flood Simulation</p>
+								<v-btn
+									block
+									variant="outlined"
+									prepend-icon="mdi-water"
+									:active="vttFloodOpen"
+									@click="toggleVttFlood"
+								>
+									{{ vttFloodOpen ? 'Hide Flood Simulation' : 'Flood Simulation (VTT)' }}
+								</v-btn>
+								<FloodSimulationPanel
+									v-if="vttFloodOpen"
+									class="mt-2"
+									@close="closeVttFlood"
+								/>
+							</template>
 							<v-divider class="my-3" />
 							<p class="section-heading">Background Maps</p>
 							<BackgroundMapBrowser />
@@ -363,6 +381,8 @@ import MapControls from '../components/MapControls.vue'
 import UnifiedSearch from '../components/UnifiedSearch.vue'
 import ViewModeCompact from '../components/ViewModeCompact.vue'
 import { useSidebarNavigation } from '../composables/useSidebarNavigation.js'
+import { LAAJASALO_CAMERA } from '../constants/vttFlood.ts'
+import { cesiumProvider, getCesium } from '../services/cesiumProvider.js'
 
 // Store and Service Imports
 import { useFeatureFlagStore } from '../stores/featureFlagStore'
@@ -371,6 +391,11 @@ import { useHeatExposureStore } from '../stores/heatExposureStore'
 import { usePropsStore } from '../stores/propsStore'
 import { useSocioEconomicsStore } from '../stores/socioEconomicsStore'
 import { useToggleStore } from '../stores/toggleStore'
+
+// Lazy-loaded VTT flood-simulation panel (only mounted when the gated layer is opened)
+const FloodSimulationPanel = defineAsyncComponent(
+	() => import('../components/FloodSimulationPanel.vue')
+)
 
 // Lazy-loaded analysis components
 const AnalysisPanel = defineAsyncComponent(() => import('../components/AnalysisPanel.vue'))
@@ -499,6 +524,42 @@ const handleDrawerUpdate = (val) => {
 	if (!val && isMobile.value) {
 		toggleStore.setSidebarMode('hidden')
 	}
+}
+
+// --- VTT Flood Simulation panel toggle ---
+const vttFloodOpen = ref(false)
+const vttFloodFlownTo = ref(false)
+
+const flyCameraToLaajasalo = () => {
+	const viewer = globalStore.cesiumViewer
+	if (!viewer || viewer.isDestroyed?.()) return
+	if (!cesiumProvider.isInitialized()) return
+	const Cesium = getCesium()
+	viewer.camera.flyTo({
+		destination: Cesium.Cartesian3.fromDegrees(
+			LAAJASALO_CAMERA.longitude,
+			LAAJASALO_CAMERA.latitude,
+			LAAJASALO_CAMERA.height
+		),
+		orientation: {
+			heading: Cesium.Math.toRadians(LAAJASALO_CAMERA.heading),
+			pitch: Cesium.Math.toRadians(LAAJASALO_CAMERA.pitch),
+			roll: 0.0,
+		},
+		duration: 1.2,
+	})
+}
+
+const toggleVttFlood = () => {
+	vttFloodOpen.value = !vttFloodOpen.value
+	if (vttFloodOpen.value && !vttFloodFlownTo.value) {
+		flyCameraToLaajasalo()
+		vttFloodFlownTo.value = true
+	}
+}
+
+const closeVttFlood = () => {
+	vttFloodOpen.value = false
 }
 </script>
 

--- a/src/services/featureFlagProvider.ts
+++ b/src/services/featureFlagProvider.ts
@@ -99,11 +99,19 @@ function buildEvaluationContext(userStore: UserStore): EvaluationContext {
 /**
  * Build InMemoryProvider flag configuration from fallback defaults.
  * Used when GOFF relay is not available.
+ *
+ * In development mode every flag is enabled so new features are visible by
+ * default in `bun run dev` without a GOFF relay. This mirrors the optimistic
+ * initial state in `buildInitialEvaluations` (featureFlagStore.ts) so the
+ * `refreshFlags()` call doesn't silently undo the dev-mode default. Production
+ * still uses `fallbackDefault` so experimental flags stay gated if the relay
+ * goes down.
  */
 function buildFallbackFlags(): Record<
 	string,
 	{ variants: Record<string, boolean>; defaultVariant: string; disabled: boolean }
 > {
+	const isDev = import.meta.env.MODE === 'development'
 	const flags: Record<
 		string,
 		{ variants: Record<string, boolean>; defaultVariant: string; disabled: boolean }
@@ -111,12 +119,13 @@ function buildFallbackFlags(): Record<
 
 	for (const name of ALL_FLAG_NAMES) {
 		const meta = FLAG_METADATA[name]
+		const enabled = isDev || meta.fallbackDefault
 		flags[meta.goffId] = {
 			variants: {
 				enabled: true,
 				disabled: false,
 			},
-			defaultVariant: meta.fallbackDefault ? 'enabled' : 'disabled',
+			defaultVariant: enabled ? 'enabled' : 'disabled',
 			disabled: false,
 		}
 	}

--- a/src/services/graphics.js
+++ b/src/services/graphics.js
@@ -198,6 +198,13 @@ export default class Graphics {
 			if (events.some((e) => e.key === 'ambientOcclusionEnabled')) {
 				this.applyAmbientOcclusionSettings()
 			}
+			if (events.some((e) => e.key === 'requestRenderMode')) {
+				this.scene.requestRenderMode = this.graphicsStore.requestRenderMode
+				if (!this.graphicsStore.requestRenderMode) {
+					// Kick the render loop back on immediately when turning RRM off
+					this.scene.requestRender()
+				}
+			}
 		})
 	}
 

--- a/src/services/hostConcurrencyLimiter.js
+++ b/src/services/hostConcurrencyLimiter.js
@@ -1,0 +1,190 @@
+/**
+ * @module services/hostConcurrencyLimiter
+ *
+ * Per-host (or per-proxy-prefix) async semaphore for HTTP fetches.
+ *
+ * Why: HSY's GeoServer at kartta.hsy.fi throttles per-IP concurrent requests
+ * silently with HTTP 429. Our viewport loader fires up to N tile fetches in
+ * parallel, all from the same dev-server IP — past ~3 concurrent the backend
+ * starts refusing every request, retries also fail, and the loader never
+ * recovers.
+ *
+ * Instead of capping concurrency at the call site (which can't see across
+ * different loaders that share the same upstream), this module gates every
+ * fetch through a hostname-keyed semaphore. All callers of `fetchWithRetry`
+ * automatically respect the per-host budget.
+ *
+ * Keying:
+ * - Absolute URL → URL.hostname (e.g. `kartta.hsy.fi`)
+ * - Relative URL → first path segment (e.g. `/pygeoapi/foo` → `pygeoapi`).
+ *   This matches Vite's proxy config, where each prefix maps to one upstream.
+ *
+ * Defaults to {@link DEFAULT_LIMIT} for any host that isn't explicitly
+ * configured. Override per-host via {@link setHostLimit}; the intent is to
+ * benchmark and tune individual upstreams over time.
+ */
+
+import logger from '../utils/logger.js'
+
+/**
+ * Default per-host concurrent request budget. Conservative on purpose — most
+ * Finnish open-data GeoServer instances throttle silently around this range.
+ * Tune via setHostLimit() once we have per-host benchmark data.
+ */
+export const DEFAULT_LIMIT = 3
+
+/**
+ * Per-host overrides. Empty by default; populate via {@link setHostLimit}.
+ * Keys are the result of {@link extractHostKey}.
+ *
+ * @type {Map<string, number>}
+ */
+const hostLimits = new Map()
+
+/**
+ * Live semaphore state per host.
+ *
+ * @type {Map<string, { active: number, queue: Array<() => void> }>}
+ */
+const hostState = new Map()
+
+/**
+ * Derive the limiter key for a URL.
+ *
+ * @param {string} url
+ * @returns {string} hostname (absolute URL) or first path segment (relative)
+ */
+export function extractHostKey(url) {
+	try {
+		// Absolute URL — use real hostname
+		const parsed = new URL(url)
+		return parsed.hostname || '__unknown__'
+	} catch {
+		// Relative URL — bucket by the leading path segment so each Vite
+		// proxy prefix gets its own budget.
+		const trimmed = String(url).replace(/^\/+/, '')
+		const slash = trimmed.indexOf('/')
+		const segment = slash === -1 ? trimmed : trimmed.slice(0, slash)
+		return segment || '__root__'
+	}
+}
+
+/**
+ * Set the concurrent request budget for a single host or proxy prefix.
+ * Affects future acquire() calls only — in-flight requests are not preempted.
+ *
+ * @param {string} hostKey - As produced by {@link extractHostKey}
+ * @param {number} limit - Max in-flight requests for this host (≥ 1)
+ */
+export function setHostLimit(hostKey, limit) {
+	if (!Number.isFinite(limit) || limit < 1) {
+		throw new Error(`setHostLimit(${hostKey}): limit must be ≥ 1, got ${limit}`)
+	}
+	hostLimits.set(hostKey, Math.floor(limit))
+}
+
+/**
+ * @param {string} hostKey
+ * @returns {number}
+ */
+function getLimit(hostKey) {
+	return hostLimits.get(hostKey) ?? DEFAULT_LIMIT
+}
+
+/**
+ * @param {string} hostKey
+ */
+function getState(hostKey) {
+	let state = hostState.get(hostKey)
+	if (!state) {
+		state = { active: 0, queue: [] }
+		hostState.set(hostKey, state)
+	}
+	return state
+}
+
+/**
+ * Wait for a slot on the given host's budget. Resolves when a slot is free.
+ * Caller MUST invoke the returned release function in a `finally` so a
+ * thrown fetch doesn't leak a slot.
+ *
+ * Respects AbortSignal: if the signal aborts while waiting in the queue,
+ * the returned promise rejects with the signal's reason and the slot is
+ * never acquired.
+ *
+ * @param {string} url
+ * @param {AbortSignal} [signal]
+ * @returns {Promise<() => void>} release function
+ */
+export async function acquireHostSlot(url, signal) {
+	const hostKey = extractHostKey(url)
+	const state = getState(hostKey)
+
+	if (state.active < getLimit(hostKey)) {
+		state.active += 1
+		return makeReleaser(hostKey, state)
+	}
+
+	// Park in the queue, waiting for someone to release.
+	return new Promise((resolve, reject) => {
+		const wake = () => {
+			signal?.removeEventListener('abort', onAbort)
+			state.active += 1
+			resolve(makeReleaser(hostKey, state))
+		}
+		const onAbort = () => {
+			const idx = state.queue.indexOf(wake)
+			if (idx !== -1) state.queue.splice(idx, 1)
+			reject(signal?.reason ?? new DOMException('Aborted', 'AbortError'))
+		}
+
+		if (signal?.aborted) {
+			reject(signal.reason ?? new DOMException('Aborted', 'AbortError'))
+			return
+		}
+		signal?.addEventListener('abort', onAbort, { once: true })
+		state.queue.push(wake)
+	})
+}
+
+function makeReleaser(_hostKey, state) {
+	let released = false
+	return () => {
+		if (released) return
+		released = true
+		state.active = Math.max(0, state.active - 1)
+		const next = state.queue.shift()
+		if (next) next()
+	}
+}
+
+/**
+ * Snapshot of current limiter state, for debugging / telemetry.
+ *
+ * @returns {Record<string, { active: number, queued: number, limit: number }>}
+ */
+export function inspectLimiter() {
+	const out = {}
+	for (const [hostKey, state] of hostState.entries()) {
+		out[hostKey] = {
+			active: state.active,
+			queued: state.queue.length,
+			limit: getLimit(hostKey),
+		}
+	}
+	return out
+}
+
+/**
+ * Reset all state. Intended for tests; do not call in production code.
+ */
+export function __resetForTests() {
+	hostLimits.clear()
+	hostState.clear()
+}
+
+// Expose a debug hook in dev so it's easy to inspect from devtools.
+if (import.meta.env?.MODE === 'development' && typeof window !== 'undefined') {
+	window.__hostLimiter = { inspectLimiter, setHostLimit, DEFAULT_LIMIT }
+	logger.debug('[hostConcurrencyLimiter] dev hook on window.__hostLimiter')
+}

--- a/src/services/unifiedLoader.js
+++ b/src/services/unifiedLoader.js
@@ -38,6 +38,7 @@
 import { useLoadingStore } from '../stores/loadingStore.js'
 import { requestIdle } from '../utils/idle.js'
 import cacheService from './cacheService.js'
+import { acquireHostSlot } from './hostConcurrencyLimiter.js'
 import progressiveLoader from './progressiveLoader.js'
 
 /**
@@ -452,14 +453,15 @@ class UnifiedLoader {
 	}
 
 	/**
-	 * Fetch with automatic retry logic
-	 * Implements exponential backoff strategy (1s, 2s, 4s, 8s...).
+	 * Fetch with automatic retry logic.
 	 *
 	 * Retry Strategy:
-	 * - Exponential backoff: 2^attempt * 1000ms
+	 * - Honors Retry-After header on 429/503 (seconds or HTTP-date)
+	 * - Falls back to exponential backoff with jitter (50–150% of 2^n * 1000ms)
+	 * - Caps the delay at MAX_RETRY_DELAY_MS so a misbehaving Retry-After
+	 *   doesn't pin a tab for minutes
+	 * - Skips retry entirely on non-retriable 4xx (anything except 408/429)
 	 * - Respects AbortController signal
-	 * - Retries on network errors and HTTP errors
-	 * - Logs each retry attempt with delay
 	 *
 	 * @param {string} url - Request URL
 	 * @param {Object} [options={}] - Fetch options (including signal)
@@ -469,27 +471,76 @@ class UnifiedLoader {
 	 * @private
 	 */
 	async fetchWithRetry(url, options = {}, retries = 3) {
+		const MAX_RETRY_DELAY_MS = 30_000
+		const isRetriableStatus = (status) => status === 408 || status === 429 || status >= 500
+		const parseRetryAfter = (header) => {
+			if (!header) return null
+			const trimmed = String(header).trim()
+			const seconds = Number(trimmed)
+			if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000
+			const date = Date.parse(trimmed)
+			if (Number.isNaN(date)) return null
+			return Math.max(0, date - Date.now())
+		}
+
 		let lastError
 
 		for (let attempt = 0; attempt <= retries; attempt++) {
+			// Per-host concurrency gate. Throws AbortError if signal fires
+			// while we're queued.
+			let releaseSlot
+			try {
+				releaseSlot = await acquireHostSlot(url, options.signal)
+			} catch (error) {
+				lastError = error
+				break
+			}
+
+			// Whatever happens in this attempt, release the slot before
+			// sleeping/returning/throwing so other waiters can proceed.
 			try {
 				const response = await fetch(url, options)
 
-				if (!response.ok) {
-					throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+				if (response.ok) return response
+
+				const status = response.status
+				if (!isRetriableStatus(status) || attempt >= retries || options.signal?.aborted) {
+					throw new Error(`HTTP ${status}: ${response.statusText}`)
 				}
 
-				return response
+				const retryAfterMs = parseRetryAfter(response.headers.get('Retry-After'))
+				const expBackoff = 2 ** attempt * 1000
+				const jitter = 0.5 + Math.random() // 0.5x–1.5x
+				const baseDelay = retryAfterMs != null ? retryAfterMs : expBackoff * jitter
+				const delay = Math.min(MAX_RETRY_DELAY_MS, Math.max(0, Math.round(baseDelay)))
+
+				logger.warn(
+					`Fetch attempt ${attempt + 1} got HTTP ${status}, retrying in ${delay}ms` +
+						(retryAfterMs != null ? ' (server Retry-After)' : '')
+				)
+				lastError = new Error(`HTTP ${status}: ${response.statusText}`)
+				releaseSlot()
+				releaseSlot = null
+				await new Promise((resolve) => setTimeout(resolve, delay))
 			} catch (error) {
 				lastError = error
 
 				if (attempt < retries && !options.signal?.aborted) {
-					const delay = 2 ** attempt * 1000 // Exponential backoff
+					const expBackoff = 2 ** attempt * 1000
+					const jitter = 0.5 + Math.random()
+					const delay = Math.min(MAX_RETRY_DELAY_MS, Math.round(expBackoff * jitter))
 					logger.warn(`Fetch attempt ${attempt + 1} failed, retrying in ${delay}ms...`)
+					releaseSlot?.()
+					releaseSlot = null
 					await new Promise((resolve) => setTimeout(resolve, delay))
 				} else {
 					break
 				}
+			} finally {
+				// Cover any path that didn't already release (e.g. terminal
+				// throw on a non-retriable status). Idempotent — second call
+				// is a no-op.
+				releaseSlot?.()
 			}
 		}
 

--- a/src/services/unifiedLoader.js
+++ b/src/services/unifiedLoader.js
@@ -482,6 +482,25 @@ class UnifiedLoader {
 			if (Number.isNaN(date)) return null
 			return Math.max(0, date - Date.now())
 		}
+		// Abortable sleep: resolves after `ms`, or rejects immediately if the
+		// caller's AbortSignal fires. Keeps backoff delays from leaking a
+		// pending timer (up to MAX_RETRY_DELAY_MS) after cancellation.
+		const sleep = (ms) =>
+			new Promise((resolve, reject) => {
+				if (options.signal?.aborted) {
+					reject(options.signal.reason ?? new DOMException('Aborted', 'AbortError'))
+					return
+				}
+				const onAbort = () => {
+					clearTimeout(timer)
+					reject(options.signal?.reason ?? new DOMException('Aborted', 'AbortError'))
+				}
+				const timer = setTimeout(() => {
+					options.signal?.removeEventListener('abort', onAbort)
+					resolve()
+				}, ms)
+				options.signal?.addEventListener('abort', onAbort)
+			})
 
 		let lastError
 
@@ -521,7 +540,7 @@ class UnifiedLoader {
 				lastError = new Error(`HTTP ${status}: ${response.statusText}`)
 				releaseSlot()
 				releaseSlot = null
-				await new Promise((resolve) => setTimeout(resolve, delay))
+				await sleep(delay)
 			} catch (error) {
 				lastError = error
 
@@ -532,7 +551,7 @@ class UnifiedLoader {
 					logger.warn(`Fetch attempt ${attempt + 1} failed, retrying in ${delay}ms...`)
 					releaseSlot?.()
 					releaseSlot = null
-					await new Promise((resolve) => setTimeout(resolve, delay))
+					await sleep(delay)
 				} else {
 					break
 				}

--- a/src/services/vttFlood.js
+++ b/src/services/vttFlood.js
@@ -1,0 +1,222 @@
+/**
+ * @module services/vttFlood
+ * Service layer for the VTT R4C flood simulation integration.
+ *
+ * Three responsibilities:
+ *  - {@link fetchSimulationFrame} — POST to the VTT proxy for a (scenario, frame)
+ *    pair, validating the payload before returning it. Implements the
+ *    cancellable-request pattern via AbortController so navigation away from
+ *    the panel aborts an in-flight request rather than letting it overwrite
+ *    fresher state.
+ *  - {@link renderFlood} — draw the returned GeoJSON as extruded polygon
+ *    entities with a blue→red gradient driven by the active dimension.
+ *  - {@link clearFlood} — remove the flood layer in one call.
+ *
+ * The service is stateless (no module-level mutable state): callers manage
+ * AbortControllers via the Pinia store and pass viewers explicitly.
+ */
+
+import {
+	VTT_API_PATH,
+	VTT_DIMENSIONS,
+	VTT_FILL_ALPHA,
+	VTT_FLOOD_LAYER_NAME,
+	VTT_MAX_EXTRUSION_M,
+	validateFrameNumber,
+	validateScenarioId,
+} from '../constants/vttFlood.ts'
+import logger from '../utils/logger.js'
+import { getCesium } from './cesiumProvider.js'
+
+const DIMENSION_KEYS = VTT_DIMENSIONS.map((d) => d.key)
+
+/**
+ * Computes per-property min/max across all features so dimension switching is
+ * an O(0) re-render rather than re-fetch.
+ *
+ * @param {Array<Object>} features - GeoJSON features.
+ * @returns {Record<string, {min: number, max: number}>}
+ */
+function computePropertyRanges(features) {
+	const ranges = {}
+	for (const key of DIMENSION_KEYS) {
+		ranges[key] = { min: Number.POSITIVE_INFINITY, max: Number.NEGATIVE_INFINITY }
+	}
+	for (const feature of features) {
+		const props = feature?.properties
+		if (!props) continue
+		for (const key of DIMENSION_KEYS) {
+			const value = props[key]
+			if (typeof value !== 'number' || !Number.isFinite(value)) continue
+			if (value < ranges[key].min) ranges[key].min = value
+			if (value > ranges[key].max) ranges[key].max = value
+		}
+	}
+	// Replace untouched ranges (no numeric values) with {min: 0, max: 0} so
+	// downstream code can rely on numeric values without a NaN sentinel.
+	for (const key of DIMENSION_KEYS) {
+		if (
+			ranges[key].min === Number.POSITIVE_INFINITY ||
+			ranges[key].max === Number.NEGATIVE_INFINITY
+		) {
+			ranges[key] = { min: 0, max: 0 }
+		}
+	}
+	return ranges
+}
+
+/**
+ * Fetch a single simulation frame from the VTT proxy.
+ *
+ * @param {Object} params
+ * @param {string} params.scenarioId - VTT scenario id (validated against
+ *   the {@link VTT_SCENARIOS} allow-list).
+ * @param {number} params.frameNumber - Frame index in 0..VTT_FRAME_COUNT-1.
+ * @param {AbortSignal} [params.signal] - Optional AbortSignal for cancellation.
+ * @returns {Promise<{features: Array<Object>, propertyRanges: Record<string, {min: number, max: number}>}>}
+ * @throws {Error} On invalid input, non-2xx response, or malformed payload.
+ *   AbortError propagates as-is so callers can distinguish cancellation from
+ *   real failures.
+ */
+export async function fetchSimulationFrame({ scenarioId, frameNumber, signal } = {}) {
+	const safeScenario = validateScenarioId(scenarioId)
+	const safeFrame = validateFrameNumber(frameNumber)
+
+	const body = JSON.stringify({
+		picture_number: safeFrame,
+		scenario_number: safeScenario,
+	})
+
+	logger.debug(
+		`[VTTFlood] Fetching scenario=${safeScenario} frame=${safeFrame} from ${VTT_API_PATH}`
+	)
+
+	const response = await fetch(VTT_API_PATH, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body,
+		signal,
+	})
+
+	if (!response.ok) {
+		throw new Error(
+			`VTT flood API responded ${response.status} ${response.statusText} for scenario=${safeScenario} frame=${safeFrame}`
+		)
+	}
+
+	const payload = await response.json()
+	if (!payload || typeof payload !== 'object' || !Array.isArray(payload.features)) {
+		throw new Error(
+			'VTT flood API returned malformed payload: expected GeoJSON FeatureCollection with features[]'
+		)
+	}
+
+	return {
+		features: payload.features,
+		propertyRanges: computePropertyRanges(payload.features),
+	}
+}
+
+/**
+ * Builds the polygon ring from a Feature's geometry.coordinates.
+ * Accepts both [[lon,lat],...] (single ring) and [[[lon,lat],...]] (Polygon
+ * outer ring) shapes — the POC API has been seen emitting both.
+ *
+ * @param {Object} geometry - GeoJSON geometry object.
+ * @returns {Array<number>|null} Flat [lon, lat, lon, lat, ...] or null on
+ *   unrecognised shape.
+ */
+function extractRing(geometry) {
+	if (!geometry?.coordinates) return null
+	const coords = geometry.coordinates
+	// flat(Infinity) collapses single ring or nested rings to a flat list — the
+	// POC relies on this same trick.
+	const flat = coords.flat(Infinity)
+	if (!flat.length || flat.length % 2 !== 0) return null
+	for (const n of flat) {
+		if (typeof n !== 'number' || !Number.isFinite(n)) return null
+	}
+	return flat
+}
+
+/**
+ * Render the flood frame as a Cesium GeoJsonDataSource of extruded polygons,
+ * coloured and sized by the active dimension.
+ *
+ * Uses the existing GeoJsonDataSource pattern (consistent with
+ * {@link DataSource#addDataSourceWithPolygonFix}) so the layer participates
+ * in `changeDataSourceShowByName` / `removeDataSourcesByNamePrefix`.
+ *
+ * @param {Object} params
+ * @param {Cesium.Viewer} params.viewer - Cesium viewer.
+ * @param {{features: Array<Object>, propertyRanges: Record<string, {min: number, max: number}>}} params.frame
+ *   Output of {@link fetchSimulationFrame}.
+ * @param {string} params.dimension - Active dimension key (one of {@link VTT_DIMENSIONS}).
+ * @returns {Promise<number>} Number of entities created.
+ */
+export async function renderFlood({ viewer, frame, dimension } = {}) {
+	if (!viewer || viewer.isDestroyed?.()) {
+		logger.warn('[VTTFlood] renderFlood: viewer not initialized; skipping')
+		return 0
+	}
+	if (!frame || !Array.isArray(frame.features)) {
+		logger.warn('[VTTFlood] renderFlood: no frame data; skipping')
+		return 0
+	}
+	if (!DIMENSION_KEYS.includes(dimension)) {
+		throw new Error(`Invalid VTT dimension: "${dimension}"`)
+	}
+
+	const Cesium = getCesium()
+	await clearFlood({ viewer })
+
+	const range = frame.propertyRanges[dimension] || { min: 0, max: 0 }
+	const span = range.max - range.min
+	const dataSource = new Cesium.CustomDataSource(VTT_FLOOD_LAYER_NAME)
+
+	let created = 0
+	for (const feature of frame.features) {
+		const ring = extractRing(feature.geometry)
+		if (!ring) continue
+
+		const value = feature.properties?.[dimension]
+		if (typeof value !== 'number' || !Number.isFinite(value)) continue
+
+		const ratio = span === 0 ? 0 : Math.max(0, Math.min(1, (value - range.min) / span))
+		const color = Cesium.Color.lerp(Cesium.Color.BLUE, Cesium.Color.RED, ratio, new Cesium.Color())
+		color.alpha = VTT_FILL_ALPHA
+
+		dataSource.entities.add({
+			polygon: {
+				hierarchy: Cesium.Cartesian3.fromDegreesArray(ring),
+				extrudedHeight: ratio * VTT_MAX_EXTRUSION_M,
+				material: color,
+				outline: true,
+				outlineColor: Cesium.Color.BLACK,
+				arcType: Cesium.ArcType.GEODESIC,
+			},
+		})
+		created++
+	}
+
+	viewer.dataSources.add(dataSource)
+	logger.debug(`[VTTFlood] Rendered ${created} cells for dimension="${dimension}"`)
+	return created
+}
+
+/**
+ * Remove the VTT flood layer from the viewer.
+ *
+ * @param {Object} params
+ * @param {Cesium.Viewer} params.viewer - Cesium viewer.
+ * @returns {Promise<void>}
+ */
+export async function clearFlood({ viewer } = {}) {
+	if (!viewer || viewer.isDestroyed?.() || !viewer.dataSources) return
+	const sources = viewer.dataSources._dataSources || []
+	for (const ds of [...sources]) {
+		if (ds.name === VTT_FLOOD_LAYER_NAME) {
+			viewer.dataSources.remove(ds, true)
+		}
+	}
+}

--- a/src/services/vttFlood.js
+++ b/src/services/vttFlood.js
@@ -87,11 +87,16 @@ export async function fetchSimulationFrame({ scenarioId, frameNumber, signal } =
 		scenario_number: safeScenario,
 	})
 
-	logger.debug(
-		`[VTTFlood] Fetching scenario=${safeScenario} frame=${safeFrame} from ${VTT_API_PATH}`
-	)
+	// Append scenario+frame as query params so the nginx proxy can build a
+	// reliable cache key from $request_uri alone. $request_body is not
+	// guaranteed to be populated during nginx's cache lookup phase, so a
+	// body-based key collapses every POST onto the same entry. The upstream
+	// VTT API still reads the POST body and ignores the query string.
+	const url = `${VTT_API_PATH}?scenario=${safeScenario}&frame=${safeFrame}`
 
-	const response = await fetch(VTT_API_PATH, {
+	logger.debug(`[VTTFlood] Fetching scenario=${safeScenario} frame=${safeFrame} from ${url}`)
+
+	const response = await fetch(url, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		body,

--- a/src/stores/graphicsStore.js
+++ b/src/stores/graphicsStore.js
@@ -41,7 +41,10 @@ export const useGraphicsStore = defineStore('graphics', {
 		ambientOcclusionEnabled: false,
 
 		// Performance settings
-		requestRenderMode: false,
+		// Default ON: Cesium only re-renders when the scene actually changes
+		// (camera move, entity update, imagery load). Without this, the viewer
+		// re-renders every animation frame and saturates CPU/GPU on idle viewports.
+		requestRenderMode: true,
 
 		// Support detection (set at runtime)
 		msaaSupported: false,

--- a/src/stores/vttFloodStore.ts
+++ b/src/stores/vttFloodStore.ts
@@ -1,0 +1,155 @@
+/**
+ * @module stores/vttFloodStore
+ * Pinia store coordinating the VTT R4C flood-simulation playback panel.
+ *
+ * The store owns the playback state (scenario, frame, dimension), cached frame
+ * data, and request lifecycle (loading, error, AbortController). The
+ * component layer watches store state and calls `vttFlood.renderFlood` /
+ * `clearFlood` directly — this mirrors the buildingStore ↔ building/ services
+ * separation already used elsewhere in the codebase.
+ *
+ * setFrame is debounced so scrubbing the slider doesn't burst-fire requests.
+ */
+
+import { defineStore } from 'pinia'
+import {
+	formatFrameOffset,
+	VTT_DIMENSIONS,
+	VTT_FRAME_COUNT,
+	VTT_SCENARIOS,
+	validateFrameNumber,
+	validateScenarioId,
+} from '@/constants/vttFlood'
+import { fetchSimulationFrame } from '@/services/vttFlood'
+import logger from '@/utils/logger'
+
+const FRAME_DEBOUNCE_MS = 200
+
+interface PropertyRange {
+	min: number
+	max: number
+}
+
+interface VttFrameData {
+	features: Array<Record<string, unknown>>
+	propertyRanges: Record<string, PropertyRange>
+}
+
+interface VttFloodState {
+	scenarioId: string
+	frameNumber: number
+	dimension: string
+	frame: VttFrameData | null
+	isLoading: boolean
+	error: string | null
+	/** Generation counter — incremented for every fetchCurrentFrame call so
+	 *  late-resolving responses can detect that they've been superseded. */
+	_requestSeq: number
+	_abortController: AbortController | null
+	_debounceTimer: ReturnType<typeof setTimeout> | null
+}
+
+export const useVttFloodStore = defineStore('vttFlood', {
+	state: (): VttFloodState => ({
+		scenarioId: VTT_SCENARIOS[0].id,
+		frameNumber: 0,
+		dimension: VTT_DIMENSIONS[0].key,
+		frame: null,
+		isLoading: false,
+		error: null,
+		_requestSeq: 0,
+		_abortController: null,
+		_debounceTimer: null,
+	}),
+
+	getters: {
+		activeRange: (state): PropertyRange => {
+			if (!state.frame) return { min: 0, max: 0 }
+			return state.frame.propertyRanges[state.dimension] || { min: 0, max: 0 }
+		},
+		frameOffsetLabel: (state): string => formatFrameOffset(state.frameNumber),
+		frameCount: (): number => VTT_FRAME_COUNT,
+	},
+
+	actions: {
+		selectScenario(id: string): void {
+			const safe = validateScenarioId(id)
+			if (safe === this.scenarioId) return
+			this.scenarioId = safe
+			this.frame = null
+			this.fetchCurrentFrame()
+		},
+
+		setFrame(frame: number): void {
+			const safe = validateFrameNumber(frame)
+			if (safe === this.frameNumber) return
+			this.frameNumber = safe
+			if (this._debounceTimer) clearTimeout(this._debounceTimer)
+			this._debounceTimer = setTimeout(() => {
+				this._debounceTimer = null
+				this.fetchCurrentFrame()
+			}, FRAME_DEBOUNCE_MS)
+		},
+
+		setDimension(key: string): void {
+			if (!VTT_DIMENSIONS.some((d) => d.key === key)) {
+				logger.warn(`[VTTFloodStore] Ignoring unknown dimension "${key}"`)
+				return
+			}
+			this.dimension = key
+		},
+
+		async fetchCurrentFrame(): Promise<void> {
+			// Cancel any in-flight request before starting a new one. The aborted
+			// fetch will reject with AbortError, which the catch below swallows.
+			if (this._abortController) {
+				this._abortController.abort()
+			}
+			const controller = new AbortController()
+			this._abortController = controller
+			this._requestSeq += 1
+			const seq = this._requestSeq
+
+			this.isLoading = true
+			this.error = null
+			try {
+				const result = await fetchSimulationFrame({
+					scenarioId: this.scenarioId,
+					frameNumber: this.frameNumber,
+					signal: controller.signal,
+				})
+				if (seq !== this._requestSeq) return // a newer call superseded us
+				this.frame = result
+			} catch (error) {
+				if (error instanceof DOMException && error.name === 'AbortError') {
+					logger.debug('[VTTFloodStore] Fetch aborted (newer request started)')
+					return
+				}
+				if (seq !== this._requestSeq) return
+				const message = error instanceof Error ? error.message : String(error)
+				logger.error('[VTTFloodStore] Failed to fetch frame:', message)
+				this.error = message
+				this.frame = null
+			} finally {
+				if (seq === this._requestSeq) {
+					this.isLoading = false
+					this._abortController = null
+				}
+			}
+		},
+
+		clear(): void {
+			if (this._abortController) {
+				this._abortController.abort()
+				this._abortController = null
+			}
+			if (this._debounceTimer) {
+				clearTimeout(this._debounceTimer)
+				this._debounceTimer = null
+			}
+			this.frame = null
+			this.error = null
+			this.isLoading = false
+		},
+	},
+})

--- a/tests/e2e/fixtures/vtt-flood/scenario-1-frame-0.json
+++ b/tests/e2e/fixtures/vtt-flood/scenario-1-frame-0.json
@@ -1,0 +1,68 @@
+{
+	"type": "FeatureCollection",
+	"features": [
+		{
+			"type": "Feature",
+			"geometry": {
+				"type": "Polygon",
+				"coordinates": [
+					[
+						[25.0420, 60.1780],
+						[25.0430, 60.1780],
+						[25.0430, 60.1790],
+						[25.0420, 60.1790],
+						[25.0420, 60.1780]
+					]
+				]
+			},
+			"properties": {
+				"canopy_air_temperature": 291.5,
+				"overland_water_depth": 0.05,
+				"transpiration": 0.30,
+				"upper_storage_water_depth": 0.02
+			}
+		},
+		{
+			"type": "Feature",
+			"geometry": {
+				"type": "Polygon",
+				"coordinates": [
+					[
+						[25.0430, 60.1780],
+						[25.0440, 60.1780],
+						[25.0440, 60.1790],
+						[25.0430, 60.1790],
+						[25.0430, 60.1780]
+					]
+				]
+			},
+			"properties": {
+				"canopy_air_temperature": 293.0,
+				"overland_water_depth": 0.20,
+				"transpiration": 0.45,
+				"upper_storage_water_depth": 0.06
+			}
+		},
+		{
+			"type": "Feature",
+			"geometry": {
+				"type": "Polygon",
+				"coordinates": [
+					[
+						[25.0440, 60.1780],
+						[25.0450, 60.1780],
+						[25.0450, 60.1790],
+						[25.0440, 60.1790],
+						[25.0440, 60.1780]
+					]
+				]
+			},
+			"properties": {
+				"canopy_air_temperature": 296.2,
+				"overland_water_depth": 0.55,
+				"transpiration": 0.62,
+				"upper_storage_water_depth": 0.11
+			}
+		}
+	]
+}

--- a/tests/e2e/vtt-flood-simulation.spec.ts
+++ b/tests/e2e/vtt-flood-simulation.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * VTT Flood Simulation — feature-flag-gated integration spec.
+ *
+ * Tags: @e2e @feature-flag @vtt-flood
+ *
+ * Mocks the POST /vtt-api endpoint with a small fixture so the panel renders
+ * without depending on the upstream VTT API.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expect } from '@playwright/test'
+import { cesiumTest } from '../fixtures/cesium-fixture'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const FIXTURE_PATH = path.join(__dirname, 'fixtures/vtt-flood/scenario-1-frame-0.json')
+const FIXTURE_BODY = fs.readFileSync(FIXTURE_PATH, 'utf-8')
+
+cesiumTest.describe('VTT Flood Simulation', () => {
+	cesiumTest.use({ tag: ['@e2e', '@feature-flag', '@vtt-flood'] })
+
+	cesiumTest('button is hidden when the flag is off', async ({ cesiumPage }) => {
+		// No flag set — vttFloodSimulation fallbackDefault is false.
+		const button = cesiumPage.getByRole('button', { name: /Flood Simulation \(VTT\)/i })
+		await expect(button).toHaveCount(0)
+	})
+
+	cesiumTest(
+		'with flag enabled, opens panel and fires exactly one POST per scenario+frame',
+		async ({ cesiumPage }) => {
+			let postCount = 0
+
+			// Narrow route: only the VTT proxy, never localhost module requests.
+			await cesiumPage.route('**/vtt-api', (route) => {
+				if (route.request().method() !== 'POST') return route.continue()
+				postCount += 1
+				return route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: FIXTURE_BODY,
+				})
+			})
+
+			// Enable the flag via localStorage override (same channel as
+			// FeatureFlagsPanel.doImport). The store reads this on init.
+			await cesiumPage.evaluate(() => {
+				localStorage.setItem('featureFlags', JSON.stringify({ vttFloodSimulation: true }))
+			})
+			await cesiumPage.reload()
+			await cesiumPage.waitForLoadState('domcontentloaded')
+
+			// Open the Layers tab and click the gated button.
+			await cesiumPage.getByRole('tab', { name: 'Layers' }).click()
+			const button = cesiumPage.getByRole('button', { name: /Flood Simulation \(VTT\)/i })
+			await expect(button).toBeVisible()
+			await button.click()
+
+			// Panel mounts and shows the scenario description (verifies select rendered).
+			await expect(cesiumPage.getByText(/80 mm\/h cloudburst/i)).toBeVisible()
+
+			// Initial fetch should have fired exactly once.
+			await expect.poll(() => postCount, { timeout: 5000 }).toBe(1)
+
+			// Switching dimension must NOT trigger another network request — the
+			// frame data is cached and only the rendering changes.
+			const overlandRadio = cesiumPage.getByLabel(/Overland water depth/i)
+			await overlandRadio.click()
+			await cesiumPage.waitForTimeout(400)
+			expect(postCount).toBe(1)
+
+			// The data source name lands in the viewer's collection.
+			const hasLayer = await cesiumPage.evaluate(() => {
+				const viewer = (window as any).__viewer || (window as any).viewer
+				if (!viewer?.dataSources) return false
+				const sources = viewer.dataSources._dataSources || []
+				return sources.some((ds: { name?: string }) => ds.name === 'VTT-Flood-Simulation')
+			})
+			expect(hasLayer).toBe(true)
+		}
+	)
+})

--- a/tests/unit/services/hostConcurrencyLimiter.test.js
+++ b/tests/unit/services/hostConcurrencyLimiter.test.js
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for hostConcurrencyLimiter.
+ *
+ * Tags: @unit
+ */
+
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+	__resetForTests,
+	acquireHostSlot,
+	DEFAULT_LIMIT,
+	extractHostKey,
+	inspectLimiter,
+	setHostLimit,
+} from '../../../src/services/hostConcurrencyLimiter.js'
+
+describe('extractHostKey', () => {
+	it('returns the hostname for absolute URLs', () => {
+		expect(extractHostKey('https://kartta.hsy.fi/geoserver/wfs')).toBe('kartta.hsy.fi')
+		expect(extractHostKey('http://localhost:5173/foo')).toBe('localhost')
+	})
+
+	it('returns the first path segment for relative URLs (matches Vite proxy buckets)', () => {
+		expect(extractHostKey('/pygeoapi/collections/foo')).toBe('pygeoapi')
+		expect(extractHostKey('/hsy-action?route=x')).toBe('hsy-action?route=x')
+		expect(extractHostKey('/wms/proxy/tile')).toBe('wms')
+	})
+
+	it('handles edge cases without crashing', () => {
+		expect(extractHostKey('/')).toBe('__root__')
+		expect(extractHostKey('')).toBe('__root__')
+	})
+})
+
+describe('acquireHostSlot', () => {
+	afterEach(() => __resetForTests())
+
+	it('lets calls up to the limit run immediately', async () => {
+		setHostLimit('host-a', 2)
+		const r1 = await acquireHostSlot('https://host-a/x')
+		const r2 = await acquireHostSlot('https://host-a/y')
+		expect(inspectLimiter()['host-a']).toEqual({ active: 2, queued: 0, limit: 2 })
+		r1()
+		r2()
+	})
+
+	it('queues calls past the limit until a slot is released', async () => {
+		setHostLimit('host-b', 1)
+		const r1 = await acquireHostSlot('https://host-b/x')
+		const pending = acquireHostSlot('https://host-b/y')
+
+		await Promise.resolve()
+		expect(inspectLimiter()['host-b']).toEqual({ active: 1, queued: 1, limit: 1 })
+
+		r1()
+		const r2 = await pending
+		expect(inspectLimiter()['host-b']).toEqual({ active: 1, queued: 0, limit: 1 })
+		r2()
+	})
+
+	it('respects DEFAULT_LIMIT for unconfigured hosts', async () => {
+		const releases = []
+		for (let i = 0; i < DEFAULT_LIMIT; i++) {
+			releases.push(await acquireHostSlot('https://default-host/x'))
+		}
+		await Promise.resolve()
+		expect(inspectLimiter()['default-host'].active).toBe(DEFAULT_LIMIT)
+		releases.forEach((r) => r())
+	})
+
+	it('keys absolute and relative URLs independently', async () => {
+		setHostLimit('kartta.hsy.fi', 1)
+		setHostLimit('pygeoapi', 1)
+
+		const a = await acquireHostSlot('https://kartta.hsy.fi/foo')
+		const b = await acquireHostSlot('/pygeoapi/bar')
+
+		// Both ran in parallel — different host keys.
+		const state = inspectLimiter()
+		expect(state['kartta.hsy.fi'].active).toBe(1)
+		expect(state.pygeoapi.active).toBe(1)
+		a()
+		b()
+	})
+
+	it('aborts a queued call when the signal fires', async () => {
+		setHostLimit('host-c', 1)
+		const r1 = await acquireHostSlot('https://host-c/x')
+
+		const controller = new AbortController()
+		const pending = acquireHostSlot('https://host-c/y', controller.signal)
+		await Promise.resolve()
+		expect(inspectLimiter()['host-c'].queued).toBe(1)
+
+		controller.abort(new Error('user cancelled'))
+		await expect(pending).rejects.toThrow('user cancelled')
+		expect(inspectLimiter()['host-c'].queued).toBe(0)
+		r1()
+	})
+
+	it('release() is idempotent', async () => {
+		setHostLimit('host-d', 1)
+		const release = await acquireHostSlot('https://host-d/x')
+		release()
+		release() // second call is a no-op
+		expect(inspectLimiter()['host-d'].active).toBe(0)
+	})
+})
+
+describe('setHostLimit validation', () => {
+	afterEach(() => __resetForTests())
+
+	it('rejects non-positive or non-finite limits', () => {
+		expect(() => setHostLimit('host-e', 0)).toThrow()
+		expect(() => setHostLimit('host-e', -1)).toThrow()
+		expect(() => setHostLimit('host-e', Number.NaN)).toThrow()
+		expect(() => setHostLimit('host-e', Number.POSITIVE_INFINITY)).toThrow()
+	})
+
+	it('floors fractional limits', async () => {
+		setHostLimit('host-f', 2.7)
+		const releases = []
+		for (let i = 0; i < 2; i++) {
+			releases.push(await acquireHostSlot('https://host-f/x'))
+		}
+		await Promise.resolve()
+		expect(inspectLimiter()['host-f'].limit).toBe(2)
+		releases.forEach((r) => r())
+	})
+})

--- a/tests/unit/services/vttFlood.test.js
+++ b/tests/unit/services/vttFlood.test.js
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Cesium mock surfaces just enough API for renderFlood + clearFlood to exercise.
+const ColorMock = vi.fn(function (r, g, b, a) {
+	this.red = r ?? 1
+	this.green = g ?? 1
+	this.blue = b ?? 1
+	this.alpha = a ?? 1
+})
+ColorMock.BLUE = new ColorMock(0, 0, 1, 1)
+ColorMock.RED = new ColorMock(1, 0, 0, 1)
+ColorMock.BLACK = new ColorMock(0, 0, 0, 1)
+ColorMock.lerp = vi.fn((_a, _b, _r, result) => result ?? new ColorMock())
+
+const Cartesian3Mock = {
+	fromDegreesArray: vi.fn((arr) => arr.slice()),
+}
+
+const CustomDataSourceMock = vi.fn(function (name) {
+	this.name = name
+	const entities = []
+	this.entities = {
+		add: vi.fn((entity) => {
+			entities.push(entity)
+			return entity
+		}),
+		values: entities,
+	}
+})
+
+vi.mock('@/services/cesiumProvider.js', () => ({
+	getCesium: () => ({
+		Color: ColorMock,
+		Cartesian3: Cartesian3Mock,
+		CustomDataSource: CustomDataSourceMock,
+		ArcType: { GEODESIC: 'GEODESIC' },
+	}),
+}))
+
+import { VTT_FLOOD_LAYER_NAME } from '@/constants/vttFlood.ts'
+import { clearFlood, fetchSimulationFrame, renderFlood } from '@/services/vttFlood.js'
+
+function makeViewer() {
+	const sources = []
+	return {
+		isDestroyed: () => false,
+		dataSources: {
+			_dataSources: sources,
+			add: vi.fn((ds) => {
+				sources.push(ds)
+				return ds
+			}),
+			remove: vi.fn((ds) => {
+				const i = sources.indexOf(ds)
+				if (i >= 0) sources.splice(i, 1)
+				return true
+			}),
+		},
+	}
+}
+
+function makeFeature(props, ring) {
+	return {
+		type: 'Feature',
+		geometry: { type: 'Polygon', coordinates: [ring] },
+		properties: props,
+	}
+}
+
+const SAMPLE_RING = [
+	[25.04, 60.18],
+	[25.041, 60.18],
+	[25.041, 60.181],
+	[25.04, 60.181],
+	[25.04, 60.18],
+]
+
+describe('fetchSimulationFrame', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('rejects invalid scenario id without firing a network request', async () => {
+		const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}'))
+		await expect(fetchSimulationFrame({ scenarioId: '9', frameNumber: 0 })).rejects.toThrow(
+			/Invalid VTT scenario/
+		)
+		expect(fetchSpy).not.toHaveBeenCalled()
+	})
+
+	it('rejects out-of-range frame number', async () => {
+		const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}'))
+		await expect(fetchSimulationFrame({ scenarioId: '1', frameNumber: -1 })).rejects.toThrow(
+			/Invalid VTT frame/
+		)
+		expect(fetchSpy).not.toHaveBeenCalled()
+	})
+
+	it('returns features and computed propertyRanges on success', async () => {
+		const payload = {
+			type: 'FeatureCollection',
+			features: [
+				makeFeature(
+					{
+						canopy_air_temperature: 290,
+						overland_water_depth: 0.1,
+						transpiration: 0.5,
+						upper_storage_water_depth: 0.05,
+					},
+					SAMPLE_RING
+				),
+				makeFeature(
+					{
+						canopy_air_temperature: 295,
+						overland_water_depth: 0.4,
+						transpiration: 0.7,
+						upper_storage_water_depth: 0.08,
+					},
+					SAMPLE_RING
+				),
+			],
+		}
+		vi.spyOn(global, 'fetch').mockResolvedValue(
+			new Response(JSON.stringify(payload), { status: 200 })
+		)
+
+		const result = await fetchSimulationFrame({ scenarioId: '1', frameNumber: 12 })
+		expect(result.features).toHaveLength(2)
+		expect(result.propertyRanges.canopy_air_temperature).toEqual({ min: 290, max: 295 })
+		expect(result.propertyRanges.overland_water_depth).toEqual({ min: 0.1, max: 0.4 })
+	})
+
+	it('throws on non-2xx response', async () => {
+		vi.spyOn(global, 'fetch').mockResolvedValue(new Response('error', { status: 500 }))
+		await expect(fetchSimulationFrame({ scenarioId: '1', frameNumber: 0 })).rejects.toThrow(/500/)
+	})
+
+	it('throws on malformed payload (missing features[])', async () => {
+		vi.spyOn(global, 'fetch').mockResolvedValue(
+			new Response(JSON.stringify({ type: 'FeatureCollection' }), { status: 200 })
+		)
+		await expect(fetchSimulationFrame({ scenarioId: '1', frameNumber: 0 })).rejects.toThrow(
+			/malformed/
+		)
+	})
+
+	it('propagates AbortError', async () => {
+		vi.spyOn(global, 'fetch').mockImplementation(() =>
+			Promise.reject(Object.assign(new DOMException('aborted', 'AbortError')))
+		)
+		await expect(fetchSimulationFrame({ scenarioId: '1', frameNumber: 0 })).rejects.toMatchObject({
+			name: 'AbortError',
+		})
+	})
+})
+
+describe('renderFlood', () => {
+	beforeEach(() => {
+		CustomDataSourceMock.mockClear()
+		ColorMock.lerp.mockClear()
+	})
+
+	it('produces the expected entity count for a small fixture', async () => {
+		const viewer = makeViewer()
+		const frame = {
+			features: [
+				makeFeature({ overland_water_depth: 0.1 }, SAMPLE_RING),
+				makeFeature({ overland_water_depth: 0.5 }, SAMPLE_RING),
+				makeFeature({ overland_water_depth: 1.0 }, SAMPLE_RING),
+			],
+			propertyRanges: {
+				canopy_air_temperature: { min: 0, max: 0 },
+				overland_water_depth: { min: 0.1, max: 1.0 },
+				transpiration: { min: 0, max: 0 },
+				upper_storage_water_depth: { min: 0, max: 0 },
+			},
+		}
+		const created = await renderFlood({ viewer, frame, dimension: 'overland_water_depth' })
+		expect(created).toBe(3)
+		expect(viewer.dataSources._dataSources).toHaveLength(1)
+		expect(viewer.dataSources._dataSources[0].name).toBe(VTT_FLOOD_LAYER_NAME)
+	})
+
+	it('handles empty features without crashing', async () => {
+		const viewer = makeViewer()
+		const frame = {
+			features: [],
+			propertyRanges: {
+				canopy_air_temperature: { min: 0, max: 0 },
+				overland_water_depth: { min: 0, max: 0 },
+				transpiration: { min: 0, max: 0 },
+				upper_storage_water_depth: { min: 0, max: 0 },
+			},
+		}
+		const created = await renderFlood({ viewer, frame, dimension: 'overland_water_depth' })
+		expect(created).toBe(0)
+	})
+
+	it('throws on unknown dimension', async () => {
+		const viewer = makeViewer()
+		const frame = { features: [], propertyRanges: {} }
+		await expect(renderFlood({ viewer, frame, dimension: 'not_a_real_dimension' })).rejects.toThrow(
+			/Invalid VTT dimension/
+		)
+	})
+
+	it('skips features with non-numeric values silently', async () => {
+		const viewer = makeViewer()
+		const frame = {
+			features: [
+				makeFeature({ overland_water_depth: 0.5 }, SAMPLE_RING),
+				makeFeature({ overland_water_depth: 'oops' }, SAMPLE_RING),
+				makeFeature({ overland_water_depth: NaN }, SAMPLE_RING),
+			],
+			propertyRanges: {
+				canopy_air_temperature: { min: 0, max: 0 },
+				overland_water_depth: { min: 0.5, max: 0.5 },
+				transpiration: { min: 0, max: 0 },
+				upper_storage_water_depth: { min: 0, max: 0 },
+			},
+		}
+		const created = await renderFlood({ viewer, frame, dimension: 'overland_water_depth' })
+		expect(created).toBe(1)
+	})
+})
+
+describe('clearFlood', () => {
+	it('removes only the VTT flood layer', async () => {
+		const viewer = makeViewer()
+		viewer.dataSources._dataSources.push({ name: VTT_FLOOD_LAYER_NAME })
+		viewer.dataSources._dataSources.push({ name: 'Buildings 00100' })
+		await clearFlood({ viewer })
+		expect(viewer.dataSources.remove).toHaveBeenCalledTimes(1)
+	})
+
+	it('is safe on a destroyed viewer', async () => {
+		await expect(clearFlood({ viewer: null })).resolves.toBeUndefined()
+		await expect(clearFlood({ viewer: { isDestroyed: () => true } })).resolves.toBeUndefined()
+	})
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -317,6 +317,18 @@ export default defineConfig(({ mode }) => {
 						});
 					},
 				},
+				'/vtt-api': {
+					// VTT R4C flood simulation API.
+					target: env.VITE_VTT_API_HOST || 'http://130.188.4.230',
+					changeOrigin: true,
+					secure: false,
+					rewrite: (path) => path.replace(/^\/vtt-api.*$/, '/python_api/calc'),
+					configure: (proxy, _options) => {
+						proxy.on('error', (err, _req, _res) => {
+							console.warn('VTT flood API proxy error:', err.message);
+						});
+					},
+				},
 			},
 		},
 	};


### PR DESCRIPTION
## Summary

Bundles four related-but-distinct improvements that were developed together:

1. **`feat(loader)`** — Per-host concurrency limiter + `Retry-After`-honoring backoff in `unifiedLoader.fetchWithRetry`. Motivated by HTTP 429 storms from `pygeoapi.dataportal.fi`, which sits behind an Envoy Gateway `BackendTrafficPolicy` enforcing a per-source-IP rate limit that per-loader caps can't see.
2. **`perf(cesium)`** — Default `requestRenderMode` on (was off). Cesium re-rendered every animation frame on idle viewports, saturating CPU/GPU. Propagated via the `r4c-request-render-mode` GOFF flag so we can revert per-user if a feature regresses.
3. **`feat(flood)`** — New FVH+VTT-internal VTT R4C flood-simulation playback panel for Laajasalo, gated by the `r4c-vtt-flood-simulation` GOFF flag. Fetches from VTT's `python_api/calc` via a new `/vtt-api` proxy (Vite + nginx) with 5-min response cache. Removes the obsolete hidden "Flood Simulations" external link from `PostalCodeView`. Introduces `flags.goff.yaml` as the app-owned canonical source for GOFF flag definitions.
4. **`chore(flags)`** — Enable all flags by default in `bun run dev` so new features are visible without panel overrides. Production unchanged (still uses `fallbackDefault`).

## Why one PR

These were developed in the same working session and share docs touchpoints (`.claude/rules/architecture.md` has sections for both the gateway-rate-limit story and the RRM story). Each commit is independently revertable — split commits, not split PRs.

## Test plan

- [ ] Unit tests for `hostConcurrencyLimiter` and `vttFlood` service pass
- [ ] Playwright E2E for VTT flood panel passes against offline fixture: `bunx playwright test vtt-flood-simulation`
- [ ] `bun run dev` shows all flags enabled in feature-flags panel without manual overrides
- [ ] In `bun run dev`, switch to a Laajasalo postal code, open the VTT Flood Simulation panel — camera flies to Laajasalo, frames load through `/vtt-api` proxy
- [ ] Inspect Cesium scene in dev: idle viewport CPU stays low (RRM on); a camera move re-renders
- [ ] Verify 429s on `/pygeoapi/*` honor `Retry-After` (manually rate-limit in DevTools or stub the response)

## Follow-up issues

<!-- Post-merge actions tracked as issues so they survive PR closure -->
- #795: update production GOFF ConfigMap to add `r4c-vtt-flood-simulation` flag definition

## Related Issues

Refs #723 (N+1 API calls — the per-host limiter + Retry-After helps but doesn't fully resolve)
Refs #778 (Cesium render-blocking — RRM default-on relieves idle-frame CPU)

## Changes since initial review

- `fix(vtt-flood)`: address gemini-code-assist feedback — VTT scenario/frame moved to URL query string so the nginx `proxy_cache_key` can rely on `$request_uri` alone (POST body is unreliable during cache lookup); VTT host parsed with a `^(https?)://(.*)$` regex so a protocol-prefixed `VITE_VTT_API_HOST` no longer produces `https://https://…`; `fetchWithRetry` backoffs use an abortable `sleep` helper so cancelling during a retry delay no longer leaks a pending timer.
- `.ts` import-extension nits declined: the project convention is to include extensions on every import (we already do so for `.js`), and `moduleResolution: bundler` permits `.ts` extensions — Typecheck remains green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

