### PR TITLE
chore(ci): bump reusable-workflow pin to pick up trivy-action fix

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -27,7 +27,7 @@ jobs:
 
   build:
     needs: setup
-    uses: ForumViriumHelsinki/.github/.github/workflows/reusable-container-build.yml@7378f9c921226d2f90908b52f0a7a5a4f13e978e # main
+    uses: ForumViriumHelsinki/.github/.github/workflows/reusable-container-build.yml@fa1be8d5f9f7326b963fec7c558869bf6ed807ba # main
     with:
       image-name: ${{ needs.setup.outputs.image-name }}
     secrets:

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -20,7 +20,7 @@ jobs:
 
   release:
     needs: setup
-    uses: ForumViriumHelsinki/.github/.github/workflows/reusable-container-release.yml@7378f9c921226d2f90908b52f0a7a5a4f13e978e # main
+    uses: ForumViriumHelsinki/.github/.github/workflows/reusable-container-release.yml@fa1be8d5f9f7326b963fec7c558869bf6ed807ba # main
     with:
       image-name: ${{ needs.setup.outputs.image-name }}
       tag-prefix: 'r4c-cesium-viewer-v'


### PR DESCRIPTION
## Summary

- ForumViriumHelsinki/.github#59 bumped `trivy-action` 0.34.0 → 0.36.0 to recover from the yanked Trivy v0.69.1 release.
- This repo pins the reusable container workflows to commit `7378f9c`, so the fix doesn't reach it until the pin advances. Bumping both `container-build.yml` and `container-release.yml` to `fa1be8d` (PR #59 merge) — keeps them in lockstep, as before.

## Why both files

`container-build.yml` doesn't use Trivy itself, but it shares the same pin with `container-release.yml`. Bumping only the release workflow would create silent drift between the two — easier to reason about if they advance together.

## Context

Failing release run that motivated the upstream fix: https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/actions/runs/26508704877/job/78067793072

The 1.51.0 image was promoted and signed before the Trivy step ran, so it's already deployed. The user-visible symptom was the workflow being marked failed.

## Test plan

- [ ] PR CI passes (build workflow uses the new pin).
- [ ] Re-run the failed 1.51.0 release workflow after merge — Trivy step should install v0.70.0 and complete the scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)