### PR TITLE
fix(auth): hide Sign Out for anonymous users; warn on non-JSON userinfo

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -72,9 +72,16 @@
 						@click="smartReset"
 					/>
 					<v-list-item
+						v-if="userStore.isAuthenticated"
 						prepend-icon="mdi-logout"
 						title="Sign out"
 						@click="signOut"
+					/>
+					<v-list-item
+						v-else
+						prepend-icon="mdi-login"
+						title="Sign in"
+						@click="signIn"
 					/>
 				</v-list>
 			</v-menu>
@@ -207,6 +214,11 @@ const stopLevelUrlWatcher = watch(
 // Navigation functions
 const signOut = () => {
 	window.location.href = '/oauth2/sign_out'
+}
+
+const signIn = () => {
+	const rd = encodeURIComponent(window.location.pathname + window.location.search)
+	window.location.href = `/oauth2/start?rd=${rd || '%2F'}`
 }
 
 const smartReset = async () => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -72,13 +72,13 @@
 						@click="smartReset"
 					/>
 					<v-list-item
-						v-if="userStore.isAuthenticated"
+						v-if="userStore.initialized && userStore.isAuthenticated"
 						prepend-icon="mdi-logout"
 						title="Sign out"
 						@click="signOut"
 					/>
 					<v-list-item
-						v-else
+						v-else-if="userStore.initialized"
 						prepend-icon="mdi-login"
 						title="Sign in"
 						@click="signIn"

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -6,6 +6,7 @@ interface UserState {
 	domain: string | null
 	isAuthenticated: boolean
 	initialized: boolean
+	nonJsonWarningEmitted: boolean
 }
 
 const COMPANY_DOMAIN = 'forumvirium.fi'
@@ -16,6 +17,7 @@ export const useUserStore = defineStore('user', {
 		domain: null,
 		isAuthenticated: false,
 		initialized: false,
+		nonJsonWarningEmitted: false,
 	}),
 
 	getters: {
@@ -37,7 +39,24 @@ export const useUserStore = defineStore('user', {
 						'OAuth2 userinfo not available (status %d), using anonymous context',
 						response.status
 					)
-					this.initialized = true
+					return
+				}
+
+				// Guard against the SPA's nginx catch-all returning index.html with a
+				// 200 OK when no /oauth2/* route is configured upstream. Without this
+				// check, response.json() throws a SyntaxError that the bare catch
+				// below would swallow, leaving every visitor reported as anonymous
+				// and the misconfiguration invisible in logs. See issue #799.
+				const contentType = response.headers.get('content-type') ?? ''
+				if (!contentType.toLowerCase().includes('application/json')) {
+					if (!this.nonJsonWarningEmitted) {
+						this.nonJsonWarningEmitted = true
+						logger.warn(
+							'OAuth2 /oauth2/userinfo returned non-JSON response (content-type: %s); ' +
+								'the OIDC proxy is likely not in front of the app. Treating user as anonymous.',
+							contentType || '(missing)'
+						)
+					}
 					return
 				}
 

--- a/tests/unit/stores/userStore.test.ts
+++ b/tests/unit/stores/userStore.test.ts
@@ -1,0 +1,107 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useUserStore } from '@/stores/userStore'
+
+type FetchMock = ReturnType<typeof vi.fn>
+
+const mockResponse = (
+	body: string,
+	{ status = 200, contentType = 'application/json' }: { status?: number; contentType?: string } = {}
+) =>
+	new Response(body, {
+		status,
+		headers: { 'content-type': contentType },
+	})
+
+describe('userStore.fetchUserInfo', () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		setActivePinia(createPinia())
+		warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+		;(global.fetch as FetchMock).mockReset()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('parses authenticated user from JSON 200', async () => {
+		;(global.fetch as FetchMock).mockResolvedValueOnce(
+			mockResponse(JSON.stringify({ email: 'lauri.gates@forumvirium.fi' }))
+		)
+
+		const store = useUserStore()
+		await store.fetchUserInfo()
+
+		expect(store.isAuthenticated).toBe(true)
+		expect(store.email).toBe('lauri.gates@forumvirium.fi')
+		expect(store.domain).toBe('forumvirium.fi')
+		expect(store.initialized).toBe(true)
+	})
+
+	it('treats non-2xx response as anonymous without warning', async () => {
+		;(global.fetch as FetchMock).mockResolvedValueOnce(mockResponse('', { status: 401 }))
+
+		const store = useUserStore()
+		await store.fetchUserInfo()
+
+		expect(store.isAuthenticated).toBe(false)
+		expect(store.email).toBeNull()
+		expect(store.initialized).toBe(true)
+		expect(warnSpy).not.toHaveBeenCalled()
+	})
+
+	// Regression: production R4C hosts return 200 OK with index.html when the
+	// OIDC proxy isn't in front of the SPA. The old implementation called
+	// response.json() unconditionally and swallowed the SyntaxError in a bare
+	// catch{}, leaving the failure invisible. See issue #799.
+	it('treats 200 text/html response as anonymous and warns once', async () => {
+		;(global.fetch as FetchMock).mockResolvedValueOnce(
+			mockResponse('<!doctype html><html></html>', { contentType: 'text/html' })
+		)
+
+		const store = useUserStore()
+		await store.fetchUserInfo()
+
+		expect(store.isAuthenticated).toBe(false)
+		expect(store.email).toBeNull()
+		expect(store.domain).toBeNull()
+		expect(store.initialized).toBe(true)
+		expect(warnSpy).toHaveBeenCalledTimes(1)
+		expect(warnSpy.mock.calls[0].join(' ')).toMatch(/oauth2.*userinfo/i)
+	})
+
+	it('treats 200 with missing content-type as anonymous and warns', async () => {
+		;(global.fetch as FetchMock).mockResolvedValueOnce(
+			new Response('not json', { status: 200, headers: {} })
+		)
+
+		const store = useUserStore()
+		await store.fetchUserInfo()
+
+		expect(store.isAuthenticated).toBe(false)
+		expect(warnSpy).toHaveBeenCalledTimes(1)
+	})
+
+	it('only warns once across repeated non-JSON 200 responses', async () => {
+		;(global.fetch as FetchMock)
+			.mockResolvedValueOnce(mockResponse('<html></html>', { contentType: 'text/html' }))
+			.mockResolvedValueOnce(mockResponse('<html></html>', { contentType: 'text/html' }))
+
+		const store = useUserStore()
+		await store.fetchUserInfo()
+		await store.fetchUserInfo()
+
+		expect(warnSpy).toHaveBeenCalledTimes(1)
+	})
+
+	it('handles fetch network error without throwing', async () => {
+		;(global.fetch as FetchMock).mockRejectedValueOnce(new TypeError('network'))
+
+		const store = useUserStore()
+		await expect(store.fetchUserInfo()).resolves.toBeUndefined()
+		expect(store.isAuthenticated).toBe(false)
+		expect(store.initialized).toBe(true)
+	})
+})


### PR DESCRIPTION
## Summary

Closes the two compounding client-side bugs in #799 that caused every R4C visitor — including anonymous users — to see a non-functional Sign Out button.

- **`App.vue`** — guard the Sign Out menu item with `v-if="userStore.isAuthenticated"`; add a Sign In affordance for anonymous users that navigates to `/oauth2/start?rd=<current-path>`.
- **`userStore.fetchUserInfo`** — check `content-type` before calling `response.json()`. On a non-JSON 2xx response (the nginx catch-all returning `index.html` when no `/oauth2/*` upstream is configured), log a single `warn` instead of silently swallowing the `SyntaxError` from `response.json()`. Track the "warned once" flag on the store so the singleton lifetime governs it in production while Pinia reset gives clean per-test state.

## Why it matters

The silent swallow left `userStore.isAuthenticated === false` for every user, which meant `userStore.domain` never got set and every email-domain-targeted GOFF flag (`r4c-vtt-flood-simulation`, `r4c-flood-layers`, `r4c-hdr-rendering`, `r4c-ambient-occlusion`, `r4c-request-render-mode`, `r4c-predictive-prefetch`, `r4c-loading-performance-info`, `r4c-background-preload`, `r4c-show-feature-panel`) could only ever apply its `defaultRule` in production. After this change, the misconfiguration is loud in logs and the UI doesn't lie about sign-in state.

## Out of scope

Restoring OIDC end-to-end on the production hosts requires infrastructure work — see ForumViriumHelsinki/infrastructure#1844 (r4c.dataportal.fi SecurityPolicy) and ForumViriumHelsinki/infrastructure#1845 (r4c-beta.dataportal.fi OIDC provisioning).

## Test plan

- [x] New `tests/unit/stores/userStore.test.ts` covers: JSON 200 happy path, 401 anonymous fallback (no warn), 200 `text/html` (warn once, anonymous), 200 missing `content-type` (warn once, anonymous), repeated non-JSON 200 still warns only once, network error (initialized=true, anonymous).
- [x] `bun run test:unit` — 788 passed / 4 skipped.
- [x] `bun run lint` — clean.
- [ ] Manual verification on `r4c-beta.dataportal.fi`: confirm `Sign In` shows (not `Sign Out`) for anonymous browser; `[WARN] OAuth2 /oauth2/userinfo returned non-JSON response (content-type: text/html); the OIDC proxy is likely not in front of the app.` appears once in console.
- [ ] Once infra#1844 lands, confirm `Sign Out` renders for authenticated users and `/oauth2/sign_out` click clears the session.

Fixes #799
