### PR TITLE
test(a11y): remove dead Vuetify v3 .v-btn--selected fallback (#140)

### DIFF
--- a/tests/e2e/accessibility/view-modes.spec.ts
+++ b/tests/e2e/accessibility/view-modes.spec.ts
@@ -30,7 +30,7 @@ function getViewModeButton(
  */
 async function isViewModeButtonSelected(button: Locator): Promise<boolean> {
 	const className = await button.getAttribute('class').catch(() => '')
-	return className?.includes('v-btn--active') || className?.includes('v-btn--selected') || false
+	return className?.includes('v-btn--active') || false
 }
 
 cesiumDescribe('View Modes Accessibility', () => {

--- a/tests/e2e/helpers/test-helpers.ts
+++ b/tests/e2e/helpers/test-helpers.ts
@@ -924,7 +924,6 @@ export class AccessibilityTestHelpers {
 					// Strategy 1: Check v-btn--active class on button
 					const button = document.querySelector(`.view-toggle-group button[value="${targetMode}"]`)
 					if (button?.classList.contains('v-btn--active')) return true
-					if (button?.classList.contains('v-btn--selected')) return true
 
 					// Strategy 2: Check aria-pressed attribute
 					if (button?.getAttribute('aria-pressed') === 'true') return true


### PR DESCRIPTION
## Summary

The `.v-btn--selected` class is Vuetify v3-era. This project is on Vuetify 4 (per `.claude/rules/architecture.md`), which uses `.v-btn--active`. Two places carried a now-dead OR fallback against `.v-btn--selected`:

- `tests/e2e/helpers/test-helpers.ts:925` — Strategy 1 of `verifyViewModeSelection`, redundant fallback `classList.contains('v-btn--selected')`
- `tests/e2e/accessibility/view-modes.spec.ts:33` — `isViewModeButtonSelected` OR-chain

Both fallbacks would never match in a Vuetify 4 codebase; their only effect was masking what the real assertion is.

## Verification

- `rg --no-heading 'v-btn--selected'` → no remaining hits
- Other v3-era selectors checked (`.v-btn--depressed`, `.theme--light/dark`, `.v-list-item--link`, `.v-application--wrap`, `.v-toolbar__title`) → no matches in repo
- `.v-application` survives in v4 (kept untouched)

## Test plan

- [x] Pre-commit hooks (biome, prettier, conventional commit) pass
- [ ] CI a11y suite stays green

Refs taskwarrior #140 (originated from PR #758 review feedback about Vuetify 4 migration cleanup).