### PR TITLE
fix(feature-flags): catch GOFF object-shape rejections (#794)

### DIFF
--- a/src/services/featureFlagProvider.ts
+++ b/src/services/featureFlagProvider.ts
@@ -210,11 +210,11 @@ function describeGoffReason(reason: unknown): string {
  * synchronous failure path, then fires `retryFetchAll()` and
  * `reconnectWebsocket()` **without awaiting** — those returned promises can
  * reject silently and surface as unhandled rejections (Sentry
- * R4C-CESIUM-VIEWER-1Z, #735).
+ * R4C-CESIUM-VIEWER-1Z, #735; R4C-CESIUM-VIEWER-21, #794).
  */
-function isGoffWebsocketRejection(reason: unknown): boolean {
+export function isGoffRejection(reason: unknown): boolean {
 	const message = describeGoffReason(reason)
-	// Two GOFF-specific rejection shapes we want to handle, narrowed so we
+	// Three GOFF-specific rejection shapes we want to handle, narrowed so we
 	// don't accidentally swallow unrelated rejections from Cesium Ion, Sentry
 	// replays, or other websocket-using subsystems:
 	//
@@ -229,6 +229,19 @@ function isGoffWebsocketRejection(reason: unknown): boolean {
 	//      enough that we only catch the GOFF retry loop in practice. Pair
 	//      with a stack-trace check on Error instances so we don't catch
 	//      unrelated URL TypeErrors thrown elsewhere on the page.
+	//   C) HTTP-error-shaped object rejections — `{response, responseHeaders,
+	//      statusCode}`. GOFF's data-collector and fetch paths reject the
+	//      background retry promise with an axios-style plain object (no
+	//      `.message`, no stack), which slips past the string checks above
+	//      and surfaces as `UnhandledRejection: Object captured as promise
+	//      rejection with keys: response, responseHeaders, statusCode`
+	//      (Sentry R4C-CESIUM-VIEWER-21, #794). Fires reliably on `vite
+	//      preview` because vite.config.js' `/feature-flags` proxy lives
+	//      under `server.proxy` only — `preview.proxy` is absent, so the
+	//      health check returns the SPA's 404 HTML and GOFF rejects. The
+	//      three-key fingerprint is specific enough to avoid swallowing
+	//      unrelated HTTP-shaped rejections (Cesium fetchJson rejects with
+	//      its own RequestErrorEvent shape, not this triple).
 	if (
 		/websocket/i.test(message) &&
 		/go-?feature-?flag|GoFeatureFlag|reached when initializing/i.test(message)
@@ -241,6 +254,12 @@ function isGoffWebsocketRejection(reason: unknown): boolean {
 		/go-?feature-?flag|GoFeatureFlag/i.test(reason.stack ?? '')
 	) {
 		return true
+	}
+	if (typeof reason === 'object' && reason !== null) {
+		const r = reason as Record<string, unknown>
+		if ('response' in r && 'responseHeaders' in r && 'statusCode' in r) {
+			return true
+		}
 	}
 	return false
 }
@@ -258,15 +277,15 @@ function installGoffRejectionHandler(): void {
 	}
 	goffRejectionHandlerInstalled = true
 	window.addEventListener('unhandledrejection', (event) => {
-		if (!isGoffWebsocketRejection(event.reason)) {
+		if (!isGoffRejection(event.reason)) {
 			return
 		}
 		const message = describeGoffReason(event.reason)
-		logger.warn('Feature flags: GOFF websocket reconnect failed (handled)', message)
+		logger.warn('Feature flags: GOFF background rejection (handled)', message)
 		Sentry.addBreadcrumb({
 			category: 'feature-flags',
 			level: 'warning',
-			message: 'GOFF websocket reconnect failed',
+			message: 'GOFF background rejection',
 			data: { reason: message },
 		})
 		event.preventDefault()

--- a/src/services/featureFlagProvider.ts
+++ b/src/services/featureFlagProvider.ts
@@ -238,10 +238,15 @@ export function isGoffRejection(reason: unknown): boolean {
 	//      (Sentry R4C-CESIUM-VIEWER-21, #794). Fires reliably on `vite
 	//      preview` because vite.config.js' `/feature-flags` proxy lives
 	//      under `server.proxy` only — `preview.proxy` is absent, so the
-	//      health check returns the SPA's 404 HTML and GOFF rejects. The
-	//      three-key fingerprint is specific enough to avoid swallowing
-	//      unrelated HTTP-shaped rejections (Cesium fetchJson rejects with
-	//      its own RequestErrorEvent shape, not this triple).
+	//      health check returns the SPA's 404 HTML and GOFF rejects.
+	//
+	//      Restricted to **plain** objects (`constructor === Object` or no
+	//      prototype) because Cesium's `RequestErrorEvent` is a function-
+	//      constructor instance with the EXACT same three keys
+	//      (`statusCode`, `response`, `responseHeaders` — see
+	//      `@cesium/engine/Source/Core/RequestErrorEvent.js`). Without the
+	//      plain-object guard we would silently swallow every Cesium tile /
+	//      terrain / imagery network error.
 	if (
 		/websocket/i.test(message) &&
 		/go-?feature-?flag|GoFeatureFlag|reached when initializing/i.test(message)
@@ -255,7 +260,11 @@ export function isGoffRejection(reason: unknown): boolean {
 	) {
 		return true
 	}
-	if (typeof reason === 'object' && reason !== null) {
+	if (
+		typeof reason === 'object' &&
+		reason !== null &&
+		(reason.constructor === Object || reason.constructor === undefined)
+	) {
 		const r = reason as Record<string, unknown>
 		if ('response' in r && 'responseHeaders' in r && 'statusCode' in r) {
 			return true

--- a/tests/unit/services/featureFlagProvider.test.ts
+++ b/tests/unit/services/featureFlagProvider.test.ts
@@ -249,5 +249,40 @@ describe('featureFlagProvider — isGoffRejection (#794)', () => {
 		it('returns false for an unrelated object that lacks the three-key fingerprint', () => {
 			expect(isGoffRejection({ message: 'something failed', code: 500 })).toBe(false)
 		})
+
+		it('returns false for a Cesium-style RequestErrorEvent with the same three keys', () => {
+			// Cesium's `RequestErrorEvent`
+			// (`@cesium/engine/Source/Core/RequestErrorEvent.js`) is a
+			// function-constructor instance with `statusCode`, `response`,
+			// and `responseHeaders` — exactly the three keys GOFF's
+			// axios-style rejection uses. Without the `constructor ===
+			// Object` plain-object guard, this fingerprint match would
+			// silently swallow every Cesium tile / terrain / imagery
+			// network error. See PR #805 review.
+			class RequestErrorEvent {
+				statusCode: number
+				response: unknown
+				responseHeaders: unknown
+				constructor(statusCode: number, response: unknown, responseHeaders: unknown) {
+					this.statusCode = statusCode
+					this.response = response
+					this.responseHeaders = responseHeaders
+				}
+			}
+			const cesiumErr = new RequestErrorEvent(404, {}, {})
+			expect(isGoffRejection(cesiumErr)).toBe(false)
+		})
+
+		it('returns true for a null-prototype object with the three-key fingerprint', () => {
+			// `Object.create(null)` has `constructor === undefined` and
+			// is also a plain dictionary — we accept it because GOFF
+			// could plausibly construct rejections this way and there's
+			// no risk of misidentifying a Cesium class instance.
+			const o = Object.create(null) as Record<string, unknown>
+			o.response = {}
+			o.responseHeaders = {}
+			o.statusCode = 404
+			expect(isGoffRejection(o)).toBe(true)
+		})
 	})
 })

--- a/tests/unit/services/featureFlagProvider.test.ts
+++ b/tests/unit/services/featureFlagProvider.test.ts
@@ -66,7 +66,7 @@ vi.mock('@openfeature/web-sdk', async () => {
 	}
 })
 
-import { isValidGoffEndpoint } from '@/services/featureFlagProvider'
+import { isGoffRejection, isValidGoffEndpoint } from '@/services/featureFlagProvider'
 
 describe('featureFlagProvider — isValidGoffEndpoint (#738)', () => {
 	let warnSpy: ReturnType<typeof vi.spyOn>
@@ -161,5 +161,93 @@ describe('featureFlagProvider — isValidGoffEndpoint (#738)', () => {
 				expect(isValidGoffEndpoint(value)).toBe(expected)
 			})
 		}
+	})
+})
+
+describe('featureFlagProvider — isGoffRejection (#794)', () => {
+	describe('matches GOFF object-shape rejections (the #794 regression)', () => {
+		it('returns true for a plain {response, responseHeaders, statusCode} object', () => {
+			// This is the exact rejection shape that bubbled past the
+			// pre-#794 string-only filter and surfaced as Sentry
+			// R4C-CESIUM-VIEWER-21: "UnhandledRejection: Object captured
+			// as promise rejection with keys: response, responseHeaders,
+			// statusCode".
+			expect(
+				isGoffRejection({
+					response: {},
+					responseHeaders: {},
+					statusCode: 404,
+				})
+			).toBe(true)
+		})
+
+		it('returns true even when the property values are non-empty', () => {
+			expect(
+				isGoffRejection({
+					response: { errorCode: 'WRONG_ENDPOINT' },
+					responseHeaders: { 'content-type': 'text/html' },
+					statusCode: 404,
+				})
+			).toBe(true)
+		})
+
+		it('returns false when only two of the three keys are present', () => {
+			// Narrowness check: the three-key fingerprint is specifically
+			// what distinguishes GOFF's axios-style rejection from other
+			// HTTP-shaped objects. Two-of-three should NOT match.
+			expect(isGoffRejection({ response: {}, statusCode: 500 })).toBe(false)
+			expect(isGoffRejection({ responseHeaders: {}, statusCode: 500 })).toBe(false)
+			expect(isGoffRejection({ response: {}, responseHeaders: {} })).toBe(false)
+		})
+	})
+
+	describe('regression coverage for existing string-match cases (#735, #738)', () => {
+		it('returns true for a websocket-init Error message', () => {
+			const err = new Error('timeout of 5000 ms reached when initializing the websocket')
+			expect(isGoffRejection(err)).toBe(true)
+		})
+
+		it('returns true for a bare websocket-init string rejection', () => {
+			expect(
+				isGoffRejection('timeout reached when initializing websocket for go-feature-flag')
+			).toBe(true)
+		})
+
+		it('returns true for a TypeError with GoFeatureFlag in the stack (#738)', () => {
+			const err = new TypeError("Failed to construct 'URL': Invalid URL")
+			// Synthesize a stack frame that points at the GOFF library.
+			err.stack =
+				"TypeError: Failed to construct 'URL': Invalid URL\n" +
+				'    at GoFeatureFlagWebProvider.retryFetchAll (go-feature-flag-web-provider/dist/index.esm.js:1:1)'
+			expect(isGoffRejection(err)).toBe(true)
+		})
+	})
+
+	describe('does not match unrelated rejections', () => {
+		it('returns false for a generic Error with no GOFF fingerprint', () => {
+			expect(isGoffRejection(new Error('Cesium WebGL context lost'))).toBe(false)
+		})
+
+		it('returns false for a TypeError whose stack is not GOFF', () => {
+			const err = new TypeError("Failed to construct 'URL': Invalid URL")
+			err.stack =
+				"TypeError: Failed to construct 'URL': Invalid URL\n" +
+				'    at SomeOtherLibrary.doThing (some-other-lib/index.js:42:7)'
+			expect(isGoffRejection(err)).toBe(false)
+		})
+
+		it('returns false for null and undefined', () => {
+			expect(isGoffRejection(null)).toBe(false)
+			expect(isGoffRejection(undefined)).toBe(false)
+		})
+
+		it('returns false for primitive non-string rejections', () => {
+			expect(isGoffRejection(404)).toBe(false)
+			expect(isGoffRejection(true)).toBe(false)
+		})
+
+		it('returns false for an unrelated object that lacks the three-key fingerprint', () => {
+			expect(isGoffRejection({ message: 'something failed', code: 500 })).toBe(false)
+		})
 	})
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -331,5 +331,19 @@ export default defineConfig(({ mode }) => {
 				},
 			},
 		},
+		// Mirror /feature-flags onto `vite preview` so the GOFF health check
+		// doesn't 404 against the SPA catch-all and reject with a
+		// {response, responseHeaders, statusCode} object (#794). Without this
+		// block, `bun run preview` against a production-tagged build fires
+		// Sentry R4C-CESIUM-VIEWER-21 on every load.
+		preview: {
+			proxy: {
+				'/feature-flags': {
+					target: 'http://localhost:1031',
+					changeOrigin: true,
+					rewrite: (path) => path.replace(/^\/feature-flags/, ''),
+				},
+			},
+		},
 	};
 });


### PR DESCRIPTION
## Summary

Sentry **R4C-CESIUM-VIEWER-21** (#794) fired on every `vite preview` page load because `isGoffWebsocketRejection` in `src/services/featureFlagProvider.ts` only matched string-based rejection reasons. The GOFF library's background `fetchAll`/data-collector path rejects with a plain `{response, responseHeaders, statusCode}` object — no `.message`, no stack — which slipped through the filter and bubbled to `window.onunhandledrejection`.

## Changes

- **`src/services/featureFlagProvider.ts`** — rename `isGoffWebsocketRejection` → `isGoffRejection` (it's no longer websocket-only) and add a third branch matching the three-key object fingerprint. Round 2: guard the object-shape branch with a `constructor === Object || constructor === undefined` plain-object check so Cesium's `RequestErrorEvent` (a function-constructor class instance with the exact same three keys) does NOT match.
- **`tests/unit/services/featureFlagProvider.test.ts`** — 13 new tests covering: positive object-shape match, narrowness checks (2-of-3 keys must NOT match), regression coverage for existing string-match cases, and negative cases (Cesium `RequestErrorEvent`-style class instances, unrelated TypeErrors, null, primitives, null-prototype dicts).
- **`vite.config.js`** — add `preview.proxy['/feature-flags']` mirroring the existing `server.proxy['/feature-flags']`. Without this, `bun run preview` against a production-tagged build 404s on the GOFF health check (the SPA catch-all swallows it) and fires the same rejection path on every load.

## Verification

- 30/30 unit tests pass (`bunx vitest run tests/unit/services/featureFlagProvider.test.ts`)
- Biome + prettier + conventional commit hooks all green

## Test plan

- [x] Unit tests cover both the new object-shape and existing string-match paths
- [x] Cesium `RequestErrorEvent` collision explicitly tested (does NOT match)
- [ ] Sentry R4C-CESIUM-VIEWER-21 stops firing on next preview deployment

Closes #794.

---

## Round 2 — review feedback

Per gemini-code-assist review on the initial push:

1. **Cesium RequestErrorEvent collision** — verified in `node_modules/@cesium/engine/Source/Core/RequestErrorEvent.js` that Cesium's `RequestErrorEvent` is a function-constructor instance with exactly `statusCode`, `response`, `responseHeaders`. Without the guard, the object-shape branch would have silently swallowed every Cesium tile/terrain/imagery network error. Applied the suggested `constructor === Object || constructor === undefined` plain-object guard and expanded the inline comment to document the collision rationale.
2. **Regression tests** — added two new cases: a Cesium-style class instance with the three keys (asserts NOT matched), and an `Object.create(null)` dictionary with the three keys (asserts IS matched, covering the second leg of the guard).

CI failures on the initial push (Lighthouse, `Accessibility Tests (desktop)`) are pre-existing flakes unrelated to feature-flag-provider changes. All other gates (Unit Tests, Typecheck, Lint, Build, Integration Tests, Security Scan) remain green.
