### PR TITLE
test: document camera-controls accessibility testing strategy (#623)

### DIFF
--- a/docs/core/TESTING.md
+++ b/docs/core/TESTING.md
@@ -230,6 +230,95 @@ npm run test:accessibility                   # Desktop only (recommended)
 npm run test:accessibility:all-viewports     # Desktop + tablet + mobile
 ```
 
+### 3b. Cesium UI Component Accessibility Testing Strategy
+
+This section records the testing strategy for the `CameraControls.vue` component
+(compass + zoom controls) and, more generally, for **Vue/SVG/DOM components that
+sit on top of the Cesium canvas**. It was written to resolve [#623] after
+discovering that the original skip rationale for
+`tests/e2e/accessibility/camera-controls.spec.ts` was a misdiagnosis.
+
+#### What `CameraControls.vue` actually is
+
+`CameraControls.vue` is a **pure Vue 3 + SVG + DOM component**. It is **not** a
+Cesium internal compass widget rendered into the WebGL canvas. Concretely:
+
+- It is mounted unconditionally as `<CameraControls />` in
+  `src/pages/CesiumViewer.vue` and renders independently of the WebGL context.
+- Its markup is plain HTML/SVG: a `.camera-controls-container` wrapper containing
+  a `.compass-assembly` (`role="group"`, `aria-label="Camera direction controls"`)
+  with a `.compass-visual` SVG (`.compass-ring` + `.compass-needle`), real
+  `<button class="dir-btn">` directional buttons, a `.zoom-controls` group
+  (`role="group"`, `aria-label="Zoom controls"`) with `.zoom-btn` buttons, and an
+  `sr-only` `role="status" aria-live="polite"` element announcing the heading.
+- Because it is regular DOM, **it renders in a headless CI browser without a full
+  WebGL context.** The only thing that requires a live Cesium camera is the
+  _reactive heading_ (the `compassRingStyle` rotation and the `sr-only` heading
+  text update after a real camera move).
+
+#### Why the suite was skipped (the real root cause)
+
+The suite was disabled with `cesiumDescribe.skip(...)` and a comment claiming the
+"Cesium compass control does not render in headless CI ... without a full WebGL
+context." That premise is **factually wrong**. The real cause is a
+**selector mismatch**:
+
+- The 37 tests query `.compass-control` and `#compass-description`.
+- **Neither selector exists anywhere in `src/`.** The component uses
+  `.camera-controls-container` / `.compass-assembly` / `.compass-visual` /
+  `.compass-ring` / `.compass-needle` / `.dir-btn` / `.zoom-btn` and has no
+  `#compass-description` id.
+
+The elements were never absent because of WebGL — the locators simply never
+matched the rendered DOM, so every `toBeVisible()` timed out and the suite was
+skipped after the failures were misattributed to Cesium.
+
+#### Chosen strategy: hybrid (DOM-only vs Cesium-coupled split)
+
+Split the assertions by what they actually depend on. This is the issue's
+recommended hybrid approach, corrected for the real root cause.
+
+| Assertion category                                       | Depends on Cesium? | How to test                                                                                        | Fixture                                        |
+| -------------------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| ARIA roles/labels on the compass + zoom groups           | No                 | Standard Playwright E2E (DOM query)                                                                | `cesiumTest` (component still mounts under it) |
+| `sr-only` `role="status"` element **presence**           | No                 | DOM `toBeAttached()`                                                                               | `cesiumTest`                                   |
+| Directional / zoom button presence + accessible names    | No                 | `getByRole('button', { name: ... })`                                                               | `cesiumTest`                                   |
+| Keyboard focusability, tab order, `tabindex`             | No                 | Playwright keyboard + focus assertions                                                             | `cesiumTest`                                   |
+| Click handlers wired (heading/zoom intent)               | No                 | Assert via store / `cameraService` effect                                                          | `cesiumTest`                                   |
+| `compassRingStyle` rotation updating after a camera move | **Yes**            | Drive `window.__viewer` camera, then assert the `sr-only` heading text / `.compass-ring` transform | `cesiumTest` + `window.__viewer`               |
+| `sr-only` heading **text** reflecting live heading       | **Yes**            | Same as above                                                                                      | `cesiumTest` + `window.__viewer`               |
+
+Key consequences:
+
+- The **DOM-only** assertions (the large majority) can run as ordinary Playwright
+  E2E once the selectors are corrected to the real class names above. They do not
+  need a live WebGL camera — only a mounted component.
+- The **Cesium-coupled** subset (live heading reactivity) is the genuinely
+  Cesium-dependent part. Drive it via the documented E2E globals
+  (`window.__viewer`, `window.__cesium`; see "Cesium & Store Global Variables" in
+  `.claude/rules/testing.md`) rather than depending on real polygon picks, and
+  tag it so it can be skipped where a live camera is unavailable.
+
+#### Re-enablement plan (deferred follow-up)
+
+The suite stays `cesiumDescribe.skip(...)` in the PR that landed this strategy —
+re-enabling it is a larger change that touches every test and risks landing flaky
+specs unreviewed. The follow-up work:
+
+1. Replace `.compass-control` / `#compass-description` selectors across all 37
+   tests with the real selectors
+   (`.camera-controls-container` / `.compass-assembly` / `.compass-ring` /
+   `.compass-needle` / `.dir-btn` / `.zoom-btn` / the `sr-only` status element).
+2. Audit each test against live `CameraControls.vue` behaviour, splitting it into
+   the DOM-only vs Cesium-coupled categories above.
+3. Tag the Cesium-heading-coupled subset and drive it through `window.__viewer`.
+4. Remove the `cesiumDescribe.skip` once the suite is green.
+
+This re-enablement should be filed as a sub-issue of [#472].
+
+[#623]: https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/623
+[#472]: https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/472
+
 ### 4. Performance Tests (`tests/performance/`)
 
 Measure and validate application performance characteristics.

--- a/tests/e2e/accessibility/camera-controls.spec.ts
+++ b/tests/e2e/accessibility/camera-controls.spec.ts
@@ -16,10 +16,29 @@ import { TIMEOUTS, VIEWPORTS } from '../../config/constants'
 import { cesiumDescribe, cesiumTest } from '../../fixtures/cesium-fixture'
 import AccessibilityTestHelpers, { TEST_TIMEOUTS } from '../helpers/test-helpers'
 
-// SKIPPED: Cesium compass control does not render in headless CI environment
-// The .compass-control element is not visible because Cesium's internal UI components
-// don't render properly without a full WebGL context
-// Related: https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/472
+// SKIPPED: selector mismatch, NOT a WebGL/headless-CI limitation.
+//
+// CameraControls.vue is a pure Vue + SVG + DOM component (mounted unconditionally
+// in src/pages/CesiumViewer.vue), not a Cesium internal compass widget rendered
+// into the WebGL canvas. It renders in headless CI without a full WebGL context.
+//
+// These tests query `.compass-control` and `#compass-description`, but NEITHER
+// selector exists in src/. The real component uses `.camera-controls-container`,
+// `.compass-assembly`, `.compass-ring`, `.compass-needle`, `.dir-btn`, `.zoom-btn`
+// and an `sr-only` role="status" element. So every assertion timed out because the
+// locators never matched — the elements were never absent due to WebGL.
+//
+// Most assertions here (ARIA roles/labels, button presence + accessible names,
+// keyboard focusability, sr-only status presence) are DOM-only and CAN run once
+// the selectors are fixed. Only live heading reactivity (compassRingStyle rotation
+// / sr-only heading text after a real camera move) is genuinely Cesium-coupled and
+// should be driven via window.__viewer and tagged accordingly.
+//
+// Strategy + re-enablement plan: docs/core/TESTING.md → "Cesium UI Component
+// Accessibility Testing Strategy". Re-enablement is a deferred follow-up
+// (sub-issue of #472) because it touches all 37 tests.
+// Related: https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/623
+//          https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/472
 cesiumDescribe.skip('Camera Controls Accessibility', () => {
 	cesiumTest.use({ tag: ['@accessibility', '@e2e'] })
 	let helpers: AccessibilityTestHelpers


### PR DESCRIPTION
## Summary

Issue #623 asks for a documented testing strategy for the Cesium camera controls. Triage revealed the issue's stated root cause is factually wrong, so this PR lands the requested strategy grounded in the corrected diagnosis.

**Corrected root cause:** `src/components/CameraControls.vue` is a pure Vue 3 + SVG + DOM component, mounted unconditionally as `<CameraControls />` in `src/pages/CesiumViewer.vue`. It is **not** a Cesium internal compass widget rendered into the WebGL canvas, and it renders in headless CI without a full WebGL context. The `camera-controls.spec.ts` suite was skipped with a comment blaming WebGL/headless CI, but the real cause is a **selector mismatch**: the 37 tests query `.compass-control` and `#compass-description`, neither of which exists anywhere in `src/`. The component uses `.camera-controls-container`, `.compass-assembly`, `.compass-ring`, `.compass-needle`, `.dir-btn`, `.zoom-btn`, and an `sr-only` `role="status"` element.

## Changes

- **`docs/core/TESTING.md`** — new "Cesium UI Component Accessibility Testing Strategy" section (§3b) recording: what `CameraControls.vue` actually is, the real skip cause, the chosen **hybrid** strategy (DOM-only assertions — ARIA roles/labels, button presence + accessible names, keyboard focusability, `sr-only` status presence — run as standard Playwright E2E once selectors are fixed; live heading reactivity is the only genuinely Cesium-coupled subset, driven via `window.__viewer`), and the deferred re-enablement plan.
- **`tests/e2e/accessibility/camera-controls.spec.ts`** — corrected the misleading skip-rationale comment to state the real cause (selector mismatch, not WebGL) and link the strategy doc.

No production code changes. The suite stays `cesiumDescribe.skip(...)` in this PR so no flaky tests land unreviewed.

## Verification

- `biome@2.3.9 check tests/e2e/accessibility/camera-controls.spec.ts` → exit 0 (clean).
- Pre-commit hooks ran on commit: biome, prettier (reformatted `TESTING.md`, re-staged), conventional-commit, trailing-whitespace, EOF, private-key, merge-conflict — all passed.
- `node_modules` was absent in the fresh worktree; biome was run via `bunx @biomejs/biome@2.3.9` rather than a full `bun install`. The full Playwright/Vitest suites were not run (the change is documentation + a comment-only edit with no code-logic change, and the suite remains intentionally skipped).

## Deferred

Re-enabling the suite is **out of scope** for this PR because it touches all 37 tests and risks landing flaky specs unreviewed. The follow-up (recommended as a sub-issue of #472):

1. Replace `.compass-control` / `#compass-description` selectors across all 37 tests with the real selectors.
2. Audit each test against live `CameraControls.vue` behaviour, splitting DOM-only vs Cesium-coupled.
3. Tag the Cesium-heading-coupled subset and drive it via `window.__viewer`.
4. Remove the `cesiumDescribe.skip` once green.

Closes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)
