### PR TITLE
fix(loading): only clear genuinely-stale layers, not all dynamic tile IDs (#680)

### DIFF
--- a/src/stores/loadingStore.js
+++ b/src/stores/loadingStore.js
@@ -290,8 +290,17 @@ export const useLoadingStore = defineStore('loading', {
 			Object.keys(this.layerLoading).forEach((layer) => {
 				if (!this.layerLoading[layer]) return // Skip layers not currently loading
 
-				const loadTime = this.loadingTimes[layer]
-				const isStale = loadTime && now - loadTime.startTime > effectiveTimeout
+				// Defensive: if a layer is flagged loading but has no recorded
+				// loadTime (inconsistent state — e.g. started without initializing
+				// loadingTimes), stamp it now. This prevents a stuck-forever loading
+				// state: it won't be cleared this tick (avoids cutting a fresh load
+				// short) but will be cleared once effectiveTimeout elapses.
+				let loadTime = this.loadingTimes[layer]
+				if (!loadTime) {
+					loadTime = { startTime: now }
+					this.loadingTimes[layer] = loadTime
+				}
+				const isStale = now - loadTime.startTime > effectiveTimeout
 
 				// Clear only when genuinely stale — a time-based safety net, not a
 				// blanket sweep of every dynamic layer ID.

--- a/src/stores/loadingStore.js
+++ b/src/stores/loadingStore.js
@@ -231,7 +231,14 @@ export const useLoadingStore = defineStore('loading', {
 		// Set error for a layer
 		setLayerError(layerName, error) {
 			this.layerLoading[layerName] = false
-			this.loadingProgress[layerName].status = 'error'
+
+			// Guard the progress dereference — a layer may have no progress entry
+			// (e.g. cancelLoading() on a layer whose progress was never created).
+			// The error path must never itself throw and orphan the loading state.
+			if (this.loadingProgress[layerName]) {
+				this.loadingProgress[layerName].status = 'error'
+			}
+
 			this.loadingErrors[layerName] = error
 			this.loadingMessages[layerName] = `Error loading ${layerName}: ${error}`
 
@@ -255,12 +262,17 @@ export const useLoadingStore = defineStore('loading', {
 		},
 
 		/**
-		 * Clear stale loading states that have been loading for longer than the timeout.
-		 * Also removes dynamic layer IDs (not in predefined list) that are still loading.
+		 * Clear loading states that have genuinely been loading longer than the timeout.
 		 * This prevents the loading indicator from getting stuck due to:
 		 * - Network timeouts not properly completing layer loading
-		 * - Dynamic layer IDs (e.g., 'buildings-00100') that failed silently
 		 * - Race conditions in navigation where layer loading was interrupted
+		 *
+		 * The staleness check is purely time-based and applies equally to predefined
+		 * layers and dynamic layer IDs (e.g., viewport tile IDs). A layer being dynamic
+		 * is NOT evidence that it is stuck — viewport tiles legitimately stay in-flight
+		 * while queued behind CONCURRENT_TILE_LOADS and rate-limited at the gateway.
+		 * Clearing them solely for being dynamic prematurely flips genuinely-loading
+		 * tiles to false, producing a warning flood and a UI flicker/race (see #680).
 		 *
 		 * In E2E test mode (VITE_E2E_TEST=true), uses a shorter timeout (5s) to prevent
 		 * test timeouts due to slow network responses in test environments.
@@ -273,18 +285,6 @@ export const useLoadingStore = defineStore('loading', {
 				typeof import.meta !== 'undefined' && import.meta.env?.VITE_E2E_TEST === 'true'
 			const effectiveTimeout = isE2ETest ? Math.min(staleTimeout, 5000) : staleTimeout
 			const now = Date.now()
-			const predefinedLayers = [
-				'trees',
-				'vegetation',
-				'otherNature',
-				'buildings',
-				'postalCodes',
-				'landcover',
-				'ndvi',
-				'populationGrid',
-				'heatData',
-				'statsGrid',
-			]
 			let clearedCount = 0
 
 			Object.keys(this.layerLoading).forEach((layer) => {
@@ -292,13 +292,12 @@ export const useLoadingStore = defineStore('loading', {
 
 				const loadTime = this.loadingTimes[layer]
 				const isStale = loadTime && now - loadTime.startTime > effectiveTimeout
-				const isDynamicLayer = !predefinedLayers.includes(layer)
 
-				// Clear if stale OR if it's a dynamic layer ID (these should be transient)
-				if (isStale || isDynamicLayer) {
+				// Clear only when genuinely stale — a time-based safety net, not a
+				// blanket sweep of every dynamic layer ID.
+				if (isStale) {
 					logger.warn(
-						`[loadingStore] Clearing stale loading state for ${layer}`,
-						isDynamicLayer ? '(dynamic layer)' : `(loading for ${now - loadTime?.startTime}ms)`
+						`[loadingStore] Clearing stale loading state for ${layer} (loading for ${now - loadTime.startTime}ms)`
 					)
 					this.layerLoading[layer] = false
 

--- a/tests/unit/stores/loadingStore.test.js
+++ b/tests/unit/stores/loadingStore.test.js
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment jsdom
+ * @tag @unit
+ */
+
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useLoadingStore } from '@/stores/loadingStore'
+
+describe('loadingStore', () => {
+	let store
+
+	beforeEach(() => {
+		// Fresh pinia instance per test so state never leaks across cases.
+		setActivePinia(createPinia())
+		store = useLoadingStore()
+		vi.clearAllMocks()
+	})
+
+	describe('lifecycle: start then complete', () => {
+		it('clears layerLoading and marks progress completed on success', () => {
+			store.startLayerLoading('buildings')
+			expect(store.layerLoading.buildings).toBe(true)
+			expect(store.loadingProgress.buildings.status).toBe('loading')
+
+			store.completeLayerLoading('buildings', true)
+
+			expect(store.layerLoading.buildings).toBe(false)
+			expect(store.loadingProgress.buildings.status).toBe('completed')
+			expect(store.isLoading).toBe(false)
+		})
+	})
+
+	describe('lifecycle: start then setLayerError', () => {
+		it('clears layerLoading and records the error', () => {
+			store.startLayerLoading('buildings')
+
+			store.setLayerError('buildings', 'boom')
+
+			expect(store.layerLoading.buildings).toBe(false)
+			expect(store.loadingProgress.buildings.status).toBe('error')
+			expect(store.loadingErrors.buildings).toBe('boom')
+			expect(store.isLoading).toBe(false)
+		})
+
+		it('does not throw when the layer has no progress entry', () => {
+			// Mirrors cancelLoading() calling setLayerError on a dynamic layer
+			// whose loadingProgress entry was never created.
+			const dynamicLayer = 'viewport_buildings_hsy_2499_6025'
+			expect(store.loadingProgress[dynamicLayer]).toBeUndefined()
+
+			expect(() => store.setLayerError(dynamicLayer, 'aborted')).not.toThrow()
+
+			expect(store.layerLoading[dynamicLayer]).toBe(false)
+			expect(store.loadingErrors[dynamicLayer]).toBe('aborted')
+		})
+	})
+
+	describe('clearStaleLoading', () => {
+		it('does NOT clear a dynamic layer that started less than the timeout ago (regression for #680)', () => {
+			const dynamicLayer = 'viewport_buildings_hsy_2499_6025'
+			store.startLayerLoading(dynamicLayer)
+			expect(store.layerLoading[dynamicLayer]).toBe(true)
+
+			// Simulate the timer firing while the tile is still legitimately in-flight.
+			const cleared = store.clearStaleLoading(30000)
+
+			expect(cleared).toBe(0)
+			expect(store.layerLoading[dynamicLayer]).toBe(true)
+			expect(store.loadingProgress[dynamicLayer].status).toBe('loading')
+		})
+
+		it('clears any layer (dynamic or predefined) older than the timeout', () => {
+			const dynamicLayer = 'viewport_buildings_hsy_2499_6025'
+			store.startLayerLoading(dynamicLayer)
+			store.startLayerLoading('buildings')
+
+			// Backdate both start times so they exceed the 30s timeout.
+			const longAgo = Date.now() - 60000
+			store.loadingTimes[dynamicLayer].startTime = longAgo
+			store.loadingTimes.buildings.startTime = longAgo
+
+			const cleared = store.clearStaleLoading(30000)
+
+			expect(cleared).toBe(2)
+			expect(store.layerLoading[dynamicLayer]).toBe(false)
+			expect(store.layerLoading.buildings).toBe(false)
+			expect(store.loadingProgress[dynamicLayer].status).toBe('timeout')
+			expect(store.loadingProgress.buildings.status).toBe('timeout')
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Fixes the root cause of the stuck/flickering loading indicators and the 30+ `[loadingStore] Clearing stale loading state for viewport_buildings_hsy_*` warnings on every cold load (confirmed in `docs/blueprint/audits/2026-W19-user-stories.md` C6/US-09).

The reported suspicion (missing `completeLayerLoading()` calls) was **not** the cause — the `unifiedLoader.loadLayer()` lifecycle is balanced. The real bug is in `loadingStore.clearStaleLoading()`:

- The clear condition was `if (isStale || isDynamicLayer)`, where `isDynamicLayer` meant "not in the hardcoded `predefinedLayers` list".
- **Every** viewport tile uses a dynamic `layerId` (`viewport_buildings_${viewPrefix}_${tileKey}`), so the 10s cleanup timer (`App.vue`) flipped *all* viewport tiles to `layerLoading = false` on the next tick — even when they were legitimately still in-flight.
- A viewport needs 30+ tiles but `CONCURRENT_TILE_LOADS` is only 3, and pygeoapi tiles are rate-limited at the Envoy gateway, so queued tiles routinely stay loading longer than a single timer interval (and longer than the stale timeout under 429 backoff) while being entirely healthy. The premature clear produced the warning flood and the documented flicker/race.

## Changes

1. **`clearStaleLoading()`** — clear only when genuinely stale (`if (isStale)`). The staleness check is now purely time-based and applies uniformly to dynamic and predefined layers. The 30s timeout safety net is preserved; being dynamic is no longer treated as evidence of being stuck. Removed the now-unused `predefinedLayers` list.
2. **`setLayerError()`** — guard the `loadingProgress[layerName]` dereference so the error path can never itself throw and orphan the loading state (e.g. `cancelLoading()` on a layer whose progress entry was never created).
3. **`tests/unit/stores/loadingStore.test.js`** (new) — Vitest, `setActivePinia(createPinia())` per `beforeEach`, covering: start→complete clears loading; start→setLayerError clears loading and does not throw on a missing progress entry; `clearStaleLoading` does NOT clear a dynamic layer started < timeout ago (regression for this issue); and DOES clear any layer older than the timeout.

This is behavior-preserving for the timeout safety net while removing the over-aggressive dynamic-layer branch.

## Verification

- `bunx biome check src/stores/loadingStore.js tests/unit/stores/loadingStore.test.js` → clean (2 files, no fixes).
- `bunx vitest run tests/unit/stores/loadingStore.test.js` → 5/5 passing.
- Pre-commit hooks (biome, conventional commit) passed on commit.

## Deferred

- **Replace the timer with per-tile `AbortSignal` tracking** so the stale-cleanup path becomes unreachable (the W19 comment's recommended end-state). Spans `unifiedLoader.activeRequests`, `viewportBuildingLoader` queue/abort wiring, and removal of the `App.vue` timer — too large to land unreviewed in one slice.
- **E2E spec `tests/e2e/loading/no-stale-warnings.spec.ts` (US-09 AC1)** — better landed once the abort-tracking change makes the warning genuinely impossible, to avoid a flaky console-count assertion against the still-present (but now correctly-gated) timer.

Closes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)
