### PR TITLE
perf: disable Cesium IIFE mode to drop render-blocking Cesium.js script (#778)

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -147,7 +147,14 @@ export default defineConfig(({ mode }) => {
 				dirs: ['src/components', 'src/pages'],
 				dts: 'src/components.d.ts',
 			}),
-			cesium(),
+			// iife: false ships Cesium as a deferred ESM lazy chunk (loaded by
+			// cesiumProvider.initialize()'s `import('cesium')`) instead of
+			// externalizing it to a render-blocking <head> <script
+			// src="/cesium-package/Cesium.js">. The plugin still copies
+			// Assets/Workers/Widgets/ThirdParty into cesium-package/ and sets
+			// CESIUM_BASE_URL regardless of this flag. Fixes the chronic Sentry
+			// "Large Render Blocking Asset on /cesium-package/Cesium.js" signal (#778).
+			cesium({ iife: false }),
 			// Put the Sentry vite plugin after all other plugins
 			sentryVitePlugin({
 				authToken: env.SENTRY_AUTH_TOKEN,


### PR DESCRIPTION
## Summary

`vite-plugin-cesium-build` defaults to `iife: true`, which is the actual delivery mechanism behind the chronic Sentry **"Large Render Blocking Asset on /cesium-package/Cesium.js"** signal. In IIFE mode the plugin:

1. Externalizes `import('cesium')` to a global `window.Cesium` (via `viteExternalsPlugin`), and
2. Injects a render/LCP-blocking `<script src="/cesium-package/Cesium.js">` into the `<head>` of `index.html` (via its `transformIndexHtml` hook, with **no** `defer`/`async`).

The three prior fixes (#279, #286, #593/#625) added JS-level lazy loading in `src/services/cesiumProvider.js` (`await import('cesium')`), but with the engine externalized to an IIFE global, that dynamic import was a **no-op against an already-loaded global** — it never produced a lazy chunk and could not defer the engine. Bundle chunking was addressed; IIFE delivery was not, so the Sentry threshold never moved.

This PR sets **`cesium({ iife: false })`** in `vite.config.js`. The plugin switches to ESM mode: it stops externalizing cesium and stops injecting the render-blocking script. It **still** copies `Assets/ThirdParty/Widgets/Workers` into `cesium-package/` and **still** sets `CESIUM_BASE_URL` (its `setBaseUrl` transform runs regardless of `iife`). `cesiumProvider.initialize()`'s `import('cesium')` now resolves against cesium's real ESM entry (`Source/Cesium.js`), and Rollup splits it into a deferred async chunk loaded only when the viewer initializes — not at first paint.

**Diff is a single line in `vite.config.js`** (plus an explanatory comment).

## Verification

`bun run build` (clean `dist/`):

- ✅ `dist/index.html` **no longer contains** the `cesium-package/Cesium.js` script tag — only the inline `CESIUM_BASE_URL` define + the deferred hashed `type="module"` entry remain.
- ✅ A separate `dist/assets/Cesium.<hash>.js` (~4.8MB) lazy chunk now appears (it didn't before).
- ✅ `dist/cesium-package/` still contains `Assets/ThirdParty/Widgets/Workers` (runtime workers/assets load via `CESIUM_BASE_URL`).

`bun run test:unit`: ✅ 801 passed, 4 skipped.

E2E (`tests/e2e/basic.spec.ts`, auto-started dev server with `VITE_E2E_TEST=true`):

- ✅ **6 passed**, including "Building properties" and "HSY Background maps" — both assert a live Cesium `#cesiumContainer canvas` / working viewer, exercising the real-Cesium init path through `cesiumProvider` and `window.__cesium`.
- The **2 failures** are both the same data-dependent "Statistical Grid View" assertion (needs backend grid data not present in the local mock-server run). Confirmed **pre-existing**: the same 2 tests fail identically on the unmodified baseline (`git stash` → rerun → same 2 failures).

The load-bearing risk (removing the IIFE `window.Cesium` global breaking the test harness) does **not** materialize: the CI mock fixture injects its own `window.Cesium`, the app sets `window.__cesium`/`window.__viewer` in `useViewerInitialization.js`, and the test helpers' `window.Cesium || window.__cesium` check covers both paths.

## Deferred

Out of scope for this minimal root-cause fix (each is a larger UX/architecture change, best validated on top of this one):

- Route-gated / user-gesture lazy loading of the viewer (issue investigation step 3).
- Cesium module-level tree-shaking to drop unused features (step 4).
- Lighthouse re-measurement against a deployed preview was not run in this isolated worktree (no preview deploy available); the build-artifact evidence above directly confirms the render-blocking `<head>` script is gone, which is the root cause of the Sentry signal.

Closes #778

🤖 Generated with [Claude Code](https://claude.com/claude-code)
