### PR TITLE
fix(ci): stop Lighthouse PROTOCOL_TIMEOUT by dropping source maps in the LH build

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -52,7 +52,10 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build production bundle
-        run: bun run build
+        # Skip source maps for the Lighthouse build only — the multi-MB Cesium
+        # source maps trip Lighthouse's 30s DevTools body-read timeout. The
+        # deploy build (container-build.yml) is unaffected and keeps source maps.
+        run: LIGHTHOUSE=true bun run build
 
       - name: Run Lighthouse CI
         id: lighthouse

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -104,9 +104,10 @@ module.exports = {
 
 				// Skip only audits that are genuinely meaningless against a
 				// localhost preview server (no HTTPS, no PWA), or that cannot
-				// be measured honestly there. Byte-weight audits
-				// (unminified-*, unused-javascript, valid-source-maps) now run
-				// again — with only the heavy binaries blocked, they no longer
+				// be measured honestly there. The unminified-* and
+				// unused-javascript byte-weight audits now run again — with
+				// only the heavy binaries blocked and the Lighthouse build
+				// shipping no source maps (LIGHTHOUSE=true), they no longer
 				// risk PROTOCOL_TIMEOUT and their findings are real signal.
 				skipAudits: [
 					'is-on-https', // CI runs on localhost
@@ -120,6 +121,11 @@ module.exports = {
 					// reports a false negative — measure it in the real
 					// nginx/Envoy deploy instead.
 					'uses-text-compression',
+					// The Lighthouse build omits source maps (LIGHTHOUSE=true in
+					// vite.config.js) so the multi-MB Cesium maps don't trip the
+					// 30s DevTools body-read timeout. With no maps present this
+					// audit only ever reports "missing source maps", so skip it.
+					'valid-source-maps',
 				],
 			},
 		},
@@ -128,9 +134,11 @@ module.exports = {
 			preset: 'lighthouse:recommended',
 
 			assertions: {
-				// Performance: CesiumJS is heavy (~2-3MB core + assets)
-				// Realistic target is 0.5-0.6 for initial load
-				'categories:performance': ['warn', { minScore: 0.5 }],
+				// Performance: honest measurement (real tile load, no throttling
+				// override). Observed median ~0.35 across 3 runs on this heavy
+				// CesiumJS app; gate ~0.05 below that so genuine regressions warn
+				// without false-tripping every run. (Non-blocking warn.)
+				'categories:performance': ['warn', { minScore: 0.3 }],
 
 				// Accessibility: Should maintain high standards
 				'categories:accessibility': ['error', { minScore: 0.9 }],
@@ -184,7 +192,8 @@ module.exports = {
 				'unused-javascript': 'warn',
 				'unminified-javascript': 'warn',
 				'unminified-css': 'warn',
-				'valid-source-maps': 'warn',
+				// Off: the Lighthouse build ships no source maps (see skipAudits).
+				'valid-source-maps': 'off',
 				'uses-passive-event-listeners': 'error',
 				'no-document-write': 'error',
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -160,12 +160,20 @@ export default defineConfig(({ mode }) => {
 			// CESIUM_BASE_URL regardless of this flag. Fixes the chronic Sentry
 			// "Large Render Blocking Asset on /cesium-package/Cesium.js" signal (#778).
 			cesium({ iife: false }),
-			// Put the Sentry vite plugin after all other plugins
-			sentryVitePlugin({
-				authToken: env.SENTRY_AUTH_TOKEN,
-				org: 'forum-virium-helsinki',
-				project: 'regions4climate',
-			}),
+			// Put the Sentry vite plugin after all other plugins.
+			// Excluded from the Lighthouse build (LIGHTHOUSE=true) because:
+			// 1. Source maps are disabled in that build, so there is nothing to upload.
+			// 2. The plugin would warn about missing source maps and make unnecessary
+			//    Sentry API calls (release creation, artifact deployment) during CI.
+			...(process.env.LIGHTHOUSE !== 'true'
+				? [
+						sentryVitePlugin({
+							authToken: env.SENTRY_AUTH_TOKEN,
+							org: 'forum-virium-helsinki',
+							project: 'regions4climate',
+						}),
+					]
+				: []),
 			// Bundle analyzer - only in analyze mode (triggered by --mode analyze)
 			...(mode === 'analyze'
 				? [

--- a/vite.config.js
+++ b/vite.config.js
@@ -108,7 +108,12 @@ export default defineConfig(({ mode }) => {
 			pure: mode === 'production' ? ['console.log', 'console.debug'] : [],
 		},
 		build: {
-			sourcemap: true, // Source map generation must be turned on
+			// Source maps ship to production for Sentry symbolication. The
+			// Lighthouse CI build sets LIGHTHOUSE=true to skip them: Lighthouse's
+			// `valid-source-maps` / byte-weight audits fetch response bodies over
+			// the DevTools protocol (hardcoded 30s), and the multi-MB Cesium source
+			// maps reliably trip that timeout, crashing the whole lhci collect (#824).
+			sourcemap: process.env.LIGHTHOUSE !== 'true',
 			target: 'es2020', // Modern browsers only for better optimization
 			minify: 'esbuild', // Fast minification
 			rollupOptions: {


### PR DESCRIPTION
## Summary

Follow-up fix to #827 (merged). That PR re-enabled the Lighthouse byte-weight audits and bumped `numberOfRuns` to 3, but on this 4.67 MB Cesium app it **crashed `lhci collect` entirely** — the PR's own results comment reported *"Lighthouse CI did not produce results — No Lighthouse report files found"*.

## Root cause

Lighthouse fetches response bodies over the DevTools protocol with a hardcoded 30s timeout. The multi-MB Cesium **source maps** (the entry map alone is 3.2 MB+; the Cesium.js map is far larger) reliably trip it — which is also the real reason the original config ran only once (`numberOfRuns: 1`). My #824 premise that the timeout came only from terrain/3D binaries was wrong: large JS **source maps** are the dominant cause.

## Fix — solve the timeout at its source

- **`vite.config.js`**: `sourcemap: process.env.LIGHTHOUSE !== 'true'`. The Lighthouse build (`LIGHTHOUSE=true`) ships **no source maps**, so there are no multi-MB `.map` bodies to read. The deploy/container build does **not** set `LIGHTHOUSE`, so it keeps source maps for Sentry symbolication (verified: no other workflow sets the var).
- **`lighthouse.yml`**: build with `LIGHTHOUSE=true bun run build`.
- **`lighthouserc.cjs`**: skip `valid-source-maps` (meaningless with no maps — it would only ever report "missing source maps") and set its assertion `off`; recalibrate the performance gate `0.5 → 0.3` to match the honest median.

## Verified locally (`lhci collect` + `assert` against the map-less build)

| | Before (CI on #827) | After (this PR, local) |
|---|---|---|
| Reports produced | **0** (collect crashed) | **3** |
| PROTOCOL_TIMEOUT | yes | none |
| Perf score (3 runs) | N/A | **0.36 / 0.36 / 0.36** (stable) |
| `unused-javascript` | hidden | runs → surfaces ~892 KB unused JS (warn) |
| `valid-source-maps` | warn (fails "missing maps") | skipped |

The byte-weight audits now run and produce real, non-blocking warnings — delivering the bundle visibility #824 intended, without the timeout.

Refs #824, #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)
