### PR TITLE
style(charts): organize imports after d3 submodule migration

### DIFF
--- a/src/components/BuildingGridChart.vue
+++ b/src/components/BuildingGridChart.vue
@@ -6,8 +6,8 @@
 </template>
 
 <script>
-import * as d3 from '@/utils/d3'
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import * as d3 from '@/utils/d3'
 import { eventBus } from '../services/eventEmitter.js'
 import Plot from '../services/plot.js'
 import { useGlobalStore } from '../stores/globalStore.js'

--- a/src/components/BuildingTreeChart.vue
+++ b/src/components/BuildingTreeChart.vue
@@ -6,8 +6,8 @@
 </template>
 
 <script>
-import * as d3 from '@/utils/d3'
 import { nextTick, ref, watch } from 'vue'
+import * as d3 from '@/utils/d3'
 import Plot from '../services/plot.js'
 import { useGlobalStore } from '../stores/globalStore.js'
 import { usePropsStore } from '../stores/propsStore.js'

--- a/src/components/HSYScatterplot.vue
+++ b/src/components/HSYScatterplot.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script>
-import * as d3 from '@/utils/d3'
 import { onBeforeUnmount, onMounted } from 'vue' // Import lifecycle hooks
+import * as d3 from '@/utils/d3'
 import Building from '../services/building.js'
 import { cesiumEntityManager } from '../services/cesiumEntityManager.js'
 import { eventBus } from '../services/eventEmitter.js'

--- a/src/components/HeatHistogram.vue
+++ b/src/components/HeatHistogram.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script>
-import * as d3 from '@/utils/d3' // Import D3.js
 import { nextTick, onBeforeUnmount, onMounted } from 'vue'
+import * as d3 from '@/utils/d3' // Import D3.js
 import Building from '../services/building.js'
 import { eventBus } from '../services/eventEmitter.js'
 import Plot from '../services/plot.js'

--- a/src/components/HeatHistogramHelsinki.vue
+++ b/src/components/HeatHistogramHelsinki.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script>
-import * as d3 from '@/utils/d3' // Import D3.js
 import { onBeforeUnmount, onMounted } from 'vue'
+import * as d3 from '@/utils/d3' // Import D3.js
 import { useSidebarOffset } from '../composables/useSidebarOffset'
 import Building from '../services/building.js'
 import { eventBus } from '../services/eventEmitter.js'

--- a/src/components/NDVIChart.vue
+++ b/src/components/NDVIChart.vue
@@ -30,8 +30,8 @@
 </template>
 
 <script>
-import * as d3 from '@/utils/d3'
 import { onMounted, ref, watch } from 'vue'
+import * as d3 from '@/utils/d3'
 import { getCesium } from '../services/cesiumProvider.js'
 import Datasource from '../services/datasource.js'
 import { usePropsStore } from '../stores/propsStore.js'

--- a/src/components/NearbyTreeArea.vue
+++ b/src/components/NearbyTreeArea.vue
@@ -114,8 +114,8 @@
 </template>
 
 <script>
-import * as d3 from '@/utils/d3' // Import D3.js
 import { computed } from 'vue'
+import * as d3 from '@/utils/d3' // Import D3.js
 import { useSidebarOffset } from '../composables/useSidebarOffset'
 import Building from '../services/building.js'
 import { cesiumEntityManager } from '../services/cesiumEntityManager.js'

--- a/src/components/PieChart.vue
+++ b/src/components/PieChart.vue
@@ -4,8 +4,8 @@
 </template>
 
 <script setup>
-import * as d3 from '@/utils/d3'
 import { onBeforeUnmount, onMounted } from 'vue'
+import * as d3 from '@/utils/d3'
 import { eventBus } from '../services/eventEmitter.js'
 import Plot from '../services/plot.js'
 import { useBackgroundMapStore } from '../stores/backgroundMapStore.js'

--- a/src/components/SocioEconomicsChart.vue
+++ b/src/components/SocioEconomicsChart.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script>
-import * as d3 from '@/utils/d3' // Import D3.js
 import { onBeforeUnmount, onMounted } from 'vue'
+import * as d3 from '@/utils/d3' // Import D3.js
 import { eventBus } from '../services/eventEmitter.js'
 import Plot from '../services/plot.js'
 import { useGlobalStore } from '../stores/globalStore.js'

--- a/src/components/VulnerabilityChart.vue
+++ b/src/components/VulnerabilityChart.vue
@@ -25,8 +25,8 @@
 </template>
 
 <script setup>
-import * as d3 from '@/utils/d3'
 import { onBeforeUnmount, onMounted, ref } from 'vue'
+import * as d3 from '@/utils/d3'
 import { eventBus } from '../services/eventEmitter.js'
 import Plot from '../services/plot.js'
 import { usePropsStore } from '../stores/propsStore.js'


### PR DESCRIPTION
## Summary

Fixes the red **Lint** check on `main`. The d3 submodule migration (#825 / #830) changed `import * as d3 from 'd3'` → `import * as d3 from '@/utils/d3'` but didn't re-sort imports, so 10 chart files violate Biome's `organizeImports` rule (the `@/utils/d3` namespace import must follow the `vue` import).

Pure `biome check --write` output — **import reordering only, no logic changes** (10 files, +10/−10).

This was my miss in #830: I lint-checked the new `d3.ts` but not the converted chart files. Since `main` is unprotected, #830 merged with the failing Lint check and every subsequent branch inherits it.

Refs #825

🤖 Generated with [Claude Code](https://claude.com/claude-code)