### PR TITLE
docs(rules): distill perf-session learnings into rules + justfile

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -67,6 +67,13 @@ Vuetify theme is configured in `src/main.js` via `createVuetify()`:
 
 All UI colors use `--v-theme-*` CSS variables — see `code-quality.md` CSS Theming section.
 
+## Icons
+
+Material Design Icons render as **inline SVG paths** via a custom Vuetify iconset (`src/plugins/mdiIconset.js`), not the MDI webfont — #821 removed the render-blocking CDN font (~339 KB CSS + ~394 KB woff2) from the critical path. The iconset re-exports Vuetify's `mdi-svg` aliases (for component internals like dropdowns/clear buttons) and maps the app's `mdi-*` names to `@mdi/js` paths via the generated `src/plugins/mdiPaths.js`. `main.js` registers it as the `mdi` set; call sites are unchanged (`<v-icon icon="mdi-foo">`).
+
+- **Adding/removing an icon**: use it as `mdi-foo` as usual, then run `node scripts/generate-mdi-iconset.mjs` to regenerate the path map. The generator scans `src/`, validates each name against `@mdi/js`, and **fails loudly** on an unmappable name — add an `OVERRIDES` entry for renamed icons (e.g. `mdi-building` → `mdiOfficeBuilding`). A missing icon renders blank, so never hand-edit `mdiPaths.js`.
+- **E2E selectors**: the iconset preserves the original `mdi-*` class on the `.v-icon` element, so `.mdi-refresh` / `.mdi-arrow-left` / etc. locators keep matching — the font classes are *not* gone.
+
 ## Cesium Render Mode
 
 `graphicsStore.requestRenderMode` defaults to `true` and is propagated to the live `viewer.scene.requestRenderMode` via the `r4c-request-render-mode` feature flag (wired in `App.vue` after `featureFlagStore.refreshFlags()`). The graphics service `$subscribe` watcher also propagates runtime toggles from `GraphicsQuality.vue` to the live scene.

--- a/.claude/rules/development.md
+++ b/.claude/rules/development.md
@@ -86,3 +86,11 @@ Container build/release use the org reusable workflows (`ForumViriumHelsinki/.gi
 - `lighthouse.yml` — performance monitoring on PRs
 
 Sentry build args (`SENTRY_AUTH_TOKEN`, `VITE_SENTRY_DSN`) reach the build via the reusable workflows' `secret-build-args` passthrough — secrets cannot flow through plain `inputs.build-args` on reusable-workflow callers.
+
+### Lighthouse CI
+
+`lighthouse.yml` runs `lhci collect` against `bun run preview`. Two hazards specific to this heavy CesiumJS app:
+
+- **Source maps cause `PROTOCOL_TIMEOUT`.** Lighthouse fetches response bodies over the DevTools protocol (hardcoded 30s). The multi-MB Cesium source maps — and the `valid-source-maps` / byte-weight audits that read them — reliably trip it and crash `lhci collect` entirely ("did not produce results"). The build step runs `LIGHTHOUSE=true bun run build`, and `vite.config.js` reads `process.env.LIGHTHOUSE` to **skip source maps for the Lighthouse build only** (the deploy/container build is unaffected and keeps maps for Sentry). Do **not** re-enable `valid-source-maps` in `lighthouserc.cjs` — no maps exist in that build by design. This is the timeout's real cause; it is **not** limited to terrain/3D binaries.
+- **The blocked-tile run is a "shell" benchmark.** `blockedUrlPatterns` blocks heavy terrain/3D binaries (raster WMS tiles are unblocked). The honest median is ~0.35 — the perf gate is a non-blocking `warn` at 0.3.
+- **Reproduce locally with `just lighthouse-local`** before pushing `lighthouserc.cjs` / build changes — CI runs are ~11 min, and `main` is unprotected so a broken config can merge before CI catches it.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -187,6 +187,24 @@ Building level UI buttons use exact casing:
 - `"Building Heat Data"` (not "Building heat data")
 - `"Building Properties"` (not "Building properties")
 
+## Icon Selectors (`.mdi-*`)
+
+Icons render as inline SVG (custom `mdi-svg` iconset — see `architecture.md`), but the iconset **preserves the `mdi-*` class on the `.v-icon` element**, so existing icon locators keep working:
+
+```typescript
+page.getByRole('button').filter({ has: page.locator('.mdi-refresh') });
+```
+
+Locating a control by its `mdi-*` class is reliable. A brand-new icon must be regenerated into the path map (`node scripts/generate-mdi-iconset.mjs`) or it renders blank.
+
+## Accessibility Specs Require Data
+
+Most `tests/e2e/accessibility/*` specs are tagged `@requires-database` — they drill to postal-code / building levels that need seeded data, and the reset/back/compass controls only mount once data loads. Without a database they skip or fail, so **red accessibility/E2E checks locally (or on a config-only PR) are usually environmental, not a regression**. Notes:
+
+- DB-free subset: `just dev-mock` + `just test-e2e-mock` (sets `SKIP_REQUIRES_DATABASE=true`).
+- `camera-controls.spec.ts` is `cesiumDescribe.skip`-ed at the source — it always reports 0/skipped.
+- Setting `window.globalStore.level` alone does **not** mount the postal-code view; the data load gates the render. Use `AccessibilityTestHelpers.drillToLevel(..., { method: 'store' })` for deterministic level changes.
+
 ## Conditional Test Skip in Custom Fixtures
 
 `cesiumTest.skip()` inside a test body (e.g., in a catch block) does **not** work — the test timeout kills the process before the skip executes. Use test-level skip instead:

--- a/justfile
+++ b/justfile
@@ -301,6 +301,12 @@ test-e2e *args:
 test-e2e-mock *args:
     VITE_E2E_TEST=true SKIP_REQUIRES_DATABASE=true bun run test:e2e {{ args }}
 
+# Reproduce the CI Lighthouse run locally (map-less build avoids PROTOCOL_TIMEOUT). See development.md.
+[group: "testing"]
+lighthouse-local:
+    LIGHTHOUSE=true bun run build
+    bunx @lhci/cli@0.14.x collect --config=lighthouserc.cjs
+
 # Run a single test file (fast iteration during test fixes)
 [group: "testing"]
 test-file file *args:


### PR DESCRIPTION
## Summary

Distills durable, reusable knowledge from the performance session (#821/#824/#825 + the #831/#832 follow-ups) into project rules and a justfile recipe, so the gotchas aren't re-discovered or re-broken.

| File | Adds |
|---|---|
| `.claude/rules/development.md` | Lighthouse `PROTOCOL_TIMEOUT` root cause (Cesium **source maps**, not just terrain binaries) + the `LIGHTHOUSE=true` map-less build pattern; don't re-enable `valid-source-maps`; reproduce with `just lighthouse-local`. |
| `.claude/rules/architecture.md` | New **Icons** section: MDI webfont → custom `@mdi/js` SVG iconset, the `scripts/generate-mdi-iconset.mjs` regeneration flow, and the `.v-icon` class-preservation contract for E2E selectors. |
| `.claude/rules/testing.md` | `.mdi-*` selectors stay valid via class preservation; accessibility specs are `@requires-database` (red locally is usually environmental); `camera-controls` is `.skip` in source; `store.level` alone doesn't mount the postal-code view. |
| `justfile` | `lighthouse-local` recipe — reproduces the CI Lighthouse run locally. |

Docs/tooling only — no runtime code. Generated via `/project:distill`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)