### PR TITLE
chore(mcp): run pal-mcp-server from installed uv tool

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -23,12 +23,7 @@
       ]
     },
     "pal-mcp-server": {
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/BeehiveInnovations/pal-mcp-server.git",
-        "pal-mcp-server"
-      ]
+      "command": "pal-mcp-server"
     }
   }
 }


### PR DESCRIPTION
## What
Switch the pal MCP server from 'uvx --from git+https://github.com/BeehiveInnovations/pal-mcp-server.git' to the globally-installed 'pal-mcp-server' command (laurigates/pal-mcp-server fork, installed via uv tool install).

## Why
The 'uvx --from git+...' form re-resolves the git source on every MCP launch, creating a process-spawn storm that taxes the system (security-stack inspection of every spawn). Installing the fork once and invoking the bare command eliminates the per-launch git churn and adopts the fork's improvements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)