### PR TITLE
fix(nginx): correct GoFeatureFlag relay-proxy service hostname

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -241,7 +241,7 @@ server {
 
     # GO Feature Flag relay proxy (OFREP endpoint)
     location /feature-flags/ {
-        set $goff_host "gofeatureflag.feature-flags.svc.cluster.local";
+        set $goff_host "gofeatureflag-relay-proxy.feature-flags.svc.cluster.local";
         proxy_pass http://$goff_host:1031/;
         proxy_set_header Host $goff_host;
         proxy_connect_timeout 3s;


### PR DESCRIPTION
## What

Fixes the `/feature-flags/` nginx proxy target in `nginx/default.conf.template`:
`gofeatureflag.feature-flags.svc.cluster.local` → `gofeatureflag-relay-proxy.feature-flags.svc.cluster.local`.

## Why

The GOFF relay-proxy Helm chart names its in-cluster Service `<release>-relay-proxy` = **`gofeatureflag-relay-proxy`**. The plain `gofeatureflag` name has never existed, so nginx fails every `/feature-flags/*` request:

```
gofeatureflag.feature-flags.svc.cluster.local could not be resolved (3: Host not found)
GET /feature-flags/health  host: r4c-beta.dataportal.fi  referrer: https://r4c-beta.dataportal.fi/?flags=true
```

This is what's breaking feature-flag evaluation on **r4c-beta** (and would affect prod once released). The fix takes effect when a new image is built and the deployment picks it up.

The shared `helm-webapp` chart default carried the same wrong name and is fixed separately in [infrastructure#1907](https://github.com/ForumViriumHelsinki/infrastructure/pull/1907).

## Test

`resolver` is configured (line 14), so nginx serves fine and resolves `$goff_host` per-request — the only issue was the hostname value. No other change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)