### PR TITLE
fix(types): drive vue-tsc to zero and pin vue-tsc/typescript

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,8 +80,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run vue-tsc
-        continue-on-error: true
-        run: bunx vue-tsc --noEmit
+        run: bun run typecheck
 
   # Build once and share across all browser-based test jobs.
   # VITE_E2E_TEST=true bakes the E2E test harness into the bundle

--- a/bun.lock
+++ b/bun.lock
@@ -42,10 +42,12 @@
         "rollup-plugin-visualizer": "^7.0.0",
         "sass-embedded": "^1.98.0",
         "typedoc": "^0.28.15",
+        "typescript": "5.9.3",
         "unplugin-auto-import": "^21.0.0",
         "vite": "^8.0.1",
         "vite-plugin-cesium-build": "^0.7.2",
         "vitest": "^4.0.15",
+        "vue-tsc": "3.3.3",
       },
     },
   },
@@ -761,6 +763,12 @@
 
     "@vitest/utils": ["@vitest/utils@4.0.15", "", { "dependencies": { "@vitest/pretty-format": "4.0.15", "tinyrainbow": "^3.0.3" } }, "sha512-HXjPW2w5dxhTD0dLwtYHDnelK3j8sR8cWIaLxr22evTyY6q8pRCjZSmhRWVjBaOVXChQd6AwMzi9pucorXCPZA=="],
 
+    "@volar/language-core": ["@volar/language-core@2.4.28", "", { "dependencies": { "@volar/source-map": "2.4.28" } }, "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ=="],
+
+    "@volar/source-map": ["@volar/source-map@2.4.28", "", {}, "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ=="],
+
+    "@volar/typescript": ["@volar/typescript@2.4.28", "", { "dependencies": { "@volar/language-core": "2.4.28", "path-browserify": "^1.0.1", "vscode-uri": "^3.0.8" } }, "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw=="],
+
     "@vue/compiler-core": ["@vue/compiler-core@3.5.25", "", { "dependencies": { "@babel/parser": "^7.28.5", "@vue/shared": "3.5.25", "entities": "^4.5.0", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-vay5/oQJdsNHmliWoZfHPoVZZRmnSWhug0BYT34njkYTPqClh3DNWLkZNJBVSjsNMrg0CCrBfoKkjZQPM/QVUw=="],
 
     "@vue/compiler-dom": ["@vue/compiler-dom@3.5.25", "", { "dependencies": { "@vue/compiler-core": "3.5.25", "@vue/shared": "3.5.25" } }, "sha512-4We0OAcMZsKgYoGlMjzYvaoErltdFI2/25wqanuTu+S4gismOTRTBPi4IASOjxWdzIwrYSjnqONfKvuqkXzE2Q=="],
@@ -774,6 +782,8 @@
     "@vue/devtools-kit": ["@vue/devtools-kit@7.7.9", "", { "dependencies": { "@vue/devtools-shared": "^7.7.9", "birpc": "^2.3.0", "hookable": "^5.5.3", "mitt": "^3.0.1", "perfect-debounce": "^1.0.0", "speakingurl": "^14.0.1", "superjson": "^2.2.2" } }, "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA=="],
 
     "@vue/devtools-shared": ["@vue/devtools-shared@7.7.9", "", { "dependencies": { "rfdc": "^1.4.1" } }, "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA=="],
+
+    "@vue/language-core": ["@vue/language-core@3.3.3", "", { "dependencies": { "@volar/language-core": "2.4.28", "@vue/compiler-dom": "^3.5.0", "@vue/shared": "^3.5.0", "alien-signals": "^3.2.0", "muggle-string": "^0.4.1", "path-browserify": "^1.0.1", "picomatch": "^4.0.4" } }, "sha512-X6p+7nfY7vVT6dQwUJ+v0Jfq/lwIfhL2jMi91dQ3ln4hnlGXlxsDu/FNkeyHYgvYtyQy18ZX76IZy7X4diDbiQ=="],
 
     "@vue/reactivity": ["@vue/reactivity@3.5.25", "", { "dependencies": { "@vue/shared": "3.5.25" } }, "sha512-5xfAypCQepv4Jog1U4zn8cZIcbKKFka3AgWHEFQeK65OW+Ys4XybP6z2kKgws4YB43KGpqp5D/K3go2UPPunLA=="],
 
@@ -796,6 +806,8 @@
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "alien-signals": ["alien-signals@3.2.1", "", {}, "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g=="],
 
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
@@ -1225,6 +1237,8 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
+
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
@@ -1260,6 +1274,8 @@
     "parse-headers": ["parse-headers@2.0.6", "", {}, "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A=="],
 
     "parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
+
+    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
@@ -1517,9 +1533,13 @@
 
     "vitest": ["vitest@4.0.15", "", { "dependencies": { "@vitest/expect": "4.0.15", "@vitest/mocker": "4.0.15", "@vitest/pretty-format": "4.0.15", "@vitest/runner": "4.0.15", "@vitest/snapshot": "4.0.15", "@vitest/spy": "4.0.15", "@vitest/utils": "4.0.15", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.15", "@vitest/browser-preview": "4.0.15", "@vitest/browser-webdriverio": "4.0.15", "@vitest/ui": "4.0.15", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA=="],
 
+    "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
+
     "vue": ["vue@3.5.25", "", { "dependencies": { "@vue/compiler-dom": "3.5.25", "@vue/compiler-sfc": "3.5.25", "@vue/runtime-dom": "3.5.25", "@vue/server-renderer": "3.5.25", "@vue/shared": "3.5.25" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g=="],
 
     "vue-component-type-helpers": ["vue-component-type-helpers@2.2.12", "", {}, "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw=="],
+
+    "vue-tsc": ["vue-tsc@3.3.3", "", { "dependencies": { "@volar/typescript": "2.4.28", "@vue/language-core": "3.3.3" }, "peerDependencies": { "typescript": ">=5.0.0" }, "bin": { "vue-tsc": "bin/vue-tsc.js" } }, "sha512-SWUEG7YRUeDJHT7Xsuhf02elYX2gxPzzAII7OxDAh4KNOr4QHQ0Lls0YfnaO5GNd560CwVa2HTfdqmA5MqvRqQ=="],
 
     "vuetify": ["vuetify@4.0.1", "", { "peerDependencies": { "typescript": ">=4.7", "vite-plugin-vuetify": ">=2.1.0", "vue": "^3.5.0", "webpack-plugin-vuetify": ">=3.1.0" }, "optionalPeers": ["typescript", "vite-plugin-vuetify", "webpack-plugin-vuetify"] }, "sha512-0z0lKd1r6KmVK4YliDb4w2k9Yk7Z83V5kxpn9z5glipIcFJEizJK+LfFBzy3G2tMxuhSZHU4DmQ4qxfpvLhjQg=="],
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"build:analyze": "NODE_OPTIONS='--max-old-space-size=3072' vite build --mode analyze",
 		"preview": "vite preview --host",
 		"lint": "biome check src/",
+		"typecheck": "vue-tsc --noEmit",
 		"lint:fix": "biome check --write src/",
 		"lint:deps": "knip",
 		"format": "biome format --write src/",
@@ -92,10 +93,12 @@
 		"rollup-plugin-visualizer": "^7.0.0",
 		"sass-embedded": "^1.98.0",
 		"typedoc": "^0.28.15",
+		"typescript": "5.9.3",
 		"unplugin-auto-import": "^21.0.0",
 		"vite": "^8.0.1",
 		"vite-plugin-cesium-build": "^0.7.2",
-		"vitest": "^4.0.15"
+		"vitest": "^4.0.15",
+		"vue-tsc": "3.3.3"
 	},
 	"overrides": {
 		"esbuild": "^0.25.11",

--- a/src/App.vue
+++ b/src/App.vue
@@ -204,7 +204,8 @@ const stopLevelUrlWatcher = watch(
 	() => [globalStore.level, globalStore.postalcode],
 	([level, code]) => {
 		if (level === 'start') {
-			updateUrlWithNavigationState('start', null)
+			// Empty string is falsy, so the helper deletes the postalcode param.
+			updateUrlWithNavigationState('start', '')
 		} else if ((level === 'postalCode' || level === 'building') && code) {
 			updateUrlWithNavigationState(level, code)
 		}
@@ -233,8 +234,10 @@ const smartReset = async () => {
 	toggleStore.onExitPostalCode()
 
 	globalStore.setLevel('start')
-	globalStore.setPostalCode(null)
-	globalStore.setNameOfZone(null)
+	// Direct state reset to null: the setters are typed `string`-only, while the
+	// state fields are `string | null`. Clearing them is the correct reset intent.
+	globalStore.postalcode = null
+	globalStore.nameOfZone = null
 	globalStore.setView('capitalRegion')
 
 	toggleStore.setShowTrees(false)
@@ -246,7 +249,7 @@ const smartReset = async () => {
 	const camera = new Camera()
 	camera.init()
 
-	const tooltip = document.querySelector('.tooltip')
+	const tooltip = /** @type {HTMLElement | null} */ (document.querySelector('.tooltip'))
 	if (tooltip) tooltip.style.display = 'none'
 }
 

--- a/src/components/BackgroundMapBrowser.vue
+++ b/src/components/BackgroundMapBrowser.vue
@@ -336,11 +336,20 @@ export default {
 		]
 
 		// HSY Environmental maps
+		/**
+		 * @typedef {{
+		 *   id: any,
+		 *   name: string,
+		 *   title: string,
+		 *   date_updated?: any,
+		 *   organization?: any
+		 * }} HSYLayer
+		 */
 		const hsySearchQuery = ref('')
-		const selectedHSYLayer = ref(null)
-		const hsyLayers = ref([])
+		const selectedHSYLayer = ref(/** @type {string | null} */ (null))
+		const hsyLayers = ref(/** @type {HSYLayer[]} */ ([]))
 		const isLoadingHSY = ref(false)
-		const hsyLoadError = ref(null)
+		const hsyLoadError = ref(/** @type {string | null} */ (null))
 
 		const filteredHSYLayers = computed(() => {
 			if (!hsySearchQuery.value) {
@@ -354,8 +363,8 @@ export default {
 		})
 
 		// Track active imagery layers for cleanup
-		const hsyMapLayer = ref(null)
-		const basicMapLayer = ref(null)
+		const hsyMapLayer = ref(/** @type {Cesium.ImageryLayer | null} */ (null))
+		const basicMapLayer = ref(/** @type {Cesium.ImageryLayer | null} */ (null))
 
 		const removeLayer = (layerRef, errorMsg) => {
 			if (layerRef.value) {
@@ -512,6 +521,7 @@ export default {
 			// Search is reactive via computed property
 		}
 
+		/** @param {HSYLayer} layer */
 		const selectHSYLayer = async (layer) => {
 			selectedHSYLayer.value = layer.name
 			const Cesium = getCesium()
@@ -528,7 +538,8 @@ export default {
 					maximumLevel: 18,
 					tilingScheme: new Cesium.GeographicTilingScheme(),
 				})
-				await provider.readyPromise
+				// Cesium >= 1.104 removed ImageryProvider.readyPromise; providers are
+				// ready synchronously after construction, so no await is needed here.
 
 				// Guard: only proceed if this is still the currently selected layer;
 				// a rapid second selection would have updated selectedHSYLayer already.

--- a/src/components/BuildingGridChart.vue
+++ b/src/components/BuildingGridChart.vue
@@ -19,7 +19,7 @@ export default {
 		const propsStore = usePropsStore()
 		const plotService = new Plot()
 		const buildingContainerId = 'buildingGridChartContainer'
-		const containerRef = ref(null)
+		const containerRef = ref(/** @type {HTMLElement | null} */ (null))
 
 		const createBuildingGridChart = (buildingProps) => {
 			plotService.initializePlotContainer(buildingContainerId)

--- a/src/components/BuildingHeatChart.vue
+++ b/src/components/BuildingHeatChart.vue
@@ -20,6 +20,12 @@ export default {
 			const address = store.buildingAddress
 			const postinumero = store.postalcode
 
+			// Chart requires a selected building (heat exposure + address) and a
+			// postal code; bail out otherwise so downstream code can rely on them.
+			if (buildingHeatExposure == null || address == null || postinumero == null) {
+				return
+			}
+
 			plotService.initializePlotContainer('buildingChartContainer')
 
 			const margin = { top: 40, right: 40, bottom: 30, left: 30 }

--- a/src/components/BuildingInformation.vue
+++ b/src/components/BuildingInformation.vue
@@ -99,9 +99,16 @@ export default {
 		const urlStore = useURLStore()
 		const showTooltip = ref(false)
 		const mousePosition = ref({ x: 0, y: 0 })
-		const buildingAttributes = ref(null)
+		/**
+		 * @typedef {Object} BuildingAttributes
+		 * @property {string} avg_temp_c - Average temperature (formatted) or 'n/a'
+		 * @property {*} rakennusaine_s - Construction material
+		 * @property {string} address - Formatted building address
+		 */
+		const buildingAttributes = ref(/** @type {BuildingAttributes | null} */ (null))
 		const pickPending = ref(false)
 		const handlerRegistered = ref(false)
+		/** @type {import('vue').Ref<string | null>} */
 		const fetchingBuildingId = ref(null) // Track in-flight lazy fetch
 
 		logger.debug('[BuildingInformation] 🎬 Component setup started')

--- a/src/components/BuildingTreeChart.vue
+++ b/src/components/BuildingTreeChart.vue
@@ -25,8 +25,8 @@ export default {
 
 		const createBuildingTreeBarChart = () => {
 			const treeArea = setTreeArea()
-			const postinumero = store.postalcode
-			const address = store.buildingAddress
+			const postinumero = store.postalcode ?? ''
+			const address = store.buildingAddress ?? ''
 
 			plotService.initializePlotContainer('buildingTreeChartContainer')
 
@@ -52,7 +52,7 @@ export default {
 			createBars(svg, data, xScale, yScale, height, colors)
 
 			plotService.setupAxes(svg, xScale, yScale, height)
-			plotService.addTitle(svg, 'Nearby tree area comparison', width, margin)
+			plotService.addTitle(svg, 'Nearby tree area comparison', width, margin.top)
 		}
 
 		const createBars = (svg, data, xScale, yScale, height, colors) => {

--- a/src/components/ClimateAdaption.vue
+++ b/src/components/ClimateAdaption.vue
@@ -166,7 +166,9 @@ watch(
 		if (isOpen) {
 			await nextTick()
 			// Focus the first tab when drawer opens
-			const firstTab = document.querySelector('.climate-adaption-panel [role="tab"]')
+			const firstTab = /** @type {HTMLElement | null} */ (
+				document.querySelector('.climate-adaption-panel [role="tab"]')
+			)
 			if (firstTab) {
 				firstTab.focus()
 			}

--- a/src/components/CoolingCenterOptimiser.vue
+++ b/src/components/CoolingCenterOptimiser.vue
@@ -74,6 +74,7 @@ const findOptimalCoolingCenters = async () => {
 	shuffleArray(availableGrids)
 
 	for (let i = 0; i < numCoolingCenters.value; i++) {
+		/** @type {import('../stores/mitigationStore.js').GridCell | null} */
 		let bestCell = null
 		let highestTotalReduction = -Infinity
 
@@ -87,9 +88,17 @@ const findOptimalCoolingCenters = async () => {
 		})
 
 		if (bestCell) {
-			if (!isCoolingCenterTooClose(bestCell)) {
-				addCoolingCenter(bestCell.entity)
-				availableGrids.splice(availableGrids.indexOf(bestCell), 1)
+			// TS narrows `bestCell` to `never` here because its only visible assignment
+			// happens inside the forEach closure (opaque to control-flow analysis), so
+			// re-widen via the declared GridCell type before reading members.
+			const selectedCell = /** @type {import('../stores/mitigationStore.js').GridCell} */ (bestCell)
+			if (!isCoolingCenterTooClose(selectedCell)) {
+				// BUG (pre-existing): mitigationStore.setGridCells intentionally does
+				// NOT store the Cesium entity reference on grid cells, so `.entity` is
+				// always undefined here and addCoolingCenter() receives undefined. Left
+				// as-is to preserve runtime behavior; tracked separately.
+				addCoolingCenter(selectedCell.entity)
+				availableGrids.splice(availableGrids.indexOf(selectedCell), 1)
 			} else {
 				availableGrids.splice(availableGrids.indexOf(bestCell), 1)
 				i--

--- a/src/components/DataSourceStatus.vue
+++ b/src/components/DataSourceStatus.vue
@@ -420,16 +420,50 @@ const emit = defineEmits(['source-retry', 'cache-cleared', 'data-preload'])
 // Store
 const _loadingStore = useLoadingStore()
 
+/**
+ * Cache statistics shape returned by cacheService.getCacheStats()
+ * @typedef {Object} CacheStats
+ * @property {number} [totalEntries] - Number of cached entries
+ * @property {number} [totalSize] - Total bytes used
+ * @property {number} [expiredCount] - Number of expired entries
+ * @property {Object<string, number>} [typeStats] - Entry counts by data type
+ * @property {number} [maxSize] - Maximum cache size in bytes
+ * @property {number} [utilizationPercent] - Percent of cache budget used
+ */
+
+/**
+ * A monitored data source entry
+ * @typedef {Object} DataSource
+ * @property {string} id
+ * @property {string} name
+ * @property {string} url
+ * @property {string} type
+ * @property {string} status
+ * @property {string} message
+ * @property {boolean} loading
+ * @property {boolean} retrying
+ * @property {boolean} cached
+ * @property {number|null} lastUpdated
+ * @property {number|null} responseTime
+ * @property {number|null} cacheAge
+ * @property {number|null} cacheSize
+ * @property {string} [errorType] - Classification of the most recent error ('auth', 'service', 'network', 'unknown')
+ */
+
 // Local state
 const refreshing = ref(false)
 const showCacheStats = ref(false)
 const detailsDialog = ref(false)
+/** @type {import('vue').Ref<DataSource|null>} */
 const selectedSource = ref(null)
+/** @type {import('vue').Ref<CacheStats>} */
 const cacheStats = ref({})
+/** @type {import('vue').Ref<ReturnType<typeof setInterval>|null>} */
 const refreshTimer = ref(null)
 
 // Data sources to monitor
 // Uses /status/* health check endpoints for better error detection
+/** @type {import('vue').Ref<DataSource[]>} */
 const dataSources = ref([
 	{
 		id: 'pygeoapi',

--- a/src/components/DataSourceStatusBadge.vue
+++ b/src/components/DataSourceStatusBadge.vue
@@ -138,51 +138,65 @@ const emit = defineEmits(['source-retry', 'cache-cleared'])
 
 // Local state
 const refreshing = ref(false)
-const refreshTimer = ref(null)
+const refreshTimer = ref(/** @type {ReturnType<typeof setInterval> | null} */ (null))
+
+/**
+ * @typedef {object} DataSource
+ * @property {string} id
+ * @property {string} name
+ * @property {string} url
+ * @property {string} status
+ * @property {string} message
+ * @property {boolean} loading
+ * @property {boolean} cached
+ * @property {number | null} responseTime
+ */
 
 // Data sources to monitor
-const dataSources = ref([
-	{
-		id: 'pygeoapi',
-		name: 'PyGeoAPI',
-		url: '/pygeoapi/collections/heatexposure_optimized/items?f=json&limit=1',
-		status: 'unknown',
-		message: 'Not checked',
-		loading: false,
-		cached: false,
-		responseTime: null,
-	},
-	{
-		id: 'hsy-action',
-		name: 'HSY Environmental',
-		url: '/hsy-action?action_route=GetHierarchicalMapLayerGroups',
-		status: 'unknown',
-		message: 'Not checked',
-		loading: false,
-		cached: false,
-		responseTime: null,
-	},
-	{
-		id: 'paavo',
-		name: 'Statistics Finland',
-		url: '/paavo',
-		status: 'unknown',
-		message: 'Not checked',
-		loading: false,
-		cached: false,
-		responseTime: null,
-	},
-	{
-		id: 'digitransit',
-		name: 'Digitransit API',
-		url: '/digitransit/geocoding/v1/search?text=Helsinki',
-		status: 'unknown',
-		message: 'Not checked',
-		loading: false,
-		cached: false,
-		responseTime: null,
-	},
-])
+const dataSources = ref(
+	/** @type {DataSource[]} */ ([
+		{
+			id: 'pygeoapi',
+			name: 'PyGeoAPI',
+			url: '/pygeoapi/collections/heatexposure_optimized/items?f=json&limit=1',
+			status: 'unknown',
+			message: 'Not checked',
+			loading: false,
+			cached: false,
+			responseTime: null,
+		},
+		{
+			id: 'hsy-action',
+			name: 'HSY Environmental',
+			url: '/hsy-action?action_route=GetHierarchicalMapLayerGroups',
+			status: 'unknown',
+			message: 'Not checked',
+			loading: false,
+			cached: false,
+			responseTime: null,
+		},
+		{
+			id: 'paavo',
+			name: 'Statistics Finland',
+			url: '/paavo',
+			status: 'unknown',
+			message: 'Not checked',
+			loading: false,
+			cached: false,
+			responseTime: null,
+		},
+		{
+			id: 'digitransit',
+			name: 'Digitransit API',
+			url: '/digitransit/geocoding/v1/search?text=Helsinki',
+			status: 'unknown',
+			message: 'Not checked',
+			loading: false,
+			cached: false,
+			responseTime: null,
+		},
+	])
+)
 
 // Computed properties
 const totalSources = computed(() => dataSources.value.length)

--- a/src/components/DataSourceStatusCompact.vue
+++ b/src/components/DataSourceStatusCompact.vue
@@ -145,51 +145,66 @@ const emit = defineEmits(['source-retry', 'cache-cleared'])
 // Local state
 const refreshing = ref(false)
 const showDetails = ref(false)
+/** @type {import('vue').Ref<ReturnType<typeof setInterval> | null>} */
 const refreshTimer = ref(null)
 
+/**
+ * @typedef {Object} DataSourceStatus
+ * @property {string} id
+ * @property {string} name
+ * @property {string} url
+ * @property {string} status
+ * @property {string} message
+ * @property {boolean} loading
+ * @property {boolean} cached
+ * @property {number | null} responseTime
+ */
+
 // Data sources to monitor
-const dataSources = ref([
-	{
-		id: 'pygeoapi',
-		name: 'PyGeoAPI',
-		url: '/pygeoapi/collections/heatexposure_optimized/items?f=json&limit=1',
-		status: 'unknown',
-		message: 'Not checked',
-		loading: false,
-		cached: false,
-		responseTime: null,
-	},
-	{
-		id: 'hsy-action',
-		name: 'HSY Environmental',
-		url: '/hsy-action?action_route=GetHierarchicalMapLayerGroups',
-		status: 'unknown',
-		message: 'Not checked',
-		loading: false,
-		cached: false,
-		responseTime: null,
-	},
-	{
-		id: 'paavo',
-		name: 'Statistics Finland',
-		url: '/paavo',
-		status: 'unknown',
-		message: 'Not checked',
-		loading: false,
-		cached: false,
-		responseTime: null,
-	},
-	{
-		id: 'digitransit',
-		name: 'Digitransit API',
-		url: '/digitransit/geocoding/v1/search?text=Helsinki',
-		status: 'unknown',
-		message: 'Not checked',
-		loading: false,
-		cached: false,
-		responseTime: null,
-	},
-])
+const dataSources = ref(
+	/** @type {DataSourceStatus[]} */ ([
+		{
+			id: 'pygeoapi',
+			name: 'PyGeoAPI',
+			url: '/pygeoapi/collections/heatexposure_optimized/items?f=json&limit=1',
+			status: 'unknown',
+			message: 'Not checked',
+			loading: false,
+			cached: false,
+			responseTime: null,
+		},
+		{
+			id: 'hsy-action',
+			name: 'HSY Environmental',
+			url: '/hsy-action?action_route=GetHierarchicalMapLayerGroups',
+			status: 'unknown',
+			message: 'Not checked',
+			loading: false,
+			cached: false,
+			responseTime: null,
+		},
+		{
+			id: 'paavo',
+			name: 'Statistics Finland',
+			url: '/paavo',
+			status: 'unknown',
+			message: 'Not checked',
+			loading: false,
+			cached: false,
+			responseTime: null,
+		},
+		{
+			id: 'digitransit',
+			name: 'Digitransit API',
+			url: '/digitransit/geocoding/v1/search?text=Helsinki',
+			status: 'unknown',
+			message: 'Not checked',
+			loading: false,
+			cached: false,
+			responseTime: null,
+		},
+	])
+)
 
 // Computed properties
 const totalSources = computed(() => dataSources.value.length)

--- a/src/components/FeatureFlagsPanel.vue
+++ b/src/components/FeatureFlagsPanel.vue
@@ -333,8 +333,8 @@ function getCategoryTotalCount(category: FeatureFlagCategory): number {
 	return featureFlagStore.flagsByCategory(category).length
 }
 
-function setFlag(flagName: FeatureFlagName, enabled: boolean): void {
-	featureFlagStore.setFlag(flagName, enabled)
+function setFlag(flagName: FeatureFlagName, enabled: boolean | null): void {
+	featureFlagStore.setFlag(flagName, enabled === true)
 }
 
 function resetFlag(flagName: FeatureFlagName): void {

--- a/src/components/FloodBackgroundSyke.vue
+++ b/src/components/FloodBackgroundSyke.vue
@@ -81,7 +81,7 @@ import logger from '../utils/logger.js'
 
 const urlStore = useURLStore()
 const globalStore = useGlobalStore()
-const selectedScenario = ref(null)
+const selectedScenario = ref(/** @type {string | null} */ (null))
 
 const legendItemsCombination = ref([
 	{ color: '#002a8e', text: 'Current situation (2020)' },

--- a/src/components/FloodSimulationPanel.vue
+++ b/src/components/FloodSimulationPanel.vue
@@ -85,7 +85,7 @@
 			density="compact"
 			hide-details
 			class="mb-2"
-			@update:model-value="store.setDimension"
+			@update:model-value="onDimensionChange"
 		>
 			<v-radio
 				v-for="dim in VTT_DIMENSIONS"
@@ -128,10 +128,10 @@
 
 <script setup>
 import { computed, onMounted, onUnmounted, watch } from 'vue'
-import { VTT_DIMENSIONS, VTT_SCENARIOS } from '../constants/vttFlood.ts'
+import { VTT_DIMENSIONS, VTT_SCENARIOS } from '../constants/vttFlood'
 import { clearFlood, renderFlood } from '../services/vttFlood.js'
 import { useGlobalStore } from '../stores/globalStore.js'
-import { useVttFloodStore } from '../stores/vttFloodStore.ts'
+import { useVttFloodStore } from '../stores/vttFloodStore'
 import logger from '../utils/logger.js'
 
 const emit = defineEmits(['close'])
@@ -162,6 +162,9 @@ const legendMax = computed(() => formatRange(store.activeRange.max))
 function onScenarioChange(id) {
 	if (id) store.selectScenario(id)
 }
+function onDimensionChange(key) {
+	if (key) store.setDimension(key)
+}
 function onFrameChange(value) {
 	store.setFrame(Number(value))
 }
@@ -176,9 +179,11 @@ function onFrameInput(value) {
 // owns Cesium calls; the store stays viewer-agnostic.
 const stopRenderWatcher = watch(
 	() => [store.frame, store.dimension],
-	async ([frame, dimension]) => {
+	async () => {
 		const viewer = globalStore.cesiumViewer
 		if (!viewer) return
+		const frame = store.frame
+		const dimension = store.dimension
 		if (!frame) {
 			await clearFlood({ viewer })
 			return

--- a/src/components/Geocoding.vue
+++ b/src/components/Geocoding.vue
@@ -63,11 +63,20 @@ import { useGlobalStore } from '../stores/globalStore'
 import { useToggleStore } from '../stores/toggleStore'
 import logger from '../utils/logger.js'
 
+/**
+ * Geocoding result row produced by {@link processAddressData}.
+ * @typedef {Object} GeocodingAddress
+ * @property {string} address - Human-readable place/address name
+ * @property {number} latitude - WGS84 latitude
+ * @property {number} longitude - WGS84 longitude
+ * @property {string} postalcode - Finnish postal code
+ */
+
 // State variables
 const searchQuery = ref('')
-const filteredAddresses = ref([]) // Store full address objects
+const filteredAddresses = ref(/** @type {GeocodingAddress[]} */ ([])) // Store full address objects
 const showSearchResults = ref(false)
-const addressData = ref([])
+const addressData = ref(/** @type {GeocodingAddress[]} */ ([]))
 
 // Access stores
 const globalStore = useGlobalStore()

--- a/src/components/GraphicsQuality.vue
+++ b/src/components/GraphicsQuality.vue
@@ -281,7 +281,9 @@ export default {
 	setup() {
 		const graphicsStore = useGraphicsStore()
 		const featureFlagStore = useFeatureFlagStore()
-		const selectedPreset = ref(null)
+		const selectedPreset = ref(
+			/** @type {'ultra' | 'high' | 'medium' | 'low' | 'performance' | null} */ (null)
+		)
 
 		// Feature flag checks for anti-aliasing options
 		const msaaOptionsEnabled = computed(() => featureFlagStore.isEnabled('msaaOptions'))

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -136,6 +136,11 @@ export default {
 	data() {
 		return {
 			viewer: null,
+			// Instance services/stores assigned in mounted() (declared here so the
+			// component instance type knows about them).
+			store: /** @type {ReturnType<typeof useGlobalStore> | null} */ (null),
+			toggleStore: /** @type {ReturnType<typeof useToggleStore> | null} */ (null),
+			datasourceService: /** @type {Datasource | null} */ (null),
 			// Vue reactive state for toggles
 			postalCodeView: false,
 			natureGrid: false,
@@ -148,29 +153,29 @@ export default {
 	},
 	watch: {
 		postalCodeView(newValue) {
-			this.toggleStore.setPostalCode(newValue)
+			this.toggleStore?.setPostalCode(newValue)
 			if (newValue) {
-				this.store.setView('capitalRegion')
+				this.store?.setView('capitalRegion')
 				this.reset()
 			}
 		},
 		natureGrid(newValue) {
-			this.toggleStore.setNatureGrid(newValue)
+			this.toggleStore?.setNatureGrid(newValue)
 			this.natureGridEvent()
 		},
 		travelTime(newValue) {
-			this.toggleStore.setTravelTime(newValue)
+			this.toggleStore?.setTravelTime(newValue)
 			this.travelTimeEvent()
 		},
 		resetGrid(newValue) {
-			this.toggleStore.setResetGrid(newValue)
+			this.toggleStore?.setResetGrid(newValue)
 			if (newValue) {
 				const populationgridService = new Populationgrid()
 				void populationgridService.createPopulationGrid()
 			}
 		},
 		surveyPlaces(newValue) {
-			this.toggleStore.setSurveyPlaces(newValue)
+			this.toggleStore?.setSurveyPlaces(newValue)
 			this.surveyPlacesEvent()
 		},
 		grid250m(_newValue) {
@@ -178,14 +183,15 @@ export default {
 		},
 	},
 	mounted() {
-		this.unsubscribe = eventBus.on('createPopulationGrid', this.createPopulationGrid)
+		// mitt's eventBus.on returns void (not an unsubscribe fn); use off() to clean up.
+		eventBus.on('createPopulationGrid', this.createPopulationGrid)
 		this.store = useGlobalStore()
 		this.toggleStore = useToggleStore()
 		this.viewer = this.store.cesiumViewer
 		this.datasourceService = new Datasource()
 	},
 	beforeUnmount() {
-		this.unsubscribe()
+		eventBus.off('createPopulationGrid', this.createPopulationGrid)
 	},
 	methods: {
 		reset() {
@@ -194,13 +200,13 @@ export default {
 			buildingService.cancelCurrentLoad()
 
 			// Restore grid visibility if it was hidden when entering postal code
-			this.toggleStore.onExitPostalCode()
+			this.toggleStore?.onExitPostalCode()
 
 			// Smart reset instead of page reload
-			this.store.setLevel('start')
-			this.store.setPostalCode(null)
-			this.store.setNameOfZone(null)
-			this.store.setView('capitalRegion')
+			this.store?.setLevel('start')
+			this.store?.setPostalCode(null)
+			this.store?.setNameOfZone(null)
+			this.store?.setView('capitalRegion')
 
 			// Reset camera to initial position
 			const camera = new Camera()
@@ -216,12 +222,12 @@ export default {
 		 */
 		activate250mGridEvent() {
 			if (this.grid250m) {
-				this.datasourceService.changeDataSourceShowByName('PopulationGrid', false)
+				this.datasourceService?.changeDataSourceShowByName('PopulationGrid', false)
 			} else {
-				this.datasourceService.removeDataSourcesByNamePrefix('250m_grid')
+				this.datasourceService?.removeDataSourcesByNamePrefix('250m_grid')
 				// Hide building grid chart via event bus (maintains component encapsulation)
 				eventBus.emit('hideBuildingGridChart')
-				this.datasourceService.changeDataSourceShowByName('PopulationGrid', true)
+				this.datasourceService?.changeDataSourceShowByName('PopulationGrid', true)
 			}
 		},
 
@@ -233,7 +239,7 @@ export default {
 				const espooSurveyService = new EspooSurvey()
 				void espooSurveyService.loadSurveyFeatures('places_in_everyday_life')
 			} else {
-				this.datasourceService.removeDataSourcesByNamePrefix('Survey ')
+				this.datasourceService?.removeDataSourcesByNamePrefix('Survey ')
 				// Hide survey scatter plot via event bus (maintains component encapsulation)
 				eventBus.emit('hideSurveyScatterPlot')
 			}
@@ -250,18 +256,18 @@ export default {
 			}
 
 			try {
-				this.datasourceService.removeDataSourcesByNamePrefix('TravelLabel')
-				this.datasourceService.removeDataSourcesByNamePrefix('PopulationGrid')
+				this.datasourceService?.removeDataSourcesByNamePrefix('TravelLabel')
+				this.datasourceService?.removeDataSourcesByNamePrefix('PopulationGrid')
 
 				if (this.travelTime) {
-					await this.datasourceService.loadGeoJsonDataSource(
+					await this.datasourceService?.loadGeoJsonDataSource(
 						0.1,
 						'assets/data/travel_time_grid.json',
 						'TravelTimeGrid'
 					)
 				} else {
-					await this.datasourceService.removeDataSourcesByNamePrefix('TravelTimeGrid')
-					await this.datasourceService.removeDataSourcesByNamePrefix('TravelLabel')
+					await this.datasourceService?.removeDataSourcesByNamePrefix('TravelTimeGrid')
+					await this.datasourceService?.removeDataSourcesByNamePrefix('TravelLabel')
 					await this.createPopulationGrid()
 				}
 			} catch (error) {
@@ -274,7 +280,7 @@ export default {
 		 * Uses batched processing for UI responsiveness with 18K+ entities.
 		 */
 		async natureGridEvent() {
-			this.datasourceService.removeDataSourcesByNamePrefix('TravelTimeGrid')
+			this.datasourceService?.removeDataSourcesByNamePrefix('TravelTimeGrid')
 
 			if (this.natureGrid) {
 				const populationgridService = new Populationgrid()
@@ -291,7 +297,7 @@ export default {
 				// Uncheck travel time toggle when nature grid is enabled
 				this.travelTime = false
 			} else {
-				this.datasourceService.removeDataSourcesByNamePrefix('PopulationGrid')
+				this.datasourceService?.removeDataSourcesByNamePrefix('PopulationGrid')
 				await this.createPopulationGrid()
 			}
 		},

--- a/src/components/HSYAreaSelect.vue
+++ b/src/components/HSYAreaSelect.vue
@@ -19,7 +19,7 @@ export default {
 		const backgroundMapStore = useBackgroundMapStore()
 		const propsStore = usePropsStore()
 		const selectedArea = ref('')
-		const areaOptions = ref([])
+		const areaOptions = ref(/** @type {string[]} */ ([]))
 
 		// Populate areaOptions when the component is mounted
 		onMounted(() => {
@@ -30,7 +30,7 @@ export default {
 		})
 
 		const extractNimiValues = (datasource) => {
-			const nimiValuesSet = new Set()
+			const nimiValuesSet = new Set(/** @type {string[]} */ ([]))
 			const entitiesArray = datasource._entityCollection?._entities._array
 
 			if (Array.isArray(entitiesArray)) {

--- a/src/components/HSYBuildingHeatChart.vue
+++ b/src/components/HSYBuildingHeatChart.vue
@@ -60,6 +60,9 @@ export default {
 
 		const createHSYBuildingBarChart = () => {
 			const buildingHeatExposure = propsStore.buildingHeatTimeseries
+			if (!buildingHeatExposure) {
+				return
+			}
 			const postalcodeHeatTimeseries = propsStore.postalcodeHeatTimeseries
 			const address = store.buildingAddress
 			const postinumero = store.postalcode
@@ -215,7 +218,7 @@ export default {
 				if (store.view === 'capitalRegion') {
 					createHSYBuildingBarChart()
 
-					if (propsStore.buildingHeatExposure > 27.2632995605) {
+					if ((propsStore.buildingHeatExposure ?? 0) > 27.2632995605) {
 						// The toggle visibility is controlled by whether the building exposure is above a threshold
 						if (!toggleStore.capitalRegionCold) {
 							coldAreaService.loadColdAreas().catch((error) => {

--- a/src/components/HSYScatterplot.vue
+++ b/src/components/HSYScatterplot.vue
@@ -173,24 +173,26 @@ export default {
 				.append('text')
 				.attr('x', 0)
 				.attr('y', (_, i) => i * 40)
-				.each(function (_, i) {
-					// Iterate over each label
+				.each(
+					/** @this {SVGTextElement} */ function (_, i) {
+						// Iterate over each label
 
-					const label = d3.select(this)
-					const labelText = labelsWithAverage[i]
+						const label = d3.select(this)
+						const labelText = labelsWithAverage[i]
 
-					const lines = labelText.split('<br>') // Split the label text by <br>
-					label.text(null) // Clear the original text
+						const lines = labelText.split('<br>') // Split the label text by <br>
+						label.text(null) // Clear the original text
 
-					// Append tspans for each line
-					lines.forEach((line, j) => {
-						label
-							.append('tspan')
-							.attr('x', 10)
-							.attr('dy', `${j + 1}em`) // Adjust vertical offset for each line
-							.text(line)
-					})
-				})
+						// Append tspans for each line
+						lines.forEach((line, j) => {
+							label
+								.append('tspan')
+								.attr('x', 10)
+								.attr('dy', `${j + 1}em`) // Adjust vertical offset for each line
+								.text(line)
+						})
+					}
+				)
 				.style('font-size', '9px')
 		}
 
@@ -225,6 +227,9 @@ export default {
 			return { heatData, labelsWithAverage, values }
 		}
 
+		/**
+		 * @returns {[any[], any[], number, any[]]} [heatList, numericalList, average, ids]
+		 */
 		const addHeatForLabelAndX = (value, features) => {
 			const heatList = []
 			const numericalList = []

--- a/src/components/HSYWMS.vue
+++ b/src/components/HSYWMS.vue
@@ -64,7 +64,7 @@ export default {
 	setup() {
 		const backgroundMapStore = useBackgroundMapStore()
 		const searchQuery = ref('')
-		const filteredLayers = ref([])
+		const filteredLayers = ref(/** @type {{ name: string, title: string }[]} */ ([]))
 		const wmsService = new wms()
 
 		const fetchLayers = async () => {
@@ -117,8 +117,10 @@ export default {
 
 		// Select and switch the WMS layer
 		const selectLayer = async (layerName) => {
-			const store = useGlobalStore()
-			removeLandcover(store.landcoverLayers, store.cesiumViewer)
+			// removeLandcover() reads the viewer + tracked layers from the stores itself;
+			// the previous call passed args (store.landcoverLayers does not exist on the
+			// global store) that were ignored.
+			removeLandcover()
 			await createHSYImageryLayer(layerName)
 			// Clear the filtered layers after selecting
 			filteredLayers.value = []

--- a/src/components/HSYYearSelect.vue
+++ b/src/components/HSYYearSelect.vue
@@ -13,12 +13,10 @@ import { ref, watch } from 'vue'
 import { eventBus } from '../services/eventEmitter.js'
 import { createHSYImageryLayer, removeLandcover } from '../services/landcover'
 import { useBackgroundMapStore } from '../stores/backgroundMapStore.js'
-import { useGlobalStore } from '../stores/globalStore.js'
 
 export default {
 	setup() {
 		const backgroundMapStore = useBackgroundMapStore()
-		const store = useGlobalStore()
 		const yearOptions = [2024, 2022, 2020, 2018, 2016]
 		const selectedYear = ref(2024)
 
@@ -26,7 +24,11 @@ export default {
 			() => selectedYear.value,
 			(newValue) => {
 				backgroundMapStore.setHSYYear(newValue)
-				removeLandcover(store.landcoverLayers, store.cesiumViewer)
+				// removeLandcover() resolves the stores internally and takes no
+				// arguments; the previous call passed stale args (and read a
+				// nonexistent `landcoverLayers` off globalStore — it lives on
+				// backgroundMapStore). Both were silently ignored.
+				removeLandcover()
 				void createHSYImageryLayer()
 				eventBus.emit('recreate piechart')
 			}

--- a/src/components/HeatHistogram.vue
+++ b/src/components/HeatHistogram.vue
@@ -188,7 +188,7 @@ export default {
 		 * @returns {void}
 		 */
 		const createHistogram = () => {
-			const urbanHeatData = propsStore.heatHistogramData
+			const urbanHeatData = /** @type {number[]} */ (propsStore.heatHistogramData ?? [])
 
 			plotService.initializePlotContainerForGrid('heatHistogramContainer')
 
@@ -199,10 +199,13 @@ export default {
 
 			const svg = plotService.createSVGElement(margin, width, height, '#heatHistogramContainer')
 
-			const minDataValue = d3.min(urbanHeatData) - 0.02
-			const maxDataValue = d3.max(urbanHeatData) + 0.02
+			const minDataValue = (d3.min(urbanHeatData) ?? 0) - 0.02
+			const maxDataValue = (d3.max(urbanHeatData) ?? 0) + 0.02
 			const x = plotService.createScaleLinear(minDataValue, maxDataValue, [0, width])
-			const bins = d3.histogram().domain(x.domain()).thresholds(x.ticks(20))(urbanHeatData)
+			const bins = d3
+				.histogram()
+				.domain(/** @type {[number, number]} */ (x.domain()))
+				.thresholds(x.ticks(20))(urbanHeatData)
 			const y = plotService.createScaleLinear(
 				0,
 				d3.max(bins, (d) => d.length),
@@ -228,7 +231,7 @@ export default {
 					svg,
 					`Heat exposure to buildings in ${store.nameOfZone}`,
 					width,
-					margin
+					margin.top
 				)
 			} else {
 				createBars(

--- a/src/components/HeatHistogramHelsinki.vue
+++ b/src/components/HeatHistogramHelsinki.vue
@@ -87,7 +87,7 @@ export default {
 		}
 
 		const createHistogram = () => {
-			const urbanHeatData = propsStore.heatHistogramData
+			const urbanHeatData = /** @type {number[]} */ (propsStore.heatHistogramData ?? [])
 
 			plotService.initializePlotContainer('heatHistogramContainer')
 
@@ -97,10 +97,13 @@ export default {
 
 			const svg = plotService.createSVGElement(margin, width, height, '#heatHistogramContainer')
 
-			const minDataValue = d3.min(urbanHeatData) - 0.02
-			const maxDataValue = d3.max(urbanHeatData) + 0.02
+			const minDataValue = (d3.min(urbanHeatData) ?? 0) - 0.02
+			const maxDataValue = (d3.max(urbanHeatData) ?? 0) + 0.02
 			const x = plotService.createScaleLinear(minDataValue, maxDataValue, [0, width])
-			const bins = d3.histogram().domain(x.domain()).thresholds(x.ticks(20))(urbanHeatData)
+			const bins = d3
+				.histogram()
+				.domain(/** @type {[number, number]} */ (x.domain()))
+				.thresholds(x.ticks(20))(urbanHeatData)
 			const y = plotService.createScaleLinear(
 				0,
 				d3.max(bins, (d) => d.length),
@@ -126,7 +129,11 @@ export default {
 					svg,
 					`Heat exposure to buildings in ${store.nameOfZone}`,
 					width,
-					margin
+					// plot.js's `addTitle` JSDoc declares `top: number`, but every caller
+					// (BuildingTreeChart, VulnerabilityChart, etc.) passes the `margin`
+					// object as the 4th arg. plot.js is out of this batch's scope, so the
+					// runtime value is preserved and cast to satisfy the inaccurate signature.
+					/** @type {number} */ (/** @type {unknown} */ (margin))
 				)
 			} else {
 				createBars(

--- a/src/components/HeatHistogramHelsinki.vue
+++ b/src/components/HeatHistogramHelsinki.vue
@@ -129,11 +129,7 @@ export default {
 					svg,
 					`Heat exposure to buildings in ${store.nameOfZone}`,
 					width,
-					// plot.js's `addTitle` JSDoc declares `top: number`, but every caller
-					// (BuildingTreeChart, VulnerabilityChart, etc.) passes the `margin`
-					// object as the 4th arg. plot.js is out of this batch's scope, so the
-					// runtime value is preserved and cast to satisfy the inaccurate signature.
-					/** @type {number} */ (/** @type {unknown} */ (margin))
+					margin.top
 				)
 			} else {
 				createBars(
@@ -151,7 +147,7 @@ export default {
 					svg,
 					`${store.nameOfZone} ${store.heatDataDate} buildings <a href="https://www.usgs.gov/landsat-missions/landsat-collection-2-surface-temperature" target="_blank">surface temperature</a> in °C`,
 					width - 20,
-					margin
+					margin.top
 				)
 			}
 		}

--- a/src/components/LandcoverToParks.vue
+++ b/src/components/LandcoverToParks.vue
@@ -108,19 +108,34 @@ const statsIndex = computed(() => propsStore.statsIndex)
 const { updateGridColors: restoreGridColoring } = useGridStyling()
 const { getIndexInfo } = useIndexData()
 
+/**
+ * @typedef {Object} CalculationResults
+ * @property {string} area
+ * @property {string} totalCoolingArea
+ * @property {number} neighborsAffected
+ * @property {string} totalReduction
+ * @property {string} selectedIndexName
+ * @property {string} initialIndex
+ * @property {string} newIndex
+ * @property {string} cumulativeCoolingArea
+ * @property {string} cumulativeHeatReduction
+ */
+
 const isSelectingGrid = ref(false)
 const isLoading = ref(false)
 const dataSourceName = 'landcover_for_parks'
 const gridDataSourceName = '250m_grid'
-const selectedGridEntity = shallowRef(null) // Cesium Entity - use shallowRef to prevent deep reactivity
-const originalGridColor = ref(null)
+const selectedGridEntity = shallowRef(/** @type {Cesium.Entity|null} */ (null)) // Cesium Entity - use shallowRef to prevent deep reactivity
+// `any`: holds a Cesium polygon material, which Cesium accepts as either a raw
+// Color or a MaterialProperty (runtime coercion not modeled by its strict types).
+const originalGridColor = ref(/** @type {any} */ (null))
 const landcoverFeaturesLoaded = ref(false)
-const loadedGeoJson = ref(null)
-const loadedLandcoverDataSource = shallowRef(null) // Cesium DataSource - use shallowRef to prevent deep reactivity
-const calculationResults = ref(null)
-const convertedCellIds = ref([])
+const loadedGeoJson = ref(/** @type {{ features: Array<any> }|null} */ (null))
+const loadedLandcoverDataSource = shallowRef(/** @type {Cesium.DataSource|null} */ (null)) // Cesium DataSource - use shallowRef to prevent deep reactivity
+const calculationResults = ref(/** @type {CalculationResults|null} */ (null))
+const convertedCellIds = ref(/** @type {Array<string|number>} */ ([]))
 const modifiedHeatIndices = ref(new Map())
-const convertedParkDataSources = shallowRef([]) // Array of Cesium DataSources - use shallowRef to prevent deep reactivity
+const convertedParkDataSources = shallowRef(/** @type {Array<Cesium.DataSource>} */ ([])) // Array of Cesium DataSources - use shallowRef to prevent deep reactivity
 
 // --- DYNAMIC UI ---
 const primaryButtonText = computed(() => {
@@ -168,7 +183,7 @@ const clearCurrentSelection = () => {
 	}
 
 	const gridDataSource = viewer.value.dataSources.getByName(gridDataSourceName)[0]
-	if (selectedGridEntity.value && originalGridColor.value && gridDataSource) {
+	if (selectedGridEntity.value?.polygon && originalGridColor.value && gridDataSource) {
 		gridDataSource.entities.collectionChanged.removeEventListener(filterGridEntities)
 		selectedGridEntity.value.polygon.material = originalGridColor.value
 		gridDataSource.entities.collectionChanged.addEventListener(filterGridEntities)
@@ -291,7 +306,7 @@ const loadLandcoverData = async (gridId) => {
 
 		if (geojsonData.features.length === 0) {
 			alert(`No convertible landcover features found.`)
-			if (selectedGridEntity.value && originalGridColor.value) {
+			if (selectedGridEntity.value?.polygon && originalGridColor.value) {
 				selectedGridEntity.value.polygon.material = originalGridColor.value
 			}
 			return
@@ -337,6 +352,9 @@ const filterGridEntities = () => {
 const turnToParks = () => {
 	if (!loadedGeoJson.value || !selectedGridEntity.value) return
 
+	// Capture the non-null entity so the narrowing survives inside closures below.
+	const selectedEntity = selectedGridEntity.value
+
 	const totalAreaConverted = loadedGeoJson.value.features.reduce((sum, feature) => {
 		return sum + (feature.properties.area_m2 || 0)
 	}, 0)
@@ -346,12 +364,9 @@ const turnToParks = () => {
 		gridDataSource.entities.collectionChanged.removeEventListener(filterGridEntities)
 
 		const currentIndexInfo = getIndexInfo(statsIndex.value)
-		const sourceGridId = selectedGridEntity.value.properties.grid_id.getValue()
+		const sourceGridId = selectedEntity.properties?.grid_id?.getValue()
 
-		const results = mitigationStore.calculateParksEffect(
-			selectedGridEntity.value,
-			totalAreaConverted
-		)
+		const results = mitigationStore.calculateParksEffect(selectedEntity, totalAreaConverted)
 
 		const entityMap = new Map()
 		for (const entity of gridDataSource.entities.values) {
@@ -375,7 +390,7 @@ const turnToParks = () => {
 				const newColor = getHeatColor(newIdx)
 				entityToColor.polygon.material = newColor
 
-				if (entityToColor.id === selectedGridEntity.value.id) {
+				if (entityToColor.id === selectedEntity.id) {
 					originalGridColor.value = newColor
 				}
 			}
@@ -385,7 +400,7 @@ const turnToParks = () => {
 
 		const initialIndexForDisplay = modifiedHeatIndices.value.has(sourceGridId)
 			? modifiedHeatIndices.value.get(sourceGridId) + results.sourceReduction
-			: selectedGridEntity.value.properties.final_avg_conditional.getValue()
+			: selectedEntity.properties?.final_avg_conditional?.getValue()
 
 		calculationResults.value = {
 			area: (totalAreaConverted / 10000).toFixed(2),
@@ -407,7 +422,9 @@ const turnToParks = () => {
 		const dataSourceToConvert = loadedLandcoverDataSource.value
 		for (const entity of dataSourceToConvert.entities.values) {
 			if (entity.polygon) {
-				entity.polygon.material = Cesium.Color.FORESTGREEN.withAlpha(0.8)
+				entity.polygon.material = new Cesium.ColorMaterialProperty(
+					Cesium.Color.FORESTGREEN.withAlpha(0.8)
+				)
 			}
 		}
 		convertedParkDataSources.value.push(dataSourceToConvert)

--- a/src/components/Layers.vue
+++ b/src/components/Layers.vue
@@ -279,7 +279,7 @@ export default {
 				// If there is a postal code available, load the nature areas for that area.
 				if (store.postalcode && !dataSourceService.getDataSourceByName('Vegetation')) {
 					const vegetationService = new Vegetation()
-					vegetationService.loadVegetation(store.postalcode).catch((error) => {
+					vegetationService.loadVegetation().catch((error) => {
 						logger.error('[Layers] Failed to load vegetation:', error)
 						store.showError(
 							'Unable to load vegetation data.',
@@ -336,7 +336,7 @@ export default {
 			if (layer === 'ndvi') {
 				landCover.value = false
 				toggleStore.setLandCover(false)
-				removeLandcover(store.landcoverLayers, store.cesiumViewer)
+				removeLandcover()
 			} else if (layer === 'landcover') {
 				ndvi.value = false
 				toggleStore.setNDVI(false)

--- a/src/components/LoadingIndicator.vue
+++ b/src/components/LoadingIndicator.vue
@@ -221,7 +221,7 @@ const props = defineProps({
 	mode: {
 		type: String,
 		default: 'overlay', // 'overlay', 'compact', 'both'
-		validator: (value) => ['overlay', 'compact', 'both'].includes(value),
+		validator: (/** @type {string} */ value) => ['overlay', 'compact', 'both'].includes(value),
 	},
 	showPerformanceInfo: {
 		type: Boolean,

--- a/src/components/MapClickLoadingOverlay.vue
+++ b/src/components/MapClickLoadingOverlay.vue
@@ -123,7 +123,7 @@ export default {
 		// Reactive computed properties from store state
 		const isVisible = computed(() => store.clickProcessingState.isProcessing)
 		const postalCodeName = computed(() => store.clickProcessingState.postalCodeName || 'Loading...')
-		const stage = computed(() => store.clickProcessingState.stage)
+		const stage = computed(() => /** @type {string|null} */ (store.clickProcessingState.stage))
 		const canCancel = computed(() => store.clickProcessingState.canCancel)
 		const error = computed(() => store.clickProcessingState.error)
 

--- a/src/components/MapControls.vue
+++ b/src/components/MapControls.vue
@@ -148,7 +148,7 @@ const hideLow = ref(toggleStore.hideLow)
  */
 const helsinkiView = computed(() => toggleStore.helsinkiView)
 const view = computed(() => store.view)
-const postalCode = computed(() => store.postalcode)
+const postalCode = computed(() => store.postalcode ?? undefined)
 
 /**
  * Detects if NDVI and Land Cover are both active
@@ -176,7 +176,10 @@ const disableOtherLayer = (layer) => {
 	if (layer === 'ndvi') {
 		landCover.value = false
 		toggleStore.setLandCover(false)
-		removeLandcover(store.landcoverLayers, store.cesiumViewer)
+		// removeLandcover() reads its layers from backgroundMapStore internally and
+		// takes no arguments; the previous call passed a non-existent
+		// store.landcoverLayers (undefined) which was silently ignored.
+		removeLandcover()
 	} else if (layer === 'landcover') {
 		ndvi.value = false
 		toggleStore.setNDVI(false)
@@ -209,7 +212,8 @@ const loadVegetation = async () => {
 
 			try {
 				const vegetationService = new Vegetation()
-				await vegetationService.loadVegetation(store.postalcode)
+				// loadVegetation() reads postalcode from the global store internally; no arg needed.
+				await vegetationService.loadVegetation()
 				loadingStore.completeLayerLoading('vegetation', true)
 			} catch (error) {
 				loadingStore.setLayerError('vegetation', error.message || 'Failed to load vegetation data')
@@ -284,7 +288,12 @@ const loadTrees = async () => {
 								loadingStore.updateLayerProgress(
 									'trees',
 									completedCategories,
-									`Loading trees: category ${category} (${completedCategories}/4)`
+									// FLAG: loadingStore.updateLayerProgress's `message = null` default makes
+									// its param infer as `null`; passing a real string message requires a cast
+									// until the store's type is widened to `string | null` (store edits are out of scope here).
+									/** @type {any} */ (
+										`Loading trees: category ${category} (${completedCategories}/4)`
+									)
 								)
 
 								if (completedCategories === 4) {

--- a/src/components/NDVIChart.vue
+++ b/src/components/NDVIChart.vue
@@ -78,14 +78,15 @@ export default {
 			if (!postCodesDataSource) return
 
 			postCodesDataSource.entities.values.forEach((entity) => {
-				const ndviValue = entity.properties[`ndvi_${props.selectedDate}`]?.getValue()
+				if (!entity.polygon) return
+				const ndviValue = entity.properties?.[`ndvi_${props.selectedDate}`]?.getValue()
 
 				if (ndviValue >= ndviRange[0] && ndviValue < ndviRange[1]) {
-					entity.polygon.outlineColor = Cesium.Color.WHITE
-					entity.polygon.outlineWidth = 20
+					entity.polygon.outlineColor = new Cesium.ConstantProperty(Cesium.Color.WHITE)
+					entity.polygon.outlineWidth = new Cesium.ConstantProperty(20)
 				} else {
-					entity.polygon.outlineColor = Cesium.Color.BLACK
-					entity.polygon.outlineWidth = 8
+					entity.polygon.outlineColor = new Cesium.ConstantProperty(Cesium.Color.BLACK)
+					entity.polygon.outlineWidth = new Cesium.ConstantProperty(8)
 				}
 			})
 		}
@@ -116,7 +117,7 @@ export default {
 				.data(bins)
 				.enter()
 				.append('rect')
-				.attr('x', (_, i) => xScale(labels[i]))
+				.attr('x', (_, i) => xScale(labels[i]) ?? 0)
 				.attr('y', (d) => yScale(d))
 				.attr('width', xScale.bandwidth())
 				.attr('height', (d) => height - margin.bottom - yScale(d))

--- a/src/components/NearbyTreeArea.vue
+++ b/src/components/NearbyTreeArea.vue
@@ -115,6 +115,7 @@
 
 <script>
 import { computed } from 'vue'
+/** @typedef {import('vue').CSSProperties} CSSProperties */
 import * as d3 from '@/utils/d3' // Import D3.js
 import { useSidebarOffset } from '../composables/useSidebarOffset'
 import Building from '../services/building.js'
@@ -130,34 +131,44 @@ export default {
 	setup() {
 		const { sidebarOffset } = useSidebarOffset(0)
 
-		const labelStyle = computed(() => ({
-			position: 'fixed',
-			bottom: '41px',
-			left: `${sidebarOffset.value + 15}px`,
-			visibility: 'hidden',
-		}))
+		const labelStyle = computed(
+			() =>
+				/** @type {CSSProperties} */ ({
+					position: 'fixed',
+					bottom: '41px',
+					left: `${sidebarOffset.value + 15}px`,
+					visibility: 'hidden',
+				})
+		)
 
-		const barsStyle = computed(() => ({
-			left: `${sidebarOffset.value - 19}px`,
-		}))
+		const barsStyle = computed(
+			() =>
+				/** @type {CSSProperties} */ ({
+					left: `${sidebarOffset.value - 19}px`,
+				})
+		)
 
-		const switchStyle = (baseLeft) =>
-			computed(() => ({
-				left: `${sidebarOffset.value + baseLeft}px`,
-			}))
+		/**
+		 * @param {number} baseLeft
+		 * @returns {CSSProperties}
+		 */
+		const switchStyle = (baseLeft) => ({
+			left: `${sidebarOffset.value + baseLeft}px`,
+		})
 
 		return { sidebarOffset, labelStyle, barsStyle, switchStyle }
 	},
 	data() {
 		return {
+			/** @type {Array<() => void>} */
 			eventCleanupFunctions: [],
+			store: useGlobalStore(),
+			toggleStore: useToggleStore(),
+			plotService: new Plot(),
 		}
 	},
 	mounted() {
-		this.unsubscribe = eventBus.on('newNearbyTreeDiagram', this.newNearbyTreeDiagram)
-		this.store = useGlobalStore()
-		this.toggleStore = useToggleStore()
-		this.plotService = new Plot()
+		eventBus.on('newNearbyTreeDiagram', this.newNearbyTreeDiagram)
 	},
 	beforeUnmount() {
 		eventBus.off('newNearbyTreeDiagram')
@@ -171,17 +182,22 @@ export default {
 			setupBearingSwitches(this.store.postalcode, this)
 
 			if (this.store.level === 'postalCode') {
-				this.plotService.hideScatterPlot()
+				// hideScatterPlot() never existed on the Plot service (latent bug since
+				// the feature was added); hideAllPlots() is the equivalent method.
+				this.plotService.hideAllPlots()
+
+				// Required serializable datasets must be present before plotting
+				const treeBuildingDistanceData = propsStore.treeBuildingDistanceData
+				const treeData = propsStore.treeData
+				const buildingData = propsStore.buildingData
+				if (!treeBuildingDistanceData || !treeData || !buildingData) {
+					return
+				}
+
 				// Call function that combines datasets for plotting
 				// Use serializable data from store + cesiumEntityManager for visual mutations
-				const sumPAlaM2Map = this.combineDistanceAndTreeData(
-					propsStore.treeBuildingDistanceData,
-					propsStore.treeData
-				)
-				const heatExpTreeArea = this.createTreeBuildingPlotMap(
-					sumPAlaM2Map,
-					propsStore.buildingData
-				)
+				const sumPAlaM2Map = this.combineDistanceAndTreeData(treeBuildingDistanceData, treeData)
+				const heatExpTreeArea = this.createTreeBuildingPlotMap(sumPAlaM2Map, buildingData)
 				const heatExpAverageTreeArea = this.extractKeysAndAverageTreeArea(heatExpTreeArea)
 				this.createTreesNearbyBuildingsPlot(
 					heatExpAverageTreeArea[0],
@@ -269,17 +285,19 @@ export default {
 					const entity = cesiumEntityManager.getBuildingEntity(building_id)
 					if (entity) {
 						// Set tree_area as a property of the entity using proper Cesium Property API
-						if (!entity.properties.hasProperty('treeArea')) {
-							entity.properties.addProperty('treeArea')
+						if (entity.properties) {
+							if (!entity.properties.hasProperty('treeArea')) {
+								entity.properties.addProperty('treeArea')
+							}
+							entity.properties.treeArea = new Cesium.ConstantProperty(tree_area)
 						}
-						entity.properties.treeArea = new Cesium.ConstantProperty(tree_area)
 
 						if (tree_area > 225) {
 							// Highlight the building entity edges by changing its outlineColor and outlineWidth
 							if (entity.polygon) {
-								entity.polygon.outline = true // Enable outline
-								entity.polygon.outlineColor = Cesium.Color.CHARTREUSE // Set outline color to green
-								entity.polygon.outlineWidth = 20 // Set outline width to 3 (adjust as needed)
+								entity.polygon.outline = new Cesium.ConstantProperty(true) // Enable outline
+								entity.polygon.outlineColor = new Cesium.ConstantProperty(Cesium.Color.CHARTREUSE) // Set outline color to green
+								entity.polygon.outlineWidth = new Cesium.ConstantProperty(20) // Set outline width
 							}
 
 							if (maxTreeArea < tree_area) {
@@ -316,8 +334,8 @@ export default {
 			const entity = cesiumEntityManager.getBuildingEntity(entityId)
 
 			if (entity?.polygon) {
-				entity.polygon.material = Cesium.Color.FORESTGREEN
-				entity.polygon.outlineColor = Cesium.Color.RED // Set outline color to red
+				entity.polygon.material = new Cesium.ColorMaterialProperty(Cesium.Color.FORESTGREEN)
+				entity.polygon.outlineColor = new Cesium.ConstantProperty(Cesium.Color.RED) // Set outline color to red
 			}
 		},
 
@@ -356,9 +374,9 @@ export default {
 						// Update visual properties via cesiumEntityManager
 						const entity = cesiumEntityManager.getTreeEntity(tree_id)
 						if (entity?.polygon) {
-							entity.polygon.outline = true // Enable outline
-							entity.polygon.outlineColor = Cesium.Color.CHARTREUSE // Set outline color to green
-							entity.polygon.outlineWidth = 20 // Set outline width to 3 (adjust as needed)
+							entity.polygon.outline = new Cesium.ConstantProperty(true) // Enable outline
+							entity.polygon.outlineColor = new Cesium.ConstantProperty(Cesium.Color.CHARTREUSE) // Set outline color to green
+							entity.polygon.outlineWidth = new Cesium.ConstantProperty(20) // Set outline width
 						}
 
 						// Aggregate tree area by building
@@ -378,7 +396,7 @@ export default {
 		 * Check if the bearing value is according to user select value
 		 *
 		 * @param { Number } bearing - The bearing of tree to building
-		 * @param { String } selectedBearingValue - The selected bearing value by user
+		 * @param { String | null } selectedBearingValue - The selected bearing value by user (null when no bearing switch is active)
 		 *
 		 * @return { Boolean }
 		 */
@@ -409,6 +427,8 @@ export default {
 				default:
 					return false
 			}
+
+			return false
 		},
 
 		createBarsForTreeChart(
@@ -456,9 +476,11 @@ export default {
 
 			for (const direction of switches) {
 				const switchContainer = document.getElementById(`bearing${direction}SwitchContainer`)
-				const toggle = switchContainer.querySelector(`#bearing${direction}Toggle`)
+				const toggle = /** @type {HTMLInputElement | null} */ (
+					switchContainer?.querySelector(`#bearing${direction}Toggle`) ?? null
+				)
 
-				if (toggle.checked) {
+				if (toggle?.checked) {
 					return toggle.value
 				}
 			}
@@ -473,7 +495,8 @@ export default {
 		 * @param { Array<Number> } tree_areas array cointainig buildings nearby tree area
 		 * @param { Array<Number> } counts array cointainig count of buildings for that heat exposure
 		 */
-		createTreesNearbyBuildingsPlot(heatexps, tree_areas) {
+		createTreesNearbyBuildingsPlot(heatexps, tree_areas, counts) {
+			void counts // documented/passed for parity; not used in the current bar plot
 			this.plotService.initializePlotContainer('nearbyTreeAreaContainer')
 
 			if (tree_areas.length > 0) {
@@ -513,7 +536,7 @@ export default {
 					svg,
 					'Nearby Tree Area of Buildings with Heat Exposure',
 					width,
-					margin
+					margin.top
 				)
 			}
 		},
@@ -531,7 +554,12 @@ const setupBearingSwitches = (postalcode, componentInstance) => {
 
 	for (const currentDirection of switches) {
 		const switchContainer = document.getElementById(`bearing${currentDirection}SwitchContainer`)
-		const toggle = switchContainer.querySelector(`#bearing${currentDirection}Toggle`)
+		const toggle = /** @type {HTMLInputElement | null} */ (
+			switchContainer?.querySelector(`#bearing${currentDirection}Toggle`) ?? null
+		)
+		if (!toggle) {
+			continue
+		}
 
 		const handler = () => {
 			updateBearingSwitches(switches, currentDirection)
@@ -560,8 +588,12 @@ const updateBearingSwitches = (switches, currentDirection) => {
 			const otherSwitchContainer = document.getElementById(
 				`bearing${otherDirection}SwitchContainer`
 			)
-			const otherToggle = otherSwitchContainer.querySelector(`#bearing${otherDirection}Toggle`)
-			otherToggle.checked = false
+			const otherToggle = /** @type {HTMLInputElement | null} */ (
+				otherSwitchContainer?.querySelector(`#bearing${otherDirection}Toggle`) ?? null
+			)
+			if (otherToggle) {
+				otherToggle.checked = false
+			}
 		}
 	}
 }

--- a/src/components/PieChart.vue
+++ b/src/components/PieChart.vue
@@ -19,7 +19,10 @@ const propsStore = usePropsStore()
 
 const createPieChart = () => {
 	const datasource = propsStore.postalCodeData
-	const nameOfZone = globalStore.nameOfZone._value
+	// nameOfZone is stored as a plain string (already unwrapped from the Cesium
+	// property's ._value at the call site in featurepicker). Reading ._value here
+	// was a bug that yielded undefined; use the value directly with a null guard.
+	const nameOfZone = globalStore.nameOfZone ?? ''
 	const year = backgroundMapStore.hsyYear
 	const area = backgroundMapStore.hsySelectArea
 
@@ -66,8 +69,10 @@ const createPieChart = () => {
 	const height = 220 - margin.top - margin.bottom
 	const radius = Math.min(width, height) / 3 // Adjust as needed
 
-	const pie = d3
-		.pie()
+	/**
+	 * @typedef {{ value: number, label: string, zone: string }} PieDatum
+	 */
+	const pie = /** @type {import('d3').Pie<any, PieDatum>} */ (/** @type {unknown} */ (d3.pie()))
 		.sort(null)
 		.value((d) => d.value)
 	const arc = d3.arc().innerRadius(0).outerRadius(radius)
@@ -130,7 +135,7 @@ const clearPieChart = () => {
 /**
  * Get total area of district properties by district data source name and district id and list of property keys
  *
- * @param { Number } id Id of the district
+ * @param { string } name Name of the district
  * @param { Array } propertyKeys - List of property keys to calculate the total area
  * @param { Number } year user selected year
  * @param { Object } datasource postalcode datasource

--- a/src/components/PostalCodePicker.vue
+++ b/src/components/PostalCodePicker.vue
@@ -263,8 +263,9 @@ export default {
 
 		// Reset selection
 		const resetSelection = () => {
-			globalStore.setPostalCode(null)
-			globalStore.setNameOfZone(null)
+			// Store setters accept null at runtime to clear selection (state is string|null).
+			globalStore.setPostalCode(/** @type {string} */ (/** @type {unknown} */ (null)))
+			globalStore.setNameOfZone(/** @type {string} */ (/** @type {unknown} */ (null)))
 			globalStore.setLevel('start')
 			searchQuery.value = ''
 

--- a/src/components/PostalCodeView.vue
+++ b/src/components/PostalCodeView.vue
@@ -247,6 +247,7 @@ import Tree from '../services/tree.js'
 import Vegetation from '../services/vegetation.js'
 import { useGlobalStore } from '../stores/globalStore.js'
 import { useToggleStore } from '../stores/toggleStore.js'
+import { useURLStore } from '../stores/urlStore.js'
 import logger from '../utils/logger.js'
 
 // Sidebar offset for navigation drawer awareness
@@ -255,6 +256,7 @@ const { offsetStyle } = useSidebarOffset(24)
 // Stores
 const store = useGlobalStore()
 const toggleStore = useToggleStore()
+const urlStore = useURLStore()
 
 // Services
 const dataSourceService = new Datasource()
@@ -294,8 +296,11 @@ const reset = () => {
 
 	// Smart reset instead of page reload
 	store.setLevel('start')
-	store.setPostalCode(null)
-	store.setNameOfZone(null)
+	// Clear selection by direct assignment: the setters are JSDoc-typed for
+	// `string`, but the state fields are `string | null` and resetting to null
+	// is the intended behavior (same runtime effect as the setters).
+	store.postalcode = null
+	store.nameOfZone = null
 	store.setView('capitalRegion')
 
 	// Reset camera to initial position
@@ -401,7 +406,7 @@ const loadOtherNatureEvent = () => {
 	if (showOtherNature.value) {
 		if (store.postalcode && !dataSourceService.getDataSourceByName('OtherNature')) {
 			const otherNatureService = new Othernature()
-			otherNatureService.loadOtherNature(store.postalcode).catch((error) => {
+			otherNatureService.loadOtherNature().catch((error) => {
 				logger.error('Failed to load other nature data:', error)
 			})
 		} else {
@@ -420,7 +425,7 @@ const loadVegetationEvent = () => {
 	if (showVegetation.value) {
 		if (store.postalcode && !dataSourceService.getDataSourceByName('Vegetation')) {
 			const vegetationService = new Vegetation()
-			vegetationService.loadVegetation(store.postalcode).catch((error) => {
+			vegetationService.loadVegetation().catch((error) => {
 				logger.error('Failed to load vegetation data:', error)
 			})
 		} else {
@@ -477,14 +482,16 @@ const loadAllEnvironmentalLayers = async () => {
 		return
 	}
 
+	const postalcode = store.postalcode
+
 	try {
-		const sessionId = `environmental_${store.postalcode}`
+		const sessionId = `environmental_${postalcode}`
 
 		// Define layer configurations for coordinated loading
 		const layerConfigs = [
 			{
 				layerId: 'vegetation',
-				url: store.urlStore?.vegetation(store.postalcode),
+				url: urlStore.vegetation(postalcode),
 				type: 'geojson',
 				processor: (data, metadata) => {
 					const vegetationService = new Vegetation()
@@ -500,7 +507,7 @@ const loadAllEnvironmentalLayers = async () => {
 			},
 			{
 				layerId: 'othernature',
-				url: store.urlStore?.otherNature(store.postalcode),
+				url: urlStore.otherNature(postalcode),
 				type: 'geojson',
 				processor: (data, metadata) => {
 					const otherNatureService = new Othernature()

--- a/src/components/PrintBox.vue
+++ b/src/components/PrintBox.vue
@@ -19,7 +19,7 @@ export default {
 			const entity = store.pickedEntity
 
 			if (entity?._polygon && entity?.properties) {
-				document.getElementById('printContainer').scroll({
+				document.getElementById('printContainer')?.scroll({
 					top: 0,
 					behavior: 'instant',
 				})
@@ -38,6 +38,10 @@ export default {
 
 		const geocodingPrint = () => {
 			const store = useGlobalStore()
+			// store.postalcode is `string | null`; nothing to look up when null
+			if (!store.postalcode) {
+				return
+			}
 			// O(1) lookup using postal code index
 			const entity = postalCodeIndex.getByPostalCode(store.postalcode)
 			if (entity) {
@@ -47,6 +51,9 @@ export default {
 
 		const printEntity = (entity, postno, view) => {
 			const container = document.getElementById('printContainer')
+			if (!container) {
+				return
+			}
 
 			// Clear existing content safely
 			container.textContent = ''
@@ -105,6 +112,9 @@ export default {
 
 		const addFooterNote = (_postno, _view) => {
 			const container = document.getElementById('printContainer')
+			if (!container) {
+				return
+			}
 
 			if (store.heatDataDate === '2023-06-23') {
 				container.appendChild(document.createElement('br'))

--- a/src/components/Scatterplot.vue
+++ b/src/components/Scatterplot.vue
@@ -7,7 +7,6 @@
 	<select
 		ref="numericalSelect"
 		v-model="numericalValue"
-		value="numerical"
 	>
 		<option value="measured_height">height</option>
 		<option value="c_valmpvm">age</option>
@@ -18,7 +17,6 @@
 	<select
 		ref="categoricalSelect"
 		v-model="categoricalValue"
-		value="categorical"
 	>
 		<option value="c_julkisivu">facade material</option>
 		<option value="c_rakeaine">building material</option>
@@ -48,6 +46,18 @@ export default {
 			// Vue reactive properties for dropdown selections
 			numericalValue: 'measured_height',
 			categoricalValue: 'c_julkisivu',
+			// Non-reactive service/store handles assigned in mounted() before any
+			// method runs. Declared here so the component instance type knows about
+			// them; the `(null)` placeholder is cast because the real value is set
+			// in mounted() prior to first use.
+			/** @type {ReturnType<typeof useGlobalStore>} */
+			store: /** @type {any} */ (null),
+			/** @type {ReturnType<typeof useToggleStore>} */
+			toggleStore: /** @type {any} */ (null),
+			/** @type {Plot} */
+			plotService: /** @type {any} */ (null),
+			/** @type {(() => void) | null} */
+			unsubscribe: null,
 		}
 	},
 	watch: {
@@ -63,8 +73,12 @@ export default {
 		this.toggleStore = useToggleStore()
 		this.plotService = new Plot()
 
-		// Subscribe to eventBus updates
-		this.unsubscribe = eventBus.on('updateScatterPlot', () => this.selectAttributeForScatterPlot())
+		// Subscribe to eventBus updates. mitt's `on()` returns void, so build an
+		// explicit unsubscribe closure that calls `off()` with the same handler
+		// (otherwise the listener would never be removed on unmount).
+		const handler = () => this.selectAttributeForScatterPlot()
+		eventBus.on('updateScatterPlot', handler)
+		this.unsubscribe = () => eventBus.off('updateScatterPlot', handler)
 
 		this.newScatterPlot()
 	},
@@ -95,8 +109,8 @@ export default {
 			// Create a scatter plot with the updated data
 			this.createScatterPlot(
 				urbanHeatDataAndMaterial,
-				this.getSelectedText('categoricalSelect'),
-				this.getSelectedText('numericalSelect')
+				this.getSelectedText('categoricalSelect') ?? '',
+				this.getSelectedText('numericalSelect') ?? ''
 			)
 		},
 		/**
@@ -109,7 +123,7 @@ export default {
 			const categorical = this.categoricalValue
 			const hideNonSote = this.toggleStore.hideNonSote
 			const hideLowToggle = this.toggleStore.hideLow
-			const hideNew = this.toggleStore.hideNew
+			const hideNew = this.toggleStore.hideNewBuildings
 			// Get entities from cesiumEntityManager instead of propsStore
 			const entities = cesiumEntityManager.getAllBuildingEntities()
 
@@ -120,8 +134,8 @@ export default {
 					this.addDataForScatterPlot(
 						urbanHeatDataAndMaterial,
 						entity,
-						this.getSelectedText('categoricalSelect'),
-						this.getSelectedText('numericalSelect'),
+						this.getSelectedText('categoricalSelect') ?? '',
+						this.getSelectedText('numericalSelect') ?? '',
 						categorical,
 						numerical
 					)
@@ -142,8 +156,8 @@ export default {
 						this.addDataForScatterPlot(
 							urbanHeatDataAndMaterial,
 							entity,
-							this.getSelectedText('categoricalSelect'),
-							this.getSelectedText('numericalSelect'),
+							this.getSelectedText('categoricalSelect') ?? '',
+							this.getSelectedText('numericalSelect') ?? '',
 							categorical,
 							numerical
 						)
@@ -177,10 +191,11 @@ export default {
 		/**
 		 * This function creates a data set required for scatter plotting urban heat exposure.
 		 *
-		 * @param { Object } features buildings in postal code area
+		 * @param { Array } urbanHeatDataAndMaterial array to append scatter plot data to
+		 * @param { Object } entity building entity in postal code area
 		 * @param { String } categorical name of categorical attribute displayed for user
 		 * @param { String } numerical name of numerical attribute displayed for user
-		 * @param { String } categoricalName name of numerical attribute in register
+		 * @param { String } categoricalName name of categorical attribute in register
 		 * @param { String } numericalName name of numerical attribute in registery
 		 */
 		addDataForScatterPlot(
@@ -227,10 +242,10 @@ export default {
 		 * Returns the selected text of a dropdown menu using Vue refs.
 		 *
 		 * @param { string } refName - The name of the Vue ref ('numericalSelect' or 'categoricalSelect')
-		 * @returns { string } The selected text of the dropdown menu, or null if no option is selected.
+		 * @returns { string | null } The selected text of the dropdown menu, or null if no option is selected.
 		 */
 		getSelectedText(refName) {
-			const elt = this.$refs[refName]
+			const elt = /** @type {HTMLSelectElement | undefined} */ (this.$refs[refName])
 
 			if (!elt || elt.selectedIndex === -1) {
 				return null
@@ -296,7 +311,7 @@ export default {
 		 */
 		initializePlotContainer() {
 			// Use Vue ref for direct DOM access (maintains component encapsulation)
-			const container = this.$refs.containerRef
+			const container = /** @type {HTMLElement | undefined} */ (this.$refs.containerRef)
 			if (container) {
 				// Use textContent for safe clearing (prevents potential XSS)
 				container.textContent = ''
@@ -479,7 +494,9 @@ export default {
 			// Remove or clear the D3.js visualization using Vue ref
 			// Using D3.js on the ref value maintains Vue encapsulation
 			if (this.$refs.containerRef) {
-				d3.select(this.$refs.containerRef).select('svg').remove()
+				d3.select(/** @type {HTMLElement} */ (this.$refs.containerRef))
+					.select('svg')
+					.remove()
 			}
 		},
 	},

--- a/src/components/SocioEconomicsChart.vue
+++ b/src/components/SocioEconomicsChart.vue
@@ -34,6 +34,10 @@ export default {
 		})
 
 		const newSocioEconomicsDiagram = () => {
+			// globalStore.postalcode is `string | null`; nothing to chart when null
+			if (!globalStore.postalcode) {
+				return
+			}
 			const dataForPostcode = socioEconomicsStore.getDataByPostcode(globalStore.postalcode)
 			const statsData = findSocioEconomicsStats()
 			createSocioEconomicsDiagram(dataForPostcode, statsData)
@@ -77,33 +81,41 @@ export default {
 		}
 
 		const wrapText = (text, width) => {
-			text.each(function () {
-				const text = d3.select(this)
-				const words = text.text().split(/\s+/).reverse()
-				let word
-				let line = []
-				let lineNumber = 0
-				const lineHeight = 1.1 // ems
-				const y = text.attr('y')
-				const dy = parseFloat(text.attr('dy'))
-				let tspan = text.text(null).append('tspan').attr('x', 0).attr('y', y).attr('dy', `${dy}em`)
+			text.each(
+				/** @this {SVGTextElement} */ function () {
+					const text = d3.select(this)
+					const words = text.text().split(/\s+/).reverse()
+					let word
+					let line = []
+					let lineNumber = 0
+					const lineHeight = 1.1 // ems
+					const y = text.attr('y')
+					const dy = parseFloat(text.attr('dy'))
+					let tspan = text
+						.text(null)
+						.append('tspan')
+						.attr('x', 0)
+						.attr('y', y)
+						.attr('dy', `${dy}em`)
 
-				while ((word = words.pop())) {
-					line.push(word)
-					tspan.text(line.join(' '))
-					if (tspan.node().getComputedTextLength() > width) {
-						line.pop()
+					while ((word = words.pop())) {
+						line.push(word)
 						tspan.text(line.join(' '))
-						line = [word]
-						tspan = text
-							.append('tspan')
-							.attr('x', 0)
-							.attr('y', y)
-							.attr('dy', `${++lineNumber * lineHeight + dy}em`)
-							.text(word)
+						const node = tspan.node()
+						if (node && node.getComputedTextLength() > width) {
+							line.pop()
+							tspan.text(line.join(' '))
+							line = [word]
+							tspan = text
+								.append('tspan')
+								.attr('x', 0)
+								.attr('y', y)
+								.attr('dy', `${++lineNumber * lineHeight + dy}em`)
+								.text(word)
+						}
 					}
 				}
-			})
+			)
 		}
 
 		const createBars = (svg, data, xScale, yScale, height, tooltip, xOffset, barColor, name) => {
@@ -172,7 +184,7 @@ export default {
 				const selectedNimi = propsStore.socioEconomics
 				const compareData = socioEconomicsStore.getDataByNimi(selectedNimi)
 				const heatData = toggleStore.capitalRegionCold
-					? 1 - globalStore.averageHeatExposure.toFixed(3) // Use cold exposure data if cold toggle is active
+					? 1 - Number(globalStore.averageHeatExposure.toFixed(3)) // Use cold exposure data if cold toggle is active
 					: globalStore.averageHeatExposure.toFixed(3) // Use heat exposure data
 
 				const yValues = calculateYValues(sosData, statsData, heatData)
@@ -250,11 +262,18 @@ export default {
 				(totalEldery / data.he_vakiy).toFixed(3),
 				(data.pt_tyott / data.he_vakiy).toFixed(3),
 				1 -
-					normalizeValue(data.ra_as_kpa, statsData.ra_as_kpa.min, statsData.ra_as_kpa.max).toFixed(
-						3
+					Number(
+						normalizeValue(
+							data.ra_as_kpa,
+							statsData.ra_as_kpa.min,
+							statsData.ra_as_kpa.max
+						).toFixed(3)
 					),
 				(data.ko_perus / data.ko_ika18y).toFixed(3),
-				1 - normalizeValue(data.hr_ktu, statsData.hr_ktu.min, statsData.hr_ktu.max).toFixed(3),
+				1 -
+					Number(
+						normalizeValue(data.hr_ktu, statsData.hr_ktu.min, statsData.hr_ktu.max).toFixed(3)
+					),
 				(data.te_vuok_as / data.te_taly).toFixed(3),
 			]
 		}

--- a/src/components/SocioEconomicsChart.vue
+++ b/src/components/SocioEconomicsChart.vue
@@ -185,7 +185,7 @@ export default {
 				const compareData = socioEconomicsStore.getDataByNimi(selectedNimi)
 				const heatData = toggleStore.capitalRegionCold
 					? 1 - Number(globalStore.averageHeatExposure.toFixed(3)) // Use cold exposure data if cold toggle is active
-					: globalStore.averageHeatExposure.toFixed(3) // Use heat exposure data
+					: Number(globalStore.averageHeatExposure.toFixed(3)) // Use heat exposure data
 
 				const yValues = calculateYValues(sosData, statsData, heatData)
 				// Guard: compareData may be undefined when getDataByNimi finds no

--- a/src/components/SocioEconomicsSelect.vue
+++ b/src/components/SocioEconomicsSelect.vue
@@ -20,8 +20,8 @@ export default {
 		const socioEconomicsStore = useSocioEconomicsStore()
 		const toggleStore = useToggleStore()
 		const propsStore = usePropsStore()
-		const selectedArea = ref('')
-		const areaOptions = ref([])
+		const selectedArea = ref(/** @type {string} */ (''))
+		const areaOptions = ref(/** @type {string[]} */ ([]))
 
 		// Populate the select options based on 'nimi' attribute of socioEconomics store
 		const populateSelectFromStore = () => {

--- a/src/components/SurveyScatterPlot.vue
+++ b/src/components/SurveyScatterPlot.vue
@@ -12,21 +12,29 @@ import { eventBus } from '../services/eventEmitter.js'
 import Plot from '../services/plot.js'
 import { useGlobalStore } from '../stores/globalStore'
 
+/**
+ * Building entity as produced by cesiumEntityManager, accessed via the
+ * internal `_properties` backing object at runtime.
+ * @typedef {Object} SurveyEntity
+ * @property {{ Paikan_kok: number, avg_temp_c: number }} _properties
+ */
+
 export default {
 	data() {
 		return {
-			unsubscribeNewPlot: null,
-			unsubscribeHide: null,
+			/** @type {Plot | null} */
+			plotService: null,
 		}
 	},
 	mounted() {
-		this.unsubscribeNewPlot = eventBus.on('newSurveyScatterPlot', this.newSurveyScatterPlot)
-		this.unsubscribeHide = eventBus.on('hideSurveyScatterPlot', this.hideScatterPlot)
+		// mitt's `on` returns void; remove listeners explicitly via `off` on unmount.
+		eventBus.on('newSurveyScatterPlot', this.newSurveyScatterPlot)
+		eventBus.on('hideSurveyScatterPlot', this.hideScatterPlot)
 		this.plotService = new Plot()
 	},
 	beforeUnmount() {
-		if (this.unsubscribeNewPlot) this.unsubscribeNewPlot()
-		if (this.unsubscribeHide) this.unsubscribeHide()
+		eventBus.off('newSurveyScatterPlot', this.newSurveyScatterPlot)
+		eventBus.off('hideSurveyScatterPlot', this.hideScatterPlot)
 	},
 	methods: {
 		newSurveyScatterPlot() {
@@ -42,14 +50,21 @@ export default {
 		 * Hide the scatter plot using Vue ref (proper component encapsulation)
 		 */
 		hideScatterPlot() {
-			if (this.$refs.containerRef) {
-				this.$refs.containerRef.style.visibility = 'hidden'
+			const container = /** @type {HTMLElement | undefined} */ (this.$refs.containerRef)
+			if (container) {
+				container.style.visibility = 'hidden'
 			}
 		},
 
 		createSurveyScatterPlot() {
+			if (!this.plotService) return
+			// Capture in a non-null local so the deferred d3 .on() callbacks below
+			// (where `this.plotService` narrowing no longer applies) stay type-safe.
+			const plotService = this.plotService
 			// Get entities from cesiumEntityManager instead of propsStore
-			const entities = cesiumEntityManager.getAllBuildingEntities()
+			const entities = /** @type {SurveyEntity[]} */ (
+				/** @type {unknown} */ (cesiumEntityManager.getAllBuildingEntities())
+			)
 			const containerId = 'surveyScatterPlot'
 			this.plotService.initializePlotContainerForGrid(containerId)
 
@@ -91,7 +106,7 @@ export default {
 				svg,
 				'Espoo on the map: resident survey places in everyday life with heat exposure',
 				width,
-				margin
+				margin.top
 			)
 
 			// Plot points, adjusted for nested properties
@@ -106,9 +121,9 @@ export default {
 				.attr('r', 2) // Increase dot size for better visibility in the larger plot
 				.style('fill', (d) => this.getOutlineColor(d._properties.Paikan_kok))
 				.on('mouseover', (event, d) =>
-					this.plotService.handleMouseover(tooltip, containerId, event, d, dataFormatter)
+					plotService.handleMouseover(tooltip, containerId, event, d, dataFormatter)
 				)
-				.on('mouseout', () => this.plotService.handleMouseout(tooltip))
+				.on('mouseout', () => plotService.handleMouseout(tooltip))
 		},
 
 		getOutlineColor(value) {
@@ -120,8 +135,9 @@ export default {
 		clearSurveyScatterPlot() {
 			// Remove or clear the D3.js visualization using Vue ref
 			// Using D3.js on the ref value maintains Vue encapsulation
-			if (this.$refs.containerRef) {
-				d3.select(this.$refs.containerRef).select('svg').remove()
+			const container = /** @type {HTMLElement | undefined} */ (this.$refs.containerRef)
+			if (container) {
+				d3.select(container).select('svg').remove()
 			}
 		},
 	},

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -188,7 +188,17 @@ export default {
 
 			const entities = buildingsDataSource.entities.values
 			void buildingService.setHeatExposureToBuildings(entities)
-			buildingService.updateHeatHistogramDataAfterFilter(entities)
+			// `updateHeatHistogramDataAfterFilter` is tagged `@private` on the Building
+			// facade but is part of its public API used by external callers such as this
+			// component (a real annotation mismatch in services/building/index.js, which is
+			// outside this batch). Cast to the exact method signature — routed through
+			// `unknown` so the private-vs-public member difference doesn't read as a bad
+			// conversion — rather than weakening the whole service type.
+			const buildingHistogram =
+				/** @type {{ updateHeatHistogramDataAfterFilter: (entities: unknown[]) => void }} */ (
+					/** @type {unknown} */ (buildingService)
+				)
+			buildingHistogram.updateHeatHistogramDataAfterFilter(entities)
 			// Register entities with cesiumEntityManager for non-reactive entity management
 			cesiumEntityManager.registerBuildingEntities(entities)
 			eventBus.emit('updateScatterPlot')

--- a/src/components/TimelineCompact.vue
+++ b/src/components/TimelineCompact.vue
@@ -77,8 +77,18 @@ const updateViewAndPlots = () => {
 	if (!buildingsDataSource) return
 
 	const entities = buildingsDataSource.entities.values
-	void buildingService.setHeatExposureToBuildings(entities)
+
+	// vue-tsc mis-resolves `setHeatExposureToBuildings` on the imported Building instance
+	// type in this file's module graph, collapsing the method member to its `Promise<void>`
+	// return type (so a direct call reads as a non-callable value — TS2349). Capture a
+	// precisely-typed callable reference and invoke via Function.prototype.call to keep `this`.
+	const styleBuildings = /** @type {(e: unknown) => Promise<void>} */ (
+		buildingService.setHeatExposureToBuildings
+	)
+	void styleBuildings.call(buildingService, entities) // fire-and-forget
+
 	buildingService.updateHeatHistogramDataAfterFilter(entities)
+
 	// Register entities with cesiumEntityManager for non-reactive entity management
 	cesiumEntityManager.registerBuildingEntities(entities)
 	eventBus.emit('updateScatterPlot')

--- a/src/components/ViewportLoadingIndicator.vue
+++ b/src/components/ViewportLoadingIndicator.vue
@@ -150,11 +150,11 @@ const isLoading = computed(() => {
 })
 
 const hasError = computed(() => {
-	return !!props.error || !!loadingStore.loadingErrors.buildings
+	return !!props.error || loadingStore.hasLayerError('buildings')
 })
 
 const errorMessage = computed(() => {
-	return props.error || loadingStore.loadingErrors.buildings || 'Failed to load buildings'
+	return props.error || loadingStore.getLayerError('buildings') || 'Failed to load buildings'
 })
 
 const showIndicator = computed(() => {

--- a/src/components/VulnerabilityChart.vue
+++ b/src/components/VulnerabilityChart.vue
@@ -168,7 +168,7 @@ const renderChart = (data) => {
 	createBars(svg, chartData, xScale, yScale, height, tooltip, 0, 'steelblue')
 
 	// Add chart title
-	plotService.addTitle(svg, 'Vulnerability Indices', width, margin)
+	plotService.addTitle(svg, 'Vulnerability Indices', width, margin.top)
 }
 
 // Refactor the createBars method
@@ -191,7 +191,9 @@ const createBars = (svg, data, xScale, yScale, height, tooltip, xOffset, barColo
 		.attr('height', (d) => height - yScale(d.value))
 		.attr('fill', (d) => d.color || barColor) // Use specified color or default
 		.on('mouseover', (event, d) => {
-			const containerRect = document.getElementById('bar-chart-container').getBoundingClientRect()
+			const container = document.getElementById('bar-chart-container')
+			if (!container) return
+			const containerRect = container.getBoundingClientRect()
 			const xPos = event.pageX - containerRect.left
 			const yPos = event.pageY - containerRect.top
 			const dataFormatter = (data) => `${data.index}: ${data.value.toFixed(2)}`

--- a/src/composables/useCameraControls.js
+++ b/src/composables/useCameraControls.js
@@ -13,7 +13,7 @@ import logger from '../utils/logger.js'
  *
  * @param {any} viewer - Cesium viewer reference
  * @param {Function} onCameraSettled - Callback function to invoke when camera stops moving
- * @param {Function} [onUrlUpdate] - Optional callback to update URL with camera state
+ * @param {Function|null} [onUrlUpdate] - Optional callback to update URL with camera state
  * @returns {{
  *   addCameraMoveEndListener: () => void,
  *   cleanup: () => void

--- a/src/composables/useEntityPicking.js
+++ b/src/composables/useEntityPicking.js
@@ -22,6 +22,7 @@ import logger from '../utils/logger.js'
  * @param {(() => any) | any} getFeaturepicker - Getter function or Featurepicker service class
  * @returns {{
  *   addFeaturePicker: () => void,
+ *   cleanup: () => void,
  *   lastPickTime: import('vue').Ref<number>
  * }} Entity picking functions and state
  *

--- a/src/composables/useGridStyling.js
+++ b/src/composables/useGridStyling.js
@@ -78,6 +78,26 @@ export const indexToColorScheme = {
 }
 
 /**
+ * A 250m grid entity as loaded from GeoJSON.
+ *
+ * The entity always has a `polygon` graphics object and a `properties` bag in
+ * this code path (grid features are guaranteed to be polygons with attributes),
+ * but Cesium's typings mark both as optional and type `material`/`extrudedHeight`
+ * as `Property`. At runtime Cesium coerces a raw `Color`/`number` assignment into
+ * the corresponding `ConstantProperty`/material, so the writable shape below
+ * reflects what is actually assignable. Guards still narrow the optional members.
+ *
+ * @typedef {Object} GridPolygon
+ * @property {*} material - Accepts a Cesium.Color or MaterialProperty (coerced at runtime)
+ * @property {number} extrudedHeight - Accepts a raw number (coerced at runtime)
+ *
+ * @typedef {Object} GridEntity
+ * @property {GridPolygon} [polygon]
+ * @property {Object<string, { getValue: () => * }>} [properties]
+ * @property {boolean} [show]
+ */
+
+/**
  * Vue 3 composable for 250m statistical grid visualization styling
  * Centralizes all color scheme logic, index-based styling, and 3D extrusion.
  * Supports heat/flood vulnerability indices, social vulnerability factors,
@@ -184,10 +204,13 @@ export function useGridStyling() {
 	 * Styles a single grid entity based on the selected index.
 	 * Extracted from updateGridColors loop body for batch processing.
 	 *
-	 * @param {Cesium.Entity} entity - The entity to style
+	 * @param {GridEntity} entity - The entity to style
 	 * @param {string} selectedIndex - The selected vulnerability index
 	 */
 	const styleGridEntity = (entity, selectedIndex) => {
+		// Grid features always have a polygon + properties; guard for the type system.
+		if (!entity.polygon || !entity.properties) return
+
 		// Reset state for each entity
 		entity.polygon.extrudedHeight = 0
 		entity.polygon.material = getCachedColor('#FFFFFF', baseAlpha.value)

--- a/src/composables/useSidebarNavigation.js
+++ b/src/composables/useSidebarNavigation.js
@@ -47,7 +47,7 @@ export function useSidebarNavigation() {
 			const featurepicker = new Featurepicker()
 			const { useToggleStore } = await import('../stores/toggleStore.js')
 			const toggleStore = useToggleStore()
-			const tooltip = document.querySelector('.tooltip')
+			const tooltip = /** @type {HTMLElement|null} */ (document.querySelector('.tooltip'))
 			if (tooltip) tooltip.style.display = 'none'
 			featurepicker.loadPostalCode().catch((error) => {
 				logger.error('Failed to load postal code:', error)
@@ -77,8 +77,9 @@ export function useSidebarNavigation() {
 		toggleStore.onExitPostalCode()
 
 		globalStore.setLevel('start')
-		globalStore.setPostalCode(null)
-		globalStore.setNameOfZone(null)
+		// Reset to cleared state — store setters accept null at runtime to clear selection.
+		globalStore.setPostalCode(/** @type {string} */ (/** @type {unknown} */ (null)))
+		globalStore.setNameOfZone(/** @type {string} */ (/** @type {unknown} */ (null)))
 		globalStore.setView('capitalRegion')
 
 		toggleStore.setShowTrees(false)
@@ -90,7 +91,7 @@ export function useSidebarNavigation() {
 		const camera = new Camera()
 		camera.init()
 
-		const tooltip = document.querySelector('.tooltip')
+		const tooltip = /** @type {HTMLElement|null} */ (document.querySelector('.tooltip'))
 		if (tooltip) tooltip.style.display = 'none'
 	}
 

--- a/src/composables/useUrlState.js
+++ b/src/composables/useUrlState.js
@@ -30,7 +30,7 @@ const URL_UPDATE_DEBOUNCE_MS = 500
  * @returns {{
  *   hasUrlState: import('vue').Ref<boolean>,
  *   getUrlState: () => Object|null,
- *   restoreStateFromUrl: (viewer: any) => Promise<boolean>,
+ *   restoreStateFromUrl: (viewer: any, featurepickerClass?: any) => Promise<boolean>,
  *   updateUrlFromCamera: (viewer: any) => void,
  *   updateUrlFromNavigation: (options: Object) => void,
  *   clearUrlState: () => void
@@ -59,9 +59,9 @@ export function useUrlState() {
 			camera: {
 				longitude: parseFloat(lon),
 				latitude: parseFloat(lat),
-				altitude: parseFloat(params.get('alt')) || 4000,
-				heading: parseFloat(params.get('heading')) || 0,
-				pitch: parseFloat(params.get('pitch')) || -35,
+				altitude: parseFloat(params.get('alt') ?? '') || 4000,
+				heading: parseFloat(params.get('heading') ?? '') || 0,
+				pitch: parseFloat(params.get('pitch') ?? '') || -35,
 			},
 			navigation: {
 				level: params.get('level') || 'start',
@@ -197,9 +197,9 @@ export function useUrlState() {
 			// Update camera position parameters
 			params.set('lon', Cesium.Math.toDegrees(cartographic.longitude).toFixed(6))
 			params.set('lat', Cesium.Math.toDegrees(cartographic.latitude).toFixed(6))
-			params.set('alt', Math.round(cartographic.height))
-			params.set('heading', Math.round(Cesium.Math.toDegrees(camera.heading)))
-			params.set('pitch', Math.round(Cesium.Math.toDegrees(camera.pitch)))
+			params.set('alt', String(Math.round(cartographic.height)))
+			params.set('heading', String(Math.round(Cesium.Math.toDegrees(camera.heading))))
+			params.set('pitch', String(Math.round(Cesium.Math.toDegrees(camera.pitch))))
 
 			// Preserve navigation state (use lowercase in URL for consistency)
 			if (store.level && store.level !== 'start') {

--- a/src/composables/useViewerInitialization.js
+++ b/src/composables/useViewerInitialization.js
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 /**
  * @module composables/useViewerInitialization
  * Handles Cesium viewer initialization with dynamic module loading.
@@ -29,7 +30,8 @@ import { loadWithRetry } from '../utils/moduleLoader.js'
  *   initViewer: () => Promise<void>,
  *   addPostalCodes: () => Promise<void>,
  *   addAttribution: () => void,
- *   retryInit: () => Promise<void>
+ *   retryInit: () => Promise<void>,
+ *   destroyViewer: () => void
  * }} Viewer initialization state and functions
  *
  * @example
@@ -42,7 +44,7 @@ export function useViewerInitialization() {
 	const graphicsStore = useGraphicsStore()
 	const propsStore = usePropsStore()
 
-	const viewer = ref(null)
+	const viewer = ref(/** @type {any} */ (null))
 	const errorSnackbar = ref(false)
 	const errorMessage = ref('')
 
@@ -163,8 +165,11 @@ export function useViewerInitialization() {
 
 		// Expose viewer to E2E test harness
 		if (isE2ETest) {
-			window.__viewer = viewer.value
-			window.__cesium = Cesium
+			// `window` is augmented with __viewer/__cesium only in E2E mode; the global
+			// Window type has no such fields, so widen to access them here.
+			const testWindow = /** @type {Window & { __viewer?: any, __cesium?: any }} */ (window)
+			testWindow.__viewer = viewer.value
+			testWindow.__cesium = Cesium
 			logger.debug('[useViewerInitialization] 🧪 Test mode enabled - viewer exposed to window')
 		}
 

--- a/src/constants/flagMetadata.ts
+++ b/src/constants/flagMetadata.ts
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 /**
  * Static flag metadata registry.
  * Maps internal flag names to GOFF flag IDs and stores display metadata.

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 import * as Sentry from '@sentry/vue'
 import { createSentryPiniaPlugin } from '@sentry/vue'
 import { createPinia } from 'pinia'
@@ -5,11 +6,29 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import './version.js' // Log version info to console
 import { useBuildingStore } from './stores/buildingStore.js'
-import { useFeatureFlagStore } from './stores/featureFlagStore.ts'
+import { useFeatureFlagStore } from './stores/featureFlagStore'
 import { useGlobalStore } from './stores/globalStore.js'
 import { useToggleStore } from './stores/toggleStore.js'
 import logger from './utils/logger.js'
 import { installPreloadErrorHandler } from './utils/preloadErrorHandler.js'
+
+/**
+ * `window` augmented with the store instances and factory functions that the
+ * E2E test harness reads. These are attached only in development/test builds
+ * (see below); typed here so the assignments type-check without an ambient
+ * `.d.ts`.
+ *
+ * @typedef {Window & {
+ *   globalStore: ReturnType<typeof useGlobalStore>,
+ *   useGlobalStore: () => ReturnType<typeof useGlobalStore>,
+ *   buildingStore: ReturnType<typeof useBuildingStore>,
+ *   useBuildingStore: () => ReturnType<typeof useBuildingStore>,
+ *   toggleStore: ReturnType<typeof useToggleStore>,
+ *   useToggleStore: () => ReturnType<typeof useToggleStore>,
+ *   featureFlagStore: ReturnType<typeof useFeatureFlagStore>,
+ *   useFeatureFlagStore: () => ReturnType<typeof useFeatureFlagStore>,
+ * }} TestWindow
+ */
 
 // Install the global vite:preloadError handler before any dynamic imports
 // can run, so stale-chunk failures after a deploy trigger a reload rather
@@ -163,23 +182,27 @@ app.use(vuetify)
 // Expose store instances to window for E2E testing
 // Must be done BEFORE mounting so the store is available when components initialize
 if (import.meta.env.MODE === 'development' || import.meta.env.MODE === 'test') {
+	// Cast to the test-surface shape (see TestWindow typedef) rather than declaring
+	// an ambient .d.ts, since these properties are not on the standard Window type.
+	const testWindow = /** @type {TestWindow} */ (/** @type {unknown} */ (window))
+
 	// Initialize the stores and expose the instances
 	const globalStore = useGlobalStore()
-	window.globalStore = globalStore
+	testWindow.globalStore = globalStore
 	// Also expose the function for backwards compatibility
-	window.useGlobalStore = () => globalStore
+	testWindow.useGlobalStore = () => globalStore
 
 	const buildingStore = useBuildingStore()
-	window.buildingStore = buildingStore
-	window.useBuildingStore = () => buildingStore
+	testWindow.buildingStore = buildingStore
+	testWindow.useBuildingStore = () => buildingStore
 
 	const toggleStore = useToggleStore()
-	window.toggleStore = toggleStore
-	window.useToggleStore = () => toggleStore
+	testWindow.toggleStore = toggleStore
+	testWindow.useToggleStore = () => toggleStore
 
 	const featureFlagStore = useFeatureFlagStore()
-	window.featureFlagStore = featureFlagStore
-	window.useFeatureFlagStore = () => featureFlagStore
+	testWindow.featureFlagStore = featureFlagStore
+	testWindow.useFeatureFlagStore = () => featureFlagStore
 }
 
 app.mount('#app')

--- a/src/pages/CapitalRegion.vue
+++ b/src/pages/CapitalRegion.vue
@@ -67,7 +67,6 @@
 </template>
 
 <script>
-import { useDebounceFn } from '@vueuse/core'
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import BuildingInformation from '../components/BuildingInformation.vue'
 import HSYWMS from '../components/HSYWMS.vue'
@@ -79,6 +78,37 @@ import { useToggleStore } from '../stores/toggleStore.js'
 import BuildingScatterPlot from '../views/BuildingScatterPlot.vue'
 import Landcover from '../views/Landcover.vue'
 import SocioEconomics from '../views/SocioEconomics.vue'
+
+/**
+ * Creates a trailing-edge debounced wrapper around `fn`. Mirrors the subset of
+ * `@vueuse/core`'s `useDebounceFn` used here (which is not a project dependency),
+ * but additionally exposes `.cancel()` so a pending call can be dropped on
+ * component unmount to avoid stale state mutations.
+ *
+ * @template {(...args: any[]) => void} F
+ * @param {F} fn - Function to debounce.
+ * @param {number} delay - Trailing delay in milliseconds.
+ * @returns {((...args: Parameters<F>) => void) & { cancel: () => void }}
+ */
+function useDebounceFn(fn, delay) {
+	/** @type {ReturnType<typeof setTimeout> | null} */
+	let timer = null
+	/** @param {Parameters<F>} args */
+	const run = (...args) => {
+		if (timer !== null) clearTimeout(timer)
+		timer = setTimeout(() => {
+			timer = null
+			fn(...args)
+		}, delay)
+	}
+	const cancel = () => {
+		if (timer !== null) {
+			clearTimeout(timer)
+			timer = null
+		}
+	}
+	return Object.assign(run, { cancel })
+}
 
 export default {
 	components: {
@@ -142,6 +172,9 @@ export default {
 			// Stop watchers to prevent stale callbacks
 			stopWatchLandCover()
 			stopWatchPostalCode()
+			// Drop any pending debounced calls so they don't mutate state post-unmount
+			debouncedLandCoverUpdate.cancel()
+			debouncedPostalCodeUpdate.cancel()
 		})
 
 		return {

--- a/src/pages/CesiumViewer.vue
+++ b/src/pages/CesiumViewer.vue
@@ -189,7 +189,13 @@ export default {
 		// Viewer initialization composable
 		// IMPORTANT: Keep reference to the object to access dynamic modules via getters.
 		// Destructuring Featurepicker/Camera directly captures null at setup time.
-		const viewerInit = useViewerInitialization()
+		// destroyViewer is returned at runtime by the composable, but its JSDoc
+		// @returns type omits it. This file cannot edit that composable's JSDoc,
+		// so widen the type here to access the genuinely-present teardown method.
+		const viewerInit =
+			/** @type {ReturnType<typeof useViewerInitialization> & { destroyViewer: () => void }} */ (
+				useViewerInitialization()
+			)
 		const {
 			viewer,
 			errorSnackbar,
@@ -209,7 +215,7 @@ export default {
 		const {
 			isLoadingBuildings,
 			viewportLoadingProgress,
-			viewportLoadingError,
+			viewportLoadingError: viewportLoadingErrorRef,
 			handleCameraSettled,
 			handleRetryViewportLoading,
 			initViewportStreaming,
@@ -218,6 +224,10 @@ export default {
 			() => viewerInit.Camera,
 			() => viewerInit.Featurepicker
 		)
+
+		// The ViewportLoadingIndicator `error` prop is `string | undefined`; the
+		// composable exposes `string | null`. Normalize null to undefined.
+		const viewportLoadingError = computed(() => viewportLoadingErrorRef.value ?? undefined)
 
 		// URL update callback for camera controls
 		const handleUrlUpdate = () => {

--- a/src/pages/ControlPanel.vue
+++ b/src/pages/ControlPanel.vue
@@ -381,7 +381,7 @@ import MapControls from '../components/MapControls.vue'
 import UnifiedSearch from '../components/UnifiedSearch.vue'
 import ViewModeCompact from '../components/ViewModeCompact.vue'
 import { useSidebarNavigation } from '../composables/useSidebarNavigation.js'
-import { LAAJASALO_CAMERA } from '../constants/vttFlood.ts'
+import { LAAJASALO_CAMERA } from '../constants/vttFlood'
 import { cesiumProvider, getCesium } from '../services/cesiumProvider.js'
 
 // Store and Service Imports
@@ -434,9 +434,23 @@ const { breadcrumbs, canGoBack, goBack } = useSidebarNavigation()
 
 const currentLevel = computed(() => globalStore.level)
 const currentView = computed(() => globalStore.view)
+/** @type {readonly ('search' | 'layers' | 'analysis' | 'details')[]} */
+const SIDEBAR_TABS = ['search', 'layers', 'analysis', 'details']
+
+/**
+ * Type guard narrowing an arbitrary tab value to the known sidebar tab union.
+ * @param {string} val
+ * @returns {val is 'search' | 'layers' | 'analysis' | 'details'}
+ */
+const isSidebarTab = (val) => /** @type {readonly string[]} */ (SIDEBAR_TABS).includes(val)
+
 const activeTab = computed({
 	get: () => toggleStore.activeTab,
-	set: (val) => toggleStore.setActiveTab(val),
+	set: (val) => {
+		if (isSidebarTab(val)) {
+			toggleStore.setActiveTab(val)
+		}
+	},
 })
 
 const isRail = computed(() => toggleStore.sidebarMode === 'rail')
@@ -496,7 +510,7 @@ const analysisComponents = computed(() => ({
 }))
 
 // Inline analysis (small charts rendered in sidebar)
-const inlineAnalysis = ref(null)
+const inlineAnalysis = ref(/** @type {keyof typeof analysisConfig | null} */ (null))
 // Right panel analysis (large charts)
 const rightPanelOpen = ref(false)
 const rightPanelAnalysis = ref('')

--- a/src/services/backgroundPreloader.js
+++ b/src/services/backgroundPreloader.js
@@ -47,7 +47,9 @@ class BackgroundPreloader {
 			lastActivity: Date.now(),
 		}
 		// Store references for cleanup
+		/** @type {ReturnType<typeof setTimeout> | null} */
 		this.idleTimer = null
+		/** @type {(() => void) | null} */
 		this.boundResetIdleTimer = null
 		this.eventListenersAttached = false
 	}
@@ -207,14 +209,13 @@ class BackgroundPreloader {
 		const startTime = Date.now()
 
 		try {
-			// Use progressive loader for chunked data
+			// Use progressive loader for chunked data. The item URL already carries
+			// its query params (built by getLayerUrl); loadData is the public API
+			// (the previous loadChunked method does not exist on ProgressiveLoader).
 			if (item.type === 'trees' || item.type === 'buildings') {
-				const data = await progressiveLoader.loadChunked({
-					layerName: `preload-${item.key}`,
-					baseUrl: item.url,
-					params: item.params || {},
+				const data = await progressiveLoader.loadData(item.url, {
 					chunkSize: 200, // Smaller chunks for background loading
-					processor: item.processor,
+					onChunk: item.processor,
 				})
 
 				await cacheService.setData(item.key, data, {
@@ -264,9 +265,9 @@ class BackgroundPreloader {
 					{ preloaded: true, url: item.url },
 					{
 						type: item.type,
-						date: item.date,
 						ttl: item.ttl || 7 * 24 * 60 * 60 * 1000, // 7 days for NDVI
 						metadata: {
+							date: item.date,
 							preloaded: true,
 							preloadTime: Date.now(),
 							loadDuration: Date.now() - startTime,
@@ -374,7 +375,7 @@ class BackgroundPreloader {
 
 		const params = new URLSearchParams({
 			f: 'json',
-			limit: 1000,
+			limit: '1000',
 		})
 
 		if (postalCode) {
@@ -435,16 +436,18 @@ class BackgroundPreloader {
 	 * Wait for user to become idle
 	 */
 	async waitForUserIdle() {
-		return new Promise((resolve) => {
-			const checkIdle = () => {
-				if (!this.isUserActive()) {
-					resolve()
-				} else {
-					setTimeout(checkIdle, 1000)
+		return new Promise(
+			/** @param {(value?: any) => void} resolve */ (resolve) => {
+				const checkIdle = () => {
+					if (!this.isUserActive()) {
+						resolve()
+					} else {
+						setTimeout(checkIdle, 1000)
+					}
 				}
+				checkIdle()
 			}
-			checkIdle()
-		})
+		)
 	}
 
 	/**
@@ -452,9 +455,9 @@ class BackgroundPreloader {
 	 */
 	setupIdlePreloading() {
 		// Create bound function reference for cleanup
-		this.boundResetIdleTimer = () => {
+		const resetIdleTimer = () => {
 			this.userBehavior.lastActivity = Date.now()
-			clearTimeout(this.idleTimer)
+			if (this.idleTimer) clearTimeout(this.idleTimer)
 
 			this.idleTimer = setTimeout(() => {
 				// User has been idle for 10 seconds, resume preloading
@@ -466,14 +469,15 @@ class BackgroundPreloader {
 				}
 			}, 10000)
 		}
+		this.boundResetIdleTimer = resetIdleTimer
 
 		// Listen for user activity
 		;['mousedown', 'mousemove', 'keypress', 'scroll', 'touchstart'].forEach((event) => {
-			document.addEventListener(event, this.boundResetIdleTimer, { passive: true })
+			document.addEventListener(event, resetIdleTimer, { passive: true })
 		})
 
 		this.eventListenersAttached = true
-		this.boundResetIdleTimer()
+		resetIdleTimer()
 	}
 
 	/**
@@ -481,8 +485,9 @@ class BackgroundPreloader {
 	 */
 	removeIdleDetection() {
 		if (this.eventListenersAttached && this.boundResetIdleTimer) {
+			const resetIdleTimer = this.boundResetIdleTimer
 			;['mousedown', 'mousemove', 'keypress', 'scroll', 'touchstart'].forEach((event) => {
-				document.removeEventListener(event, this.boundResetIdleTimer)
+				document.removeEventListener(event, resetIdleTimer)
 			})
 			this.eventListenersAttached = false
 			this.boundResetIdleTimer = null

--- a/src/services/building/buildingFilter.js
+++ b/src/services/building/buildingFilter.js
@@ -84,7 +84,7 @@ export class BuildingFilter {
 
 				// Check hideNewBuildings filter
 				if (hideNewBuildings) {
-					const completionDate = entity._properties?._c_valmpvm?._value
+					const completionDate = entity.properties?._c_valmpvm?._value
 					if (completionDate && new Date(completionDate).getTime() >= cutoffDate) {
 						shouldHide = true
 					}
@@ -93,10 +93,10 @@ export class BuildingFilter {
 				// Check hideNonSote filter (social/healthcare buildings)
 				if (!shouldHide && hideNonSote) {
 					const kayttotark = helsinkiView
-						? entity._properties?._c_kayttark?._value
-							? Number(entity._properties?._c_kayttark?._value)
+						? entity.properties?._c_kayttark?._value
+							? Number(entity.properties?._c_kayttark?._value)
 							: null
-						: entity._properties?._kayttarks?._value
+						: entity.properties?._kayttarks?._value
 
 					const entityIsSoteBuilding = helsinkiView
 						? kayttotark && isSoteBuilding(kayttotark)
@@ -110,7 +110,7 @@ export class BuildingFilter {
 				// Check hideLow filter (buildings with <= 6 floors)
 				if (!shouldHide && hideLow) {
 					const floorCount =
-						entity._properties?.[helsinkiView ? '_i_kerrlkm' : '_kerrosten_lkm']?._value
+						entity.properties?.[helsinkiView ? '_i_kerrlkm' : '_kerrosten_lkm']?._value
 					if (!floorCount || floorCount <= 6) {
 						shouldHide = true
 					}
@@ -157,15 +157,17 @@ export class BuildingFilter {
 			this.viewer.scene.requestRender()
 		}
 
-		this.updateHeatHistogramDataAfterFilter(buildingsDataSource.entities._entities._array)
+		this.updateHeatHistogramDataAfterFilter(buildingsDataSource.entities.values)
 	}
 
 	/**
 	 * Updates heat histogram data after filtering buildings
 	 * Extracts heat exposure values from visible entities and emits update event.
 	 *
+	 * Public API: the Building facade (building/index.js) and components delegate to
+	 * this for backward compatibility, so it is intentionally not private.
+	 *
 	 * @param {Array<Cesium.Entity>} entities - Building entities to process
-	 * @private
 	 */
 	updateHeatHistogramDataAfterFilter(entities) {
 		const visibleEntities = entities.filter((entity) => entity.show)
@@ -175,7 +177,7 @@ export class BuildingFilter {
 			? visibleEntities.map((entity) => entity.properties?._avgheatexposuretobuilding?._value)
 			: visibleEntities
 					.map((entity) => {
-						const heatTimeseries = entity.properties.heat_timeseries?._value || []
+						const heatTimeseries = entity.properties?.heat_timeseries?._value || []
 						const foundEntry = heatTimeseries.find(({ date }) => date === targetDate)
 						return foundEntry ? foundEntry.avg_temp_c : null
 					})
@@ -197,10 +199,10 @@ export class BuildingFilter {
 	 */
 	soteBuildings(entity) {
 		const kayttotark = this.toggleStore.helsinkiView
-			? entity._properties?._c_kayttark?._value
-				? Number(entity._properties?._c_kayttark?._value)
+			? entity.properties?._c_kayttark?._value
+				? Number(entity.properties?._c_kayttark?._value)
 				: null
-			: entity._properties?._kayttarks?._value
+			: entity.properties?._kayttarks?._value
 
 		entity.show = this.toggleStore.helsinkiView
 			? kayttotark && isSoteBuilding(kayttotark)
@@ -214,7 +216,7 @@ export class BuildingFilter {
 	 */
 	lowBuildings(entity) {
 		if (
-			entity._properties?.[this.toggleStore.helsinkiView ? '_i_kerrlkm' : '_kerrosten_lkm']
+			entity.properties?.[this.toggleStore.helsinkiView ? '_i_kerrlkm' : '_kerrosten_lkm']
 				?._value <= 6
 		) {
 			entity.show = false
@@ -233,7 +235,7 @@ export class BuildingFilter {
 		this.lastFilterState = null
 
 		// Batch visibility changes
-		const entities = buildingsDataSource._entityCollection._entities._array
+		const entities = buildingsDataSource.entities.values
 		let hasChanges = false
 
 		for (let i = 0; i < entities.length; i++) {
@@ -249,7 +251,7 @@ export class BuildingFilter {
 			this.viewer.scene.requestRender()
 		}
 
-		this.updateHeatHistogramDataAfterFilter(buildingsDataSource.entities._entities._array)
+		this.updateHeatHistogramDataAfterFilter(buildingsDataSource.entities.values)
 	}
 
 	/**

--- a/src/services/building/buildingFilter.js
+++ b/src/services/building/buildingFilter.js
@@ -84,7 +84,7 @@ export class BuildingFilter {
 
 				// Check hideNewBuildings filter
 				if (hideNewBuildings) {
-					const completionDate = entity.properties?._c_valmpvm?._value
+					const completionDate = entity.properties?._c_valmpvm?.getValue()
 					if (completionDate && new Date(completionDate).getTime() >= cutoffDate) {
 						shouldHide = true
 					}
@@ -93,10 +93,10 @@ export class BuildingFilter {
 				// Check hideNonSote filter (social/healthcare buildings)
 				if (!shouldHide && hideNonSote) {
 					const kayttotark = helsinkiView
-						? entity.properties?._c_kayttark?._value
-							? Number(entity.properties?._c_kayttark?._value)
+						? entity.properties?._c_kayttark?.getValue()
+							? Number(entity.properties?._c_kayttark?.getValue())
 							: null
-						: entity.properties?._kayttarks?._value
+						: entity.properties?._kayttarks?.getValue()
 
 					const entityIsSoteBuilding = helsinkiView
 						? kayttotark && isSoteBuilding(kayttotark)
@@ -110,7 +110,7 @@ export class BuildingFilter {
 				// Check hideLow filter (buildings with <= 6 floors)
 				if (!shouldHide && hideLow) {
 					const floorCount =
-						entity.properties?.[helsinkiView ? '_i_kerrlkm' : '_kerrosten_lkm']?._value
+						entity.properties?.[helsinkiView ? '_i_kerrlkm' : '_kerrosten_lkm']?.getValue()
 					if (!floorCount || floorCount <= 6) {
 						shouldHide = true
 					}
@@ -177,7 +177,7 @@ export class BuildingFilter {
 			? visibleEntities.map((entity) => entity.properties?._avgheatexposuretobuilding?._value)
 			: visibleEntities
 					.map((entity) => {
-						const heatTimeseries = entity.properties?.heat_timeseries?._value || []
+						const heatTimeseries = entity.properties?.heat_timeseries?.getValue() || []
 						const foundEntry = heatTimeseries.find(({ date }) => date === targetDate)
 						return foundEntry ? foundEntry.avg_temp_c : null
 					})

--- a/src/services/building/buildingHighlighter.js
+++ b/src/services/building/buildingHighlighter.js
@@ -77,12 +77,13 @@ export class BuildingHighlighter {
 	 * @param {Array<number>} values - Values to match against
 	 */
 	outlineByTemperature(entity, property, values) {
-		const heatTimeseries = entity._properties?.heat_timeseries?._value || []
+		const heatTimeseries = entity.properties?.heat_timeseries?.getValue() || []
 		const foundEntry = heatTimeseries.find(({ date }) => date === this.store.heatDataDate)
 
+		const propertyValue = entity.properties?.[property]?.getValue()
 		const shouldOutlineYellow = !this.toggleStore.helsinkiView
 			? foundEntry && values.includes(foundEntry.avg_temp_c)
-			: entity._properties?.[property] && values.includes(entity._properties[property]._value)
+			: propertyValue != null && values.includes(propertyValue)
 
 		if (shouldOutlineYellow) {
 			this.polygonOutlineToYellow(entity)
@@ -121,7 +122,8 @@ export class BuildingHighlighter {
 	 * @private
 	 */
 	outlineById(entity, property, id) {
-		if (entity._properties?.[property] && entity._properties[property]._value === id) {
+		const propertyValue = entity.properties?.[property]?.getValue()
+		if (propertyValue != null && propertyValue === id) {
 			this.polygonOutlineToYellow(entity)
 			this.store.setPickedEntity(entity)
 			eventBus.emit('entityPrintEvent')
@@ -141,9 +143,9 @@ export class BuildingHighlighter {
 		}
 
 		const Cesium = getCesium()
-		entity.polygon.outline = true
-		entity.polygon.outlineColor = Cesium.Color.YELLOW
-		entity.polygon.outlineWidth = 20
+		entity.polygon.outline = new Cesium.ConstantProperty(true)
+		entity.polygon.outlineColor = new Cesium.ConstantProperty(Cesium.Color.YELLOW)
+		entity.polygon.outlineWidth = new Cesium.ConstantProperty(20)
 	}
 
 	/**
@@ -157,8 +159,8 @@ export class BuildingHighlighter {
 		}
 
 		const Cesium = getCesium()
-		entity.polygon.outlineColor = Cesium.Color.BLACK
-		entity.polygon.outlineWidth = 8
+		entity.polygon.outlineColor = new Cesium.ConstantProperty(Cesium.Color.BLACK)
+		entity.polygon.outlineWidth = new Cesium.ConstantProperty(8)
 	}
 }
 

--- a/src/services/building/buildingLoader.js
+++ b/src/services/building/buildingLoader.js
@@ -109,6 +109,12 @@ export class BuildingLoader {
 	 */
 	async loadBuildings(postalCode) {
 		const targetPostalCode = postalCode || this.store.postalcode
+		// Guard: store.postalcode is `string | null`; without a postal code there
+		// is nothing to load (and downstream URL/heat/tree calls require a string).
+		if (!targetPostalCode) {
+			logger.debug('[HelsinkiBuilding] No postal code available; skipping building load')
+			return []
+		}
 		const url = this.urlStore.helsinkiBuildingsUrl(targetPostalCode)
 		const layerId = `helsinki_buildings_${targetPostalCode}`
 

--- a/src/services/building/buildingStyler.js
+++ b/src/services/building/buildingStyler.js
@@ -133,11 +133,14 @@ export class BuildingStyler {
 	 * @returns {Promise<void>}
 	 */
 	async setHelsinkiBuildingsHeight(entities) {
+		const Cesium = getCesium()
 		await processBatchAdaptive(
 			entities,
 			(entity) => {
 				if (entity.polygon) {
-					entity.polygon.extrudedHeight = calculateBuildingHeight(entity.properties)
+					entity.polygon.extrudedHeight = new Cesium.ConstantProperty(
+						calculateBuildingHeight(entity.properties)
+					)
 				}
 			},
 			{ processorName: 'heightExtrusion' }
@@ -254,7 +257,7 @@ export class BuildingStyler {
 	 * Processes building heat timeseries data, tree coverage, and heat exposure values.
 	 *
 	 * @param {number} treeArea - Nearby tree coverage area in square meters
-	 * @param {number} avg_temp_c - Average surface temperature in Celsius (unused)
+	 * @param {number} _avg_temp_c - Average surface temperature in Celsius (unused)
 	 * @param {Object} buildingProps - Building properties object containing heat and structural data
 	 * @returns {Promise<void>}
 	 */

--- a/src/services/building/index.js
+++ b/src/services/building/index.js
@@ -71,7 +71,7 @@ export default class Building {
 	/**
 	 * Loads Helsinki buildings for a postal code with caching support.
 	 * @param {string} [postalCode] - Optional postal code to load buildings for.
-	 * @returns {Promise<void>}
+	 * @returns {Promise<Array>} Building entities, or an empty array if the load was cancelled.
 	 */
 	async loadBuildings(postalCode) {
 		return this._loader.loadBuildings(postalCode)
@@ -170,11 +170,11 @@ export default class Building {
 
 			// Reset outline styling
 			const Cesium = getCesium()
-			entity.polygon.outlineColor = Cesium.Color.BLACK
-			entity.polygon.outlineWidth = 3
+			entity.polygon.outlineColor = new Cesium.ConstantProperty(Cesium.Color.BLACK)
+			entity.polygon.outlineWidth = new Cesium.ConstantProperty(3)
 
 			// Ensure fill is enabled to prevent wireframe appearance
-			entity.polygon.fill = true
+			entity.polygon.fill = new Cesium.ConstantProperty(true)
 
 			// Use the proper method that handles both Helsinki and Capital Region views
 			this._styler.setBuildingEntityPolygon(entity)
@@ -203,8 +203,9 @@ export default class Building {
 	/**
 	 * Updates heat histogram data after filtering buildings.
 	 * Note: resetBuildingOutline is called via callback injected into filter module.
+	 * Public facade API: components (e.g. TimelineCompact) delegate to this, so it is
+	 * intentionally not private.
 	 * @param {Array<Cesium.Entity>} entities - Building entities to process
-	 * @private
 	 */
 	updateHeatHistogramDataAfterFilter(entities) {
 		this._filter.updateHeatHistogramDataAfterFilter(entities)
@@ -294,7 +295,10 @@ export default class Building {
 	 * @param {string|number} id - Value to match against property
 	 */
 	outlineById(entity, property, id) {
-		return this._highlighter.outlineById(entity, property, id)
+		// `outlineById` is @private on BuildingHighlighter, but this facade legitimately
+		// delegates to it for backward compatibility. Cast to access the private member
+		// without editing the module class.
+		return /** @type {any} */ (this._highlighter).outlineById(entity, property, id)
 	}
 
 	/**

--- a/src/services/cacheService.js
+++ b/src/services/cacheService.js
@@ -124,7 +124,7 @@ class CacheService {
 			}
 
 			request.onupgradeneeded = (event) => {
-				const db = event.target.result
+				const db = /** @type {IDBOpenDBRequest} */ (event.target).result
 
 				// Create object stores
 				if (!db.objectStoreNames.contains('layers')) {
@@ -182,7 +182,8 @@ class CacheService {
 		// Check cache size before storing
 		await this.ensureCacheSize(cacheEntry.size)
 
-		const transaction = this.db.transaction(['layers'], 'readwrite')
+		const db = await this.init()
+		const transaction = db.transaction(['layers'], 'readwrite')
 		const store = transaction.objectStore('layers')
 
 		return new Promise((resolve, reject) => {
@@ -215,9 +216,9 @@ class CacheService {
 	 * const cached = await cacheService.getData('buildings-00100', 5 * 60 * 1000);
 	 */
 	async getData(key, maxAge = null) {
-		await this.init()
+		const db = await this.init()
 
-		const transaction = this.db.transaction(['layers'], 'readonly')
+		const transaction = db.transaction(['layers'], 'readonly')
 		const store = transaction.objectStore('layers')
 
 		return new Promise((resolve, reject) => {
@@ -288,9 +289,9 @@ class CacheService {
 	 * await cacheService.removeData('buildings-00100');
 	 */
 	async removeData(key) {
-		await this.init()
+		const db = await this.init()
 
-		const transaction = this.db.transaction(['layers'], 'readwrite')
+		const transaction = db.transaction(['layers'], 'readwrite')
 		const store = transaction.objectStore('layers')
 
 		return new Promise((resolve, reject) => {
@@ -313,14 +314,15 @@ class CacheService {
 	 * // ['buildings-00100', 'trees-00100', 'vegetation-00150']
 	 */
 	async getCachedKeys() {
-		await this.init()
+		const db = await this.init()
 
-		const transaction = this.db.transaction(['layers'], 'readonly')
+		const transaction = db.transaction(['layers'], 'readonly')
 		const store = transaction.objectStore('layers')
 
 		return new Promise((resolve, reject) => {
 			const request = store.getAllKeys()
-			request.onsuccess = () => resolve(request.result)
+			request.onsuccess = () =>
+				resolve(request.result.map((/** @type {IDBValidKey} */ k) => String(k)))
 			request.onerror = () => reject(request.error)
 		})
 	}
@@ -340,9 +342,9 @@ class CacheService {
 	 * // By type: { buildings: 3, trees: 2, vegetation: 1 }
 	 */
 	async getCacheStats() {
-		await this.init()
+		const db = await this.init()
 
-		const transaction = this.db.transaction(['layers'], 'readonly')
+		const transaction = db.transaction(['layers'], 'readonly')
 		const store = transaction.objectStore('layers')
 
 		return new Promise((resolve, reject) => {
@@ -392,9 +394,9 @@ class CacheService {
 	 * console.log(`Removed ${cleaned} expired cache entries`);
 	 */
 	async cleanupExpired() {
-		await this.init()
+		const db = await this.init()
 
-		const transaction = this.db.transaction(['layers'], 'readwrite')
+		const transaction = db.transaction(['layers'], 'readwrite')
 		const store = transaction.objectStore('layers')
 
 		return new Promise((resolve, reject) => {
@@ -450,9 +452,9 @@ class CacheService {
 	 * @private
 	 */
 	async removeOldestEntries(spaceNeeded) {
-		await this.init()
+		const db = await this.init()
 
-		const transaction = this.db.transaction(['layers'], 'readwrite')
+		const transaction = db.transaction(['layers'], 'readwrite')
 		const store = transaction.objectStore('layers')
 		const index = store.index('timestamp')
 
@@ -461,7 +463,7 @@ class CacheService {
 			let freedSpace = 0
 
 			request.onsuccess = (event) => {
-				const cursor = event.target.result
+				const cursor = /** @type {IDBRequest<IDBCursorWithValue|null>} */ (event.target).result
 
 				if (cursor && freedSpace < spaceNeeded) {
 					const entry = cursor.value
@@ -491,9 +493,9 @@ class CacheService {
 	 * console.log('All cache data cleared');
 	 */
 	async clearAll() {
-		await this.init()
+		const db = await this.init()
 
-		const transaction = this.db.transaction(['layers'], 'readwrite')
+		const transaction = db.transaction(['layers'], 'readwrite')
 		const store = transaction.objectStore('layers')
 
 		return new Promise((resolve, reject) => {
@@ -593,9 +595,9 @@ class CacheService {
 	 * });
 	 */
 	async setMetadata(key, metadata) {
-		await this.init()
+		const db = await this.init()
 
-		const transaction = this.db.transaction(['metadata'], 'readwrite')
+		const transaction = db.transaction(['metadata'], 'readwrite')
 		const store = transaction.objectStore('metadata')
 
 		return new Promise((resolve, reject) => {
@@ -620,9 +622,9 @@ class CacheService {
 	 * }
 	 */
 	async getMetadata(key) {
-		await this.init()
+		const db = await this.init()
 
-		const transaction = this.db.transaction(['metadata'], 'readonly')
+		const transaction = db.transaction(['metadata'], 'readonly')
 		const store = transaction.objectStore('metadata')
 
 		return new Promise((resolve, reject) => {

--- a/src/services/cacheWarmer.js
+++ b/src/services/cacheWarmer.js
@@ -208,7 +208,7 @@ class CacheWarmer {
 					layerId: `warmcache_helsinki_buildings_${postalCode}`,
 					url,
 					type: 'geojson',
-					processor: null, // Cache only, don't process
+					// Cache only, don't process (processor omitted)
 					options: {
 						cache: true,
 						cacheTTL: 60 * 60 * 1000, // 1 hour
@@ -225,7 +225,7 @@ class CacheWarmer {
 					layerId: `warmcache_hsy_buildings_${postalCode}`,
 					url,
 					type: 'geojson',
-					processor: null, // Cache only, don't process
+					// Cache only, don't process (processor omitted)
 					options: {
 						cache: true,
 						cacheTTL: 60 * 60 * 1000, // 1 hour
@@ -265,7 +265,12 @@ class CacheWarmer {
 	 * cacheWarmer.warmNearbyPostalCodes('00100', ['00150', '00170', '00180']);
 	 */
 	warmNearbyPostalCodes(currentPostalCode, nearbyPostalCodes) {
-		if (import.meta.env.VITE_E2E_TEST === 'true') return
+		// Vite injects `env` on import.meta but the project has no vite/client
+		// ambient types, so narrow import.meta locally to a shape that has it.
+		const meta = /** @type {{ env: Record<string, string | undefined> }} */ (
+			/** @type {unknown} */ (import.meta)
+		)
+		if (meta.env.VITE_E2E_TEST === 'true') return
 
 		logger.debug('[CacheWarmer] 🎯 Predictively warming nearby postal codes...')
 

--- a/src/services/camera.js
+++ b/src/services/camera.js
@@ -243,8 +243,15 @@ export default class Camera {
 			return
 		}
 
+		// Guard: postal code must be set before lookup
+		const postalcode = this.store.postalcode
+		if (!postalcode) {
+			logger.warn('[Camera] Cannot switch to 2D view: No postal code selected')
+			return
+		}
+
 		// O(1) lookup using postal code index
-		const entity = postalCodeIndex.getByPostalCode(this.store.postalcode)
+		const entity = postalCodeIndex.getByPostalCode(postalcode)
 
 		if (!entity) {
 			logger.warn(`[Camera] Postal code ${this.store.postalcode} not found for 2D view`)
@@ -293,8 +300,15 @@ export default class Camera {
 		// Capture current camera state before starting flight
 		this.captureCurrentState()
 
+		// Guard: postal code must be set before lookup
+		const postalcode = this.store.postalcode
+		if (!postalcode) {
+			logger.warn('[Camera] Cannot switch to 3D view: No postal code selected')
+			return
+		}
+
 		// O(1) lookup using postal code index
-		const entity = postalCodeIndex.getByPostalCode(this.store.postalcode)
+		const entity = postalCodeIndex.getByPostalCode(postalcode)
 
 		if (!entity) {
 			logger.warn(`[Camera] Postal code ${this.store.postalcode} not found for 3D view`)
@@ -373,7 +387,10 @@ export default class Camera {
 				duration: 1, // Animation duration in seconds
 			})
 
-			this.store.setLevel(null)
+			// `switchTo3DGrid` historically resets to a null level (see camera spec).
+			// `setLevel` is typed for the string state machine, so cast the intentional
+			// null reset through unknown rather than change the runtime value.
+			this.store.setLevel(/** @type {string} */ (/** @type {unknown} */ (null)))
 		}
 	}
 
@@ -507,8 +524,9 @@ export default class Camera {
 			return
 		}
 
-		// O(1) lookup using postal code index
-		const entity = postalCodeIndex.getByPostalCode(postalCode)
+		// O(1) lookup using postal code index. The index is keyed by string posno
+		// values, so normalize numeric postal codes to string before lookup.
+		const entity = postalCodeIndex.getByPostalCode(String(postalCode))
 
 		if (!entity) {
 			logger.warn(`[Camera] Postal code ${postalCode} not found in index`)

--- a/src/services/cesiumEntityManager.js
+++ b/src/services/cesiumEntityManager.js
@@ -52,7 +52,7 @@ class CesiumEntityManager {
 		this.treeEntitiesById.clear()
 
 		for (const entity of entities) {
-			const kohdeId = entity._properties?._kohde_id?._value
+			const kohdeId = entity.properties?.kohde_id?.getValue()
 			if (kohdeId) {
 				this.treeEntitiesById.set(kohdeId, entity)
 			}
@@ -71,7 +71,7 @@ class CesiumEntityManager {
 		this.buildingEntitiesById.clear()
 
 		for (const entity of entities) {
-			const id = entity._properties?._id?._value || entity._properties?._hki_id?._value
+			const id = entity.properties?.id?.getValue() || entity.properties?.hki_id?.getValue()
 			if (id) {
 				this.buildingEntitiesById.set(id, entity)
 			}

--- a/src/services/cesiumProvider.js
+++ b/src/services/cesiumProvider.js
@@ -16,7 +16,9 @@ import logger from '../utils/logger.js'
 
 class CesiumProvider {
 	constructor() {
+		/** @type {typeof import('cesium') | null} */
 		this._cesium = null
+		/** @type {Promise<typeof import('cesium')> | null} */
 		this._initPromise = null
 		this._initialized = false
 	}
@@ -27,7 +29,7 @@ class CesiumProvider {
 	 * @returns {Promise<typeof import('cesium')>}
 	 */
 	async initialize() {
-		if (this._initialized) return this._cesium
+		if (this._initialized && this._cesium) return this._cesium
 		if (this._initPromise) return this._initPromise
 
 		this._initPromise = (async () => {
@@ -39,7 +41,7 @@ class CesiumProvider {
 			this._cesium = cesiumModule
 			this._initialized = true
 			logger.debug('[CesiumProvider] Cesium module loaded')
-			return this._cesium
+			return cesiumModule
 		})()
 		return this._initPromise
 	}
@@ -51,7 +53,7 @@ class CesiumProvider {
 	 * @throws {Error} If Cesium not yet initialized
 	 */
 	get() {
-		if (!this._initialized) {
+		if (!this._initialized || !this._cesium) {
 			throw new Error(
 				'[CesiumProvider] Cesium accessed before initialization. ' +
 					'Ensure cesiumProvider.initialize() completes before using getCesium().'

--- a/src/services/coldarea.js
+++ b/src/services/coldarea.js
@@ -67,9 +67,15 @@ export default class ColdArea {
 	 * @returns {Promise} - A promise that resolves once the data has been loaded
 	 */
 	async loadColdAreas() {
+		const postalCode = this.store.postalcode
+		if (!postalCode) {
+			logger.warn('loadColdAreas called without a postal code; skipping')
+			return
+		}
+
 		this.store.setIsLoading(true)
 		try {
-			const response = await fetch(this.urlStore.coldAreas(this.store.postalcode))
+			const response = await fetch(this.urlStore.coldAreas(postalCode))
 			const data = await response.json()
 			await this.addColdAreaDataSource(data)
 		} catch (error) {
@@ -96,17 +102,21 @@ export default class ColdArea {
 			const Cesium = getCesium()
 			this.elementsDisplayService.setColdAreasElementsDisplay('inline-block')
 			for (let i = 0; i < entities.length; i++) {
-				const entity = entities[i]
-
-				if (entity._properties._heatexposure && entity.polygon) {
-					entity.polygon.material = new Cesium.Color(
-						1,
-						1 - entity._properties._heatexposure._value,
-						0,
-						entity._properties._heatexposure._value
+				const entity =
+					/** @type {Cesium.Entity & { _properties?: Record<string, { _value?: any } | undefined> }} */ (
+						entities[i]
 					)
-					entity.polygon.outlineColor = Cesium.Color.BLACK
-					entity.polygon.outlineWidth = 3
+
+				const heatexposure = entity._properties?._heatexposure
+				// Cesium's polygon graphics setters accept raw Color/number at
+				// runtime (coerced to ConstantProperty), but the published types
+				// declare them as Property/MaterialProperty — hence the cast.
+				const polygon = /** @type {any} */ (entity.polygon)
+
+				if (heatexposure && polygon) {
+					polygon.material = new Cesium.Color(1, 1 - heatexposure._value, 0, heatexposure._value)
+					polygon.outlineColor = Cesium.Color.BLACK
+					polygon.outlineWidth = 3
 				}
 			}
 		}

--- a/src/services/datasource.js
+++ b/src/services/datasource.js
@@ -113,48 +113,50 @@ export default class DataSource {
 
 		for (const dataSource of dataSourcesCopy) {
 			if (dataSource.name.startsWith(namePrefix)) {
-				const removalPromise = new Promise((resolveRemove) => {
-					const REMOVAL_TIMEOUT_MS = 5000
+				const removalPromise = /** @type {Promise<void>} */ (
+					new Promise((resolveRemove) => {
+						const REMOVAL_TIMEOUT_MS = 5000
 
-					const onDataSourceRemoved = (removedDataSource) => {
-						if (removedDataSource === dataSource) {
+						const onDataSourceRemoved = (removedDataSource) => {
+							if (removedDataSource === dataSource) {
+								clearTimeout(timeoutId)
+								this.store.cesiumViewer?.dataSources?.dataSourceRemoved?.removeEventListener(
+									onDataSourceRemoved
+								)
+								resolveRemove()
+							}
+						}
+
+						// Add listener BEFORE calling remove to avoid race condition
+						this.store.cesiumViewer?.dataSources?.dataSourceRemoved?.addEventListener(
+							onDataSourceRemoved
+						)
+
+						// Timeout safeguard: resolve and clean up listener if removal event never fires
+						const timeoutId = setTimeout(() => {
+							this.store.cesiumViewer?.dataSources?.dataSourceRemoved?.removeEventListener(
+								onDataSourceRemoved
+							)
+							logger.warn(
+								`[DataSource] Removal event for "${dataSource.name}" timed out after ${REMOVAL_TIMEOUT_MS}ms, cleaning up listener`
+							)
+							resolveRemove()
+						}, REMOVAL_TIMEOUT_MS)
+
+						// Call remove and check if it succeeded
+						const wasRemoved = this.store.cesiumViewer?.dataSources?.remove(dataSource, true)
+
+						// If removal failed (data source not in collection), resolve immediately
+						// Also handles the case where viewer was destroyed (wasRemoved === undefined)
+						if (!wasRemoved) {
 							clearTimeout(timeoutId)
 							this.store.cesiumViewer?.dataSources?.dataSourceRemoved?.removeEventListener(
 								onDataSourceRemoved
 							)
 							resolveRemove()
 						}
-					}
-
-					// Add listener BEFORE calling remove to avoid race condition
-					this.store.cesiumViewer?.dataSources?.dataSourceRemoved?.addEventListener(
-						onDataSourceRemoved
-					)
-
-					// Timeout safeguard: resolve and clean up listener if removal event never fires
-					const timeoutId = setTimeout(() => {
-						this.store.cesiumViewer?.dataSources?.dataSourceRemoved?.removeEventListener(
-							onDataSourceRemoved
-						)
-						logger.warn(
-							`[DataSource] Removal event for "${dataSource.name}" timed out after ${REMOVAL_TIMEOUT_MS}ms, cleaning up listener`
-						)
-						resolveRemove()
-					}, REMOVAL_TIMEOUT_MS)
-
-					// Call remove and check if it succeeded
-					const wasRemoved = this.store.cesiumViewer?.dataSources?.remove(dataSource, true)
-
-					// If removal failed (data source not in collection), resolve immediately
-					// Also handles the case where viewer was destroyed (wasRemoved === undefined)
-					if (!wasRemoved) {
-						clearTimeout(timeoutId)
-						this.store.cesiumViewer?.dataSources?.dataSourceRemoved?.removeEventListener(
-							onDataSourceRemoved
-						)
-						resolveRemove()
-					}
-				})
+					})
+				)
 
 				removalPromises.push(removalPromise)
 			}
@@ -367,8 +369,10 @@ export default class DataSource {
 				const entity = loadedData.entities.values[i]
 
 				if (Cesium.defined(entity.polygon)) {
-					entity.polygon.arcType = Cesium.ArcType.GEODESIC
-					entity.polygon.fill = true
+					// Wrap primitives in ConstantProperty so they satisfy the
+					// `Property` setter type (Cesium does this internally at runtime).
+					entity.polygon.arcType = new Cesium.ConstantProperty(Cesium.ArcType.GEODESIC)
+					entity.polygon.fill = new Cesium.ConstantProperty(true)
 				}
 			}
 

--- a/src/services/elementsDisplay.js
+++ b/src/services/elementsDisplay.js
@@ -144,7 +144,10 @@ export default class ElementsDisplay {
 			'hideNonSoteLabel',
 		]
 
-		document.getElementById('hideNonSoteLabel').textContent = 'Only public buildings'
+		const hideNonSoteLabel = document.getElementById('hideNonSoteLabel')
+		if (hideNonSoteLabel) {
+			hideNonSoteLabel.textContent = 'Only public buildings'
+		}
 
 		this.setElementsDisplay(elements, display)
 	}

--- a/src/services/featureFlagProvider.ts
+++ b/src/services/featureFlagProvider.ts
@@ -1,3 +1,5 @@
+/// <reference types="vite/client" />
+
 /**
  * OpenFeature SDK initialization with GOFF web provider.
  * Falls back to InMemoryProvider when GOFF relay is unavailable (local dev).
@@ -88,10 +90,13 @@ type UserStore = ReturnType<typeof useUserStore>
  * This context is sent to GOFF for targeting rule evaluation.
  */
 function buildEvaluationContext(userStore: UserStore): EvaluationContext {
+	// `EvaluationContextValue` does not permit `undefined`, so omit the optional
+	// identity fields entirely when they're absent rather than assigning
+	// `undefined` (which preserves the original "key not sent to GOFF" intent).
 	return {
 		targetingKey: userStore.targetingKey,
-		email: userStore.email ?? undefined,
-		domain: userStore.domain ?? undefined,
+		...(userStore.email != null ? { email: userStore.email } : {}),
+		...(userStore.domain != null ? { domain: userStore.domain } : {}),
 		app: 'r4c-cesium-viewer',
 	}
 }

--- a/src/services/featurepicker/buildingHandler.js
+++ b/src/services/featurepicker/buildingHandler.js
@@ -15,10 +15,7 @@ import { eventBus } from '../eventEmitter.js'
  * Updates application level to 'building', shows loading indicator, emits visibility events,
  * and creates building-specific charts. Manages loading state throughout the process.
  *
- * @param {Object} properties - Building properties object containing building attributes
- * @param {string} properties._postinumero - Postal code of the building
- * @param {number} [properties.treeArea] - Nearby tree area
- * @param {number} [properties._avg_temp_c] - Average temperature
+ * @param {Cesium.PropertyBag} properties - Building properties bag containing Cesium property objects
  * @param {Object} context - Context object with services and stores
  * @param {Object} context.store - Global store instance
  * @param {Object} context.toggleStore - Toggle store instance
@@ -77,11 +74,15 @@ export async function handleBuildingFeature(properties, context) {
  * @param {Object} context - Context object with services and stores
  * @param {Object} context.store - Global store instance
  * @param {Object} context.coldAreaService - Cold area service instance
+ * @param {Object} context.toggleStore - Toggle store instance
+ * @param {Object} context.buildingService - Building service instance
+ * @param {Object} context.elementsDisplayService - Elements display service instance
  * @returns {Promise<void>}
  */
 export async function processBuildingAtPostalCodeLevel(entity, context) {
 	const { store, coldAreaService } = context
 	const properties = entity.properties
+	if (!properties) return
 
 	store.setBuildingAddress(findAddressForBuilding(properties))
 

--- a/src/services/featurepicker/entityPicker.js
+++ b/src/services/featurepicker/entityPicker.js
@@ -85,7 +85,8 @@ export function pickEntity(windowPosition, context, onEntityPicked) {
  * @returns {void}
  */
 export function removeEntityByName(viewer, name) {
-	viewer.entities._entities._array.forEach((entity) => {
+	// Iterate over a copy of the values array since remove() mutates the collection
+	;[...viewer.entities.values].forEach((entity) => {
 		if (entity.name === name) {
 			viewer.entities.remove(entity)
 		}
@@ -106,7 +107,7 @@ export function getBoundingBox(entity) {
 	if (entity.polygon) {
 		const Cesium = getCesium()
 		// Access the polygon hierarchy to get vertex positions
-		const hierarchy = entity.polygon.hierarchy.getValue()
+		const hierarchy = entity.polygon.hierarchy?.getValue()
 
 		if (hierarchy) {
 			const positions = hierarchy.positions

--- a/src/services/featurepicker/index.js
+++ b/src/services/featurepicker/index.js
@@ -236,6 +236,7 @@ export default class FeaturePicker {
 	 */
 	setNameOfZone() {
 		const targetPostalCode = this.store.postalcode
+		if (!targetPostalCode) return
 		setNameOfZoneHelper(
 			targetPostalCode,
 			this.propStore.postalCodeData,
@@ -297,7 +298,9 @@ export default class FeaturePicker {
 			})
 		}
 
-		this.propStore.setTreeArea(null)
+		// `null` clears the tree area (propsStore.treeArea is number|null); the
+		// store action's @param is documented as {number} only, so cast here.
+		this.propStore.setTreeArea(/** @type {number} */ (/** @type {unknown} */ (null)))
 		this.propStore.setHeatFloodVulnerability(id.properties ?? null)
 
 		if (id.properties.grid_id) {
@@ -306,13 +309,17 @@ export default class FeaturePicker {
 
 		// Handle building selection at postal code level
 		if (this.store.level === 'postalCode') {
-			processBuildingAtPostalCodeLevel(id, {
+			// Assemble context in a variable so TS structural assignment (not
+			// object-literal excess-property checking) applies — the extra keys
+			// are forwarded by processBuildingAtPostalCodeLevel to handleBuildingFeature.
+			const postalCodeContext = {
 				store: this.store,
 				coldAreaService: this.coldAreaService,
 				toggleStore: this.toggleStore,
 				buildingService: this.buildingService,
 				elementsDisplayService: this.elementsDisplayService,
-			}).catch((error) => {
+			}
+			processBuildingAtPostalCodeLevel(id, postalCodeContext).catch((error) => {
 				logger.error('Failed to handle building feature:', error)
 			})
 		}
@@ -335,7 +342,9 @@ export default class FeaturePicker {
 				return
 			}
 
-			if (shouldNavigateToPostalCode(newPostalCode, this.store.postalcode, this.store.level)) {
+			if (
+				shouldNavigateToPostalCode(newPostalCode, this.store.postalcode ?? '', this.store.level)
+			) {
 				// Cancel any in-flight building loads before starting new navigation
 				this.buildingService.cancelCurrentLoad()
 
@@ -368,9 +377,13 @@ export default class FeaturePicker {
 			this.traveltimeService.loadTravelTimeData(id.properties.id._value).catch((error) => {
 				logger.error('Failed to load travel time data:', error)
 			})
-			this.traveltimeService.markCurrentLocation(id).catch((error) => {
+			// markCurrentLocation is synchronous (returns void) — calling .catch on its
+			// undefined return throws a TypeError, so guard with try/catch instead.
+			try {
+				this.traveltimeService.markCurrentLocation(id)
+			} catch (error) {
 				logger.error('Failed to mark current location:', error)
-			})
+			}
 		}
 	}
 
@@ -418,7 +431,7 @@ export default class FeaturePicker {
 			const { visibilityChanges, postalCodesToLoad } = calculateVisibilityChanges(
 				this.visiblePostalCodes,
 				newVisibleSet,
-				currentPostalCode,
+				currentPostalCode ?? '',
 				this.datasourceService
 			)
 
@@ -447,7 +460,7 @@ export default class FeaturePicker {
 					if (this.toggleStore.helsinkiView) {
 						await this.buildingService.loadBuildings(postalCode)
 					} else {
-						await this.hSYBuildingService.loadHSYBuildings(null, postalCode)
+						await this.hSYBuildingService.loadHSYBuildings(undefined, postalCode)
 					}
 
 					logger.debug('[FeaturePicker] Loaded buildings for postal code:', postalCode)
@@ -461,7 +474,7 @@ export default class FeaturePicker {
 			}
 
 			this.visiblePostalCodes = newVisibleSet
-			warmNearbyPostalCodes(currentPostalCode, visiblePostalCodes)
+			warmNearbyPostalCodes(currentPostalCode ?? '', visiblePostalCodes)
 			this._dumpBuildingDatasourceState()
 		} finally {
 			this._isLoadingVisiblePostalCodes = false

--- a/src/services/featurepicker/visibilityManager.js
+++ b/src/services/featurepicker/visibilityManager.js
@@ -213,7 +213,10 @@ export function hideTreesForPostalCode(postalCode, datasourceService) {
  * @returns {void}
  */
 export function dumpBuildingDatasourceState(viewer, visiblePostalCodes) {
-	const allDatasources = viewer?.dataSources?._dataSources || []
+	const dataSources = /** @type {{ _dataSources?: Cesium.DataSource[] } | undefined} */ (
+		viewer?.dataSources
+	)
+	const allDatasources = dataSources?._dataSources || []
 	const buildingDatasources = allDatasources.filter((ds) => ds.name?.startsWith('Buildings '))
 
 	logger.debug(

--- a/src/services/floodwms.js
+++ b/src/services/floodwms.js
@@ -77,7 +77,8 @@ export const createFloodImageryLayer = async (url, layerName) => {
 			retryHandler.handleTileError(error, layerName)
 		})
 
-		await provider.readyPromise
+		// WebMapServiceImageryProvider is constructed ready in this Cesium version;
+		// the removed `readyPromise` API would resolve to `await undefined` anyway.
 		const addedLayer = viewer.imageryLayers.addImageryProvider(provider)
 		addedLayer.alpha = 1
 		backgroundMapStore.floodLayers.push(addedLayer)

--- a/src/services/graphics.js
+++ b/src/services/graphics.js
@@ -66,6 +66,7 @@ export default class Graphics {
 	detectSupport() {
 		// Skip if already detected
 		if (this._supportDetected) return
+		if (!this.scene) return
 
 		const Cesium = getCesium()
 		const supportInfo = {
@@ -109,6 +110,7 @@ export default class Graphics {
 	 * Apply MSAA (Multi-Sample Anti-Aliasing) settings
 	 */
 	applyMsaaSettings() {
+		if (!this.scene) return
 		if (this.graphicsStore.msaaSupported) {
 			const effectiveSamples = this.graphicsStore.effectiveMsaaSamples
 			this.scene.msaaSamples = effectiveSamples
@@ -122,6 +124,7 @@ export default class Graphics {
 	 * Apply FXAA (Fast Approximate Anti-Aliasing) settings
 	 */
 	applyFxaaSettings() {
+		if (!this.scene) return
 		const fxaaStage = this.scene.postProcessStages.fxaa
 		if (fxaaStage) {
 			fxaaStage.enabled = this.graphicsStore.fxaaEnabled
@@ -133,6 +136,7 @@ export default class Graphics {
 	 * Apply HDR (High Dynamic Range) settings
 	 */
 	applyHdrSettings() {
+		if (!this.scene) return
 		if (this.graphicsStore.hdrSupported) {
 			this.scene.highDynamicRange = this.graphicsStore.hdrEnabled
 			logger.debug(`HDR ${this.graphicsStore.hdrEnabled ? 'enabled' : 'disabled'}`)
@@ -145,6 +149,7 @@ export default class Graphics {
 	 * Apply Ambient Occlusion settings
 	 */
 	applyAmbientOcclusionSettings() {
+		if (!this.scene) return
 		if (this.graphicsStore.ambientOcclusionSupported) {
 			const ambientOcclusion = this.scene.postProcessStages.ambientOcclusion
 			ambientOcclusion.enabled = this.graphicsStore.ambientOcclusionEnabled
@@ -183,6 +188,7 @@ export default class Graphics {
 		// Watch for MSAA changes — store stop fn so destroy() can release it
 		this._unsubscribe = this.graphicsStore.$subscribe((mutation, _state) => {
 			if (!this.viewer || this.viewer.isDestroyed?.()) return
+			if (!this.scene) return
 			// mutation.events may be undefined for single-change mutations
 			const events = Array.isArray(mutation.events) ? mutation.events : []
 
@@ -225,6 +231,7 @@ export default class Graphics {
 	 * Get current graphics performance info
 	 */
 	getPerformanceInfo() {
+		if (!this.scene) return null
 		return {
 			msaaSamples: this.scene.msaaSamples,
 			fxaaEnabled: this.scene.postProcessStages.fxaa?.enabled || false,
@@ -239,6 +246,7 @@ export default class Graphics {
 	 * Show or hide FPS counter for performance monitoring
 	 */
 	setShowFps(show) {
+		if (!this.scene) return
 		this.scene.debugShowFramesPerSecond = show
 	}
 
@@ -246,6 +254,7 @@ export default class Graphics {
 	 * Force a render update (useful with request render mode)
 	 */
 	requestRender() {
+		if (!this.scene) return
 		if (this.scene.requestRenderMode) {
 			this.scene.requestRender()
 		}

--- a/src/services/helsinki.js
+++ b/src/services/helsinki.js
@@ -90,7 +90,7 @@ export default class Helsinki {
 			await this.treeService.loadTrees()
 		}
 
-		if (this.toggleStore.OtherNature) {
+		if (this.toggleStore.showOtherNature) {
 			await this.otherNatureService.loadOtherNature()
 		}
 	}

--- a/src/services/hostConcurrencyLimiter.js
+++ b/src/services/hostConcurrencyLimiter.js
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 /**
  * @module services/hostConcurrencyLimiter
  *
@@ -164,6 +165,7 @@ function makeReleaser(_hostKey, state) {
  * @returns {Record<string, { active: number, queued: number, limit: number }>}
  */
 export function inspectLimiter() {
+	/** @type {Record<string, { active: number, queued: number, limit: number }>} */
 	const out = {}
 	for (const [hostKey, state] of hostState.entries()) {
 		out[hostKey] = {
@@ -185,6 +187,13 @@ export function __resetForTests() {
 
 // Expose a debug hook in dev so it's easy to inspect from devtools.
 if (import.meta.env?.MODE === 'development' && typeof window !== 'undefined') {
-	window.__hostLimiter = { inspectLimiter, setHostLimit, DEFAULT_LIMIT }
+	// Attach an ad-hoc debug hook; cast through a loose shape since this custom
+	// global isn't part of the standard Window type.
+	const debugWindow = /** @type {Window & { __hostLimiter?: object }} */ (window)
+	debugWindow.__hostLimiter = {
+		inspectLimiter,
+		setHostLimit,
+		DEFAULT_LIMIT,
+	}
 	logger.debug('[hostConcurrencyLimiter] dev hook on window.__hostLimiter')
 }

--- a/src/services/hsybuilding.js
+++ b/src/services/hsybuilding.js
@@ -79,6 +79,14 @@ export default class HSYBuilding {
 				return []
 			}
 
+			// A postal code is required to key the building URL, heat fetch, and
+			// merge. Without one (and no bbox), the downstream calls would build
+			// garbage `null`-keyed requests, so bail out early.
+			if (!targetPostalCode) {
+				logger.debug('[HSYBuilding] ℹ️ No postal code available; skipping HSY building load')
+				return []
+			}
+
 			const buildingUrl = bbox
 				? this.urlStore.hsyGridBuildings(bbox)
 				: this.urlStore.hsyBuildings(targetPostalCode)
@@ -190,6 +198,10 @@ export default class HSYBuilding {
 		}
 	}
 
+	/**
+	 * Builds a GeoJSON polygon Feature from the current grid cell's Cesium hierarchy.
+	 * @returns {import('geojson').Feature | null} The polygon feature, or null when no valid grid cell exists.
+	 */
 	createGeoJsonPolygon() {
 		try {
 			if (!this.store.currentGridCell?.polygon?.hierarchy) {
@@ -228,15 +240,15 @@ export default class HSYBuilding {
 		if (!cellProps?.asukkaita) return
 
 		const asukkaita = cellProps.asukkaita
-		feature.properties.pop_d_0_9 = weight * (cellProps.ika0_9 / asukkaita).toFixed(4)
-		feature.properties.pop_d_10_19 = weight * (cellProps.ika10_19 / asukkaita).toFixed(4)
-		feature.properties.pop_d_20_29 = weight * (cellProps.ika20_29 / asukkaita).toFixed(4)
-		feature.properties.pop_d_30_39 = weight * (cellProps.ika30_39 / asukkaita).toFixed(4)
-		feature.properties.pop_d_40_49 = weight * (cellProps.ika40_49 / asukkaita).toFixed(4)
-		feature.properties.pop_d_50_59 = weight * (cellProps.ika50_59 / asukkaita).toFixed(4)
-		feature.properties.pop_d_60_69 = weight * (cellProps.ika60_69 / asukkaita).toFixed(4)
-		feature.properties.pop_d_70_79 = weight * (cellProps.ika70_79 / asukkaita).toFixed(4)
-		feature.properties.pop_d_over80 = weight * (cellProps.ika_yli80 / asukkaita).toFixed(4)
+		feature.properties.pop_d_0_9 = weight * Number((cellProps.ika0_9 / asukkaita).toFixed(4))
+		feature.properties.pop_d_10_19 = weight * Number((cellProps.ika10_19 / asukkaita).toFixed(4))
+		feature.properties.pop_d_20_29 = weight * Number((cellProps.ika20_29 / asukkaita).toFixed(4))
+		feature.properties.pop_d_30_39 = weight * Number((cellProps.ika30_39 / asukkaita).toFixed(4))
+		feature.properties.pop_d_40_49 = weight * Number((cellProps.ika40_49 / asukkaita).toFixed(4))
+		feature.properties.pop_d_50_59 = weight * Number((cellProps.ika50_59 / asukkaita).toFixed(4))
+		feature.properties.pop_d_60_69 = weight * Number((cellProps.ika60_69 / asukkaita).toFixed(4))
+		feature.properties.pop_d_70_79 = weight * Number((cellProps.ika70_79 / asukkaita).toFixed(4))
+		feature.properties.pop_d_over80 = weight * Number((cellProps.ika_yli80 / asukkaita).toFixed(4))
 	}
 
 	approximateOtherAttributesForIntersectingBuilding(feature, weight, gridProps) {
@@ -245,15 +257,15 @@ export default class HSYBuilding {
 			if (!props?.asukkaita) continue
 
 			const asukkaita = props.asukkaita
-			feature.properties.pop_d_0_9 += weight * (props.ika0_9 / asukkaita).toFixed(4)
-			feature.properties.pop_d_10_19 += weight * (props.ika10_19 / asukkaita).toFixed(4)
-			feature.properties.pop_d_20_29 += weight * (props.ika20_29 / asukkaita).toFixed(4)
-			feature.properties.pop_d_30_39 += weight * (props.ika30_39 / asukkaita).toFixed(4)
-			feature.properties.pop_d_40_49 += weight * (props.ika40_49 / asukkaita).toFixed(4)
-			feature.properties.pop_d_50_59 += weight * (props.ika50_59 / asukkaita).toFixed(4)
-			feature.properties.pop_d_60_69 += weight * (props.ika60_69 / asukkaita).toFixed(4)
-			feature.properties.pop_d_70_79 += weight * (props.ika70_79 / asukkaita).toFixed(4)
-			feature.properties.pop_d_over80 += weight * (props.ika_yli80 / asukkaita).toFixed(4)
+			feature.properties.pop_d_0_9 += weight * Number((props.ika0_9 / asukkaita).toFixed(4))
+			feature.properties.pop_d_10_19 += weight * Number((props.ika10_19 / asukkaita).toFixed(4))
+			feature.properties.pop_d_20_29 += weight * Number((props.ika20_29 / asukkaita).toFixed(4))
+			feature.properties.pop_d_30_39 += weight * Number((props.ika30_39 / asukkaita).toFixed(4))
+			feature.properties.pop_d_40_49 += weight * Number((props.ika40_49 / asukkaita).toFixed(4))
+			feature.properties.pop_d_50_59 += weight * Number((props.ika50_59 / asukkaita).toFixed(4))
+			feature.properties.pop_d_60_69 += weight * Number((props.ika60_69 / asukkaita).toFixed(4))
+			feature.properties.pop_d_70_79 += weight * Number((props.ika70_79 / asukkaita).toFixed(4))
+			feature.properties.pop_d_over80 += weight * Number((props.ika_yli80 / asukkaita).toFixed(4))
 		}
 	}
 
@@ -273,7 +285,7 @@ export default class HSYBuilding {
 
 			for (let i = 0; i < entities.length; i++) {
 				const entity = entities[i]
-				if (entity.properties._index._value !== cellProps._index._value) {
+				if (entity.properties?._index?._value !== cellProps._index._value) {
 					const entityGeoJson = this.entityToGeoJson(entity)
 					if (entityGeoJson && turf.booleanIntersects(bboxPolygon, entityGeoJson)) {
 						gridProps.push(entityGeoJson.properties)
@@ -319,15 +331,17 @@ export default class HSYBuilding {
 			'features with progressive loading'
 		)
 
-		// Use progressive loading with the unified loader if available
+		// Use progressive loading with the unified loader if available.
+		// `unifiedLoader` is the module-level singleton (default export); the
+		// previous `const { unifiedLoader } = await import(...)` destructured a
+		// non-existent named export, so it was always undefined and silently fell
+		// through to the legacy path.
 		try {
-			const { unifiedLoader } = await import('./unifiedLoader.js')
-
 			const processor = async (batch) => {
 				return this.processGridAttributeBatch(batch, geoJsonPolygon)
 			}
 
-			await unifiedLoader.loadLayer({
+			await this.unifiedLoader.loadLayer({
 				layerId: 'grid-attributes',
 				data: features,
 				processor,
@@ -403,7 +417,11 @@ export default class HSYBuilding {
 			}
 
 			const isWithin = turf.booleanWithin(
-				{ type: 'Feature', properties: {}, geometry: featureGeoJson.geometry },
+				/** @type {import('geojson').Feature} */ ({
+					type: 'Feature',
+					properties: {},
+					geometry: featureGeoJson.geometry,
+				}),
 				geoJsonPolygon
 			)
 
@@ -414,6 +432,7 @@ export default class HSYBuilding {
 			}
 
 			// Copy calculated attributes to the Cesium entity's PropertyBag
+			if (!entity.properties) continue
 			for (const key of gridAttributeKeys) {
 				if (tempFeature.properties[key] == null) continue
 
@@ -434,11 +453,11 @@ export default class HSYBuilding {
 			try {
 				if (!feature.geometry) continue
 
-				const featureGeoJson = {
+				const featureGeoJson = /** @type {import('geojson').Feature} */ ({
 					type: 'Feature',
 					properties: feature.properties,
 					geometry: feature.geometry,
-				}
+				})
 
 				const isWithin = turf.booleanWithin(featureGeoJson, geoJsonPolygon)
 
@@ -468,11 +487,11 @@ export default class HSYBuilding {
 				try {
 					if (!feature.geometry) continue
 
-					const featureGeoJson = {
+					const featureGeoJson = /** @type {import('geojson').Feature} */ ({
 						type: 'Feature',
 						properties: feature.properties,
 						geometry: feature.geometry,
-					}
+					})
 
 					const isWithin = turf.booleanWithin(featureGeoJson, geoJsonPolygon)
 
@@ -510,6 +529,12 @@ export default class HSYBuilding {
 		return weights[length] || 1
 	}
 
+	/**
+	 * Converts a Cesium polygon entity to a GeoJSON Feature for Turf.js analysis.
+	 *
+	 * @param {Cesium.Entity} entity - Cesium entity with a polygon hierarchy
+	 * @returns {import('geojson').Feature | null} GeoJSON Feature or null when the entity has no polygon
+	 */
 	entityToGeoJson(entity) {
 		try {
 			if (!entity?.polygon?.hierarchy) return null
@@ -532,14 +557,14 @@ export default class HSYBuilding {
 				coordinates.push(coordinates[0])
 			}
 
-			return {
+			return /** @type {import('geojson').Feature} */ ({
 				type: 'Feature',
 				properties: entity.properties,
 				geometry: {
 					type: 'Polygon',
 					coordinates: [coordinates],
 				},
-			}
+			})
 		} catch (error) {
 			logger.error('Error converting entity to GeoJSON:', error)
 			return null
@@ -559,7 +584,10 @@ export default class HSYBuilding {
 	async calculateHSYUrbanHeatData(data, entities, postalCode) {
 		logger.debug('[HSYBuilding] 🌡️ Calculating urban heat data for', entities.length, 'entities')
 
-		const heatExposureData = this.urbanHeatService.calculateAverageExposure(data.features)
+		// calculateAverageExposure returns undefined when no buildings have heat
+		// data (count === 0). Default to an empty array so the .length logging and
+		// the heatExposureData[1] access in setBuildingPropsAndEmitEvent stay safe.
+		const heatExposureData = this.urbanHeatService.calculateAverageExposure(data.features) ?? []
 		const targetDate = this.store.heatDataDate
 
 		const avgTempCList = entities

--- a/src/services/landcover.js
+++ b/src/services/landcover.js
@@ -73,8 +73,8 @@ export const createHSYImageryLayer = async (newLayers) => {
 		tilingScheme: new Cesium.GeographicTilingScheme(),
 	})
 
-	await provider.readyPromise
-
+	// Cesium 1.104+ removed ImageryProvider.readyPromise/ready — WebMapServiceImageryProvider
+	// is usable immediately after construction, so no await is needed here.
 	// Add the new layer and update store
 	const addedLayer = store.cesiumViewer.imageryLayers.addImageryProvider(provider)
 	backgroundMapStore.landcoverLayers.push(addedLayer)

--- a/src/services/loadingCoordinator.js
+++ b/src/services/loadingCoordinator.js
@@ -67,8 +67,8 @@ import unifiedLoader from './unifiedLoader.js'
  * @property {number} layersLoaded - Total layers loaded across all sessions
  * @property {number} totalLoadTime - Cumulative loading time in milliseconds
  * @property {number} avgLoadTime - Average loading time per layer in milliseconds
- * @property {number} activeSessions - Number of currently active sessions
- * @property {number} sessionDuration - Current session duration in milliseconds
+ * @property {number} [activeSessions] - Number of currently active sessions (added by getPerformanceMetrics)
+ * @property {number} [sessionDuration] - Current session duration in milliseconds (added by getPerformanceMetrics)
  */
 
 /**
@@ -279,7 +279,7 @@ class LoadingCoordinator {
 	 * 2. Normal + Low priority: Parallel (no delays)
 	 * 3. Background priority: Scheduled with requestIdleCallback
 	 *
-	 * @param {string} sessionId - Session identifier
+	 * @param {string} _sessionId - Session identifier (unused; kept for signature parity)
 	 * @param {Object[]} layerConfigs - Layer configurations
 	 * @returns {Promise<SessionResult[]>} Loading results
 	 * @private
@@ -387,7 +387,7 @@ class LoadingCoordinator {
 	 * Load all layers in parallel
 	 * Maximum throughput strategy - all layers load simultaneously.
 	 *
-	 * @param {string} sessionId - Session identifier
+	 * @param {string} _sessionId - Session identifier (unused; kept for signature parity)
 	 * @param {Object[]} layerConfigs - Layer configurations
 	 * @returns {Promise<SessionResult[]>} Loading results
 	 * @private

--- a/src/services/othernature.js
+++ b/src/services/othernature.js
@@ -42,10 +42,15 @@ export default class Othernature {
 	 * @returns {Promise} - A promise that resolves once the data has been loaded
 	 */
 	async loadOtherNature() {
+		const postalcode = this.store.postalcode
+		if (!postalcode) {
+			logger.warn('loadOtherNature called without a postal code; skipping')
+			return null
+		}
 		try {
 			const data = await unifiedLoader.loadLayer({
 				layerId: 'othernature',
-				url: this.urlStore.otherNature(this.store.postalcode),
+				url: this.urlStore.otherNature(postalcode),
 				type: 'geojson',
 				processor: (data) => this.addOtherNatureDataSource(data),
 				options: {
@@ -82,7 +87,7 @@ export default class Othernature {
 
 				// Process batch
 				for (const entity of batch) {
-					const category = entity.properties._koodi?._value
+					const category = entity.properties?._koodi?._value
 					if (category) {
 						this.setOtherNaturePolygonMaterialColor(entity, category)
 					}

--- a/src/services/othernature.js
+++ b/src/services/othernature.js
@@ -87,7 +87,7 @@ export default class Othernature {
 
 				// Process batch
 				for (const entity of batch) {
-					const category = entity.properties?._koodi?._value
+					const category = entity.properties?._koodi?.getValue()
 					if (category) {
 						this.setOtherNaturePolygonMaterialColor(entity, category)
 					}

--- a/src/services/plot.js
+++ b/src/services/plot.js
@@ -80,7 +80,9 @@ export default class Plot {
 
 		for (const direction of switchContainers) {
 			const switchContainer = document.getElementById(`bearing${direction}SwitchContainer`)
-			switchContainer.style.visibility = status
+			if (switchContainer) {
+				switchContainer.style.visibility = status
+			}
 		}
 	}
 
@@ -89,7 +91,10 @@ export default class Plot {
 	 */
 
 	updateTreeElements(status) {
-		document.getElementById('nearbyTreeAreaContainer').style.visibility = status
+		const nearbyTreeAreaContainer = document.getElementById('nearbyTreeAreaContainer')
+		if (nearbyTreeAreaContainer) {
+			nearbyTreeAreaContainer.style.visibility = status
+		}
 		this.toggleBearingSwitchesVisibility(status)
 	}
 
@@ -100,6 +105,7 @@ export default class Plot {
 	 */
 	initializePlotContainerForGrid(containerId) {
 		const container = document.getElementById(containerId)
+		if (!container) return
 		// Use textContent for safe clearing (prevents potential XSS)
 		container.textContent = ''
 
@@ -113,6 +119,7 @@ export default class Plot {
 	 */
 	initializePlotContainer(containerId) {
 		const container = document.getElementById(containerId)
+		if (!container) return
 		// Use textContent for safe clearing (prevents potential XSS)
 		container.textContent = ''
 
@@ -182,6 +189,11 @@ export default class Plot {
 		return d3.scaleBand().domain(xLabels).range([0, width]).padding(0.1)
 	}
 
+	/**
+	 * Creates a styled tooltip div appended to the given container.
+	 * @param {string} container - CSS selector for the tooltip's parent element
+	 * @returns {import('@/utils/d3').Selection<HTMLDivElement, unknown, HTMLElement, any>} The tooltip selection
+	 */
 	createTooltip(container) {
 		return d3
 			.select(container)
@@ -210,7 +222,9 @@ export default class Plot {
 	}
 
 	handleMouseover(tooltip, containerId, event, d, dataFormatter) {
-		const containerRect = document.getElementById(containerId).getBoundingClientRect()
+		const container = document.getElementById(containerId)
+		if (!container) return
+		const containerRect = container.getBoundingClientRect()
 		const xPos = event.pageX - containerRect.left
 		const yPos = event.pageY - containerRect.top
 

--- a/src/services/postalCodeLoader.js
+++ b/src/services/postalCodeLoader.js
@@ -270,7 +270,7 @@ export function updateLoadingProgress(current, total, setStateCallback) {
  * Handles partial success (one operation succeeds, other fails).
  * Checks for pending navigation and triggers it if one was queued.
  *
- * @param {Array<PromiseSettledResult>} results - Results from Promise.allSettled
+ * @param {Array<PromiseSettledResult<unknown>>} results - Results from Promise.allSettled
  * @param {string} postalCode - Postal code being loaded
  * @param {Function} setStateCallback - Callback to set click processing state
  * @param {Function} resetStateCallback - Callback to reset click processing state
@@ -282,7 +282,7 @@ export function processParallelLoadingResults(
 	postalCode,
 	setStateCallback,
 	resetStateCallback,
-	getPendingNavigationCallback = null
+	getPendingNavigationCallback = undefined
 ) {
 	const [cameraResult, dataResult] = results
 
@@ -367,7 +367,7 @@ export async function loadPostalCodeWithParallelStrategy(
 	services,
 	stores,
 	setNameOfZoneCallback,
-	onNavigationRequest = null
+	onNavigationRequest = undefined
 ) {
 	performance.mark('parallel-load-start')
 
@@ -416,7 +416,8 @@ export async function loadPostalCodeWithParallelStrategy(
 	// Wait for data loading to complete
 	const dataResult = await Promise.allSettled([dataPromise])
 	// Provide a synthetic fulfilled camera result to reuse processParallelLoadingResults signature
-	const results = [{ status: 'fulfilled' }, dataResult[0]]
+	/** @type {PromiseSettledResult<unknown>[]} */
+	const results = [{ status: 'fulfilled', value: undefined }, dataResult[0]]
 
 	// Process results with comprehensive error handling (FR-3.4)
 	// Also checks for pending navigation (latest-wins pattern)
@@ -466,6 +467,7 @@ export async function loadPostalCodeWithParallelStrategy(
  * @param {Function} setNameCallback - Callback to set zone name in store
  * @param {Object} [options] - Optional callbacks
  * @param {Function} [options.setPickedEntityIfEmpty] - Receives the polygon entity; the global store action will be invoked only when no entity is currently set.
+ * @param {() => (string | null)} [options.getCurrentPostalCode] - Returns the currently active postal code (or null); used to discard stale late-arriving resolutions.
  * @returns {void}
  */
 export function setNameOfZone(postalCode, _postalCodeData, setNameCallback, options = {}) {

--- a/src/services/progressiveLoader.js
+++ b/src/services/progressiveLoader.js
@@ -174,7 +174,7 @@ class ProgressiveLoader {
 
 			return {
 				estimatedSize: contentLength ? parseInt(contentLength, 10) : null,
-				contentType: response.headers.get('content-type'),
+				contentType: response.headers.get('content-type') ?? 'application/json',
 				supportsRangeRequests: response.headers.get('accept-ranges') === 'bytes',
 			}
 		} catch (error) {
@@ -230,10 +230,9 @@ class ProgressiveLoader {
 	 * @private
 	 */
 	async loadStandard(url, signal, config) {
-		const response = await fetch(url, {
-			signal,
-			timeout: config.timeout,
-		})
+		// Note: `fetch` has no `timeout` option (it is silently ignored by the
+		// browser); cancellation is driven by `signal` via the AbortController.
+		const response = await fetch(url, { signal })
 
 		if (!response.ok) {
 			throw new Error(`HTTP ${response.status}: ${response.statusText}`)
@@ -260,7 +259,7 @@ class ProgressiveLoader {
 	 * Future Enhancement: True streaming for APIs that support it (chunked transfer encoding).
 	 *
 	 * @param {string} url - Data source URL
-	 * @param {DatasetMetadata} metadata - Dataset metadata (not currently used)
+	 * @param {DatasetMetadata} _metadata - Dataset metadata (not currently used)
 	 * @param {AbortSignal} signal - Abort signal for cancellation
 	 * @param {ProgressiveOptions} config - Loading configuration
 	 * @returns {Promise<*>} Complete dataset
@@ -275,7 +274,8 @@ class ProgressiveLoader {
 		logger.debug('🔄 Starting progressive loading for:', url)
 
 		// Load the complete dataset
-		const response = await fetch(url, { signal, timeout: config.timeout })
+		// Note: `fetch` has no `timeout` option; cancellation is driven by `signal`.
+		const response = await fetch(url, { signal })
 
 		if (!response.ok) {
 			throw new Error(`HTTP ${response.status}: ${response.statusText}`)
@@ -284,7 +284,7 @@ class ProgressiveLoader {
 		const fullData = await response.json()
 
 		// Process data in chunks if it has features
-		if (fullData.features && fullData.features.length > config.chunkSize) {
+		if (fullData.features && fullData.features.length > (config.chunkSize ?? 1000)) {
 			return this.processDataInChunks(fullData, config)
 		} else {
 			// Small dataset, process normally
@@ -319,7 +319,7 @@ class ProgressiveLoader {
 		const totalFeatures = features.length
 		const chunkSize = config.adaptiveChunking
 			? this.calculateOptimalChunkSize(totalFeatures)
-			: config.chunkSize
+			: (config.chunkSize ?? 1000)
 
 		logger.debug(`📦 Processing ${totalFeatures} features in chunks of ${chunkSize}`)
 
@@ -438,9 +438,9 @@ class ProgressiveLoader {
 	 * Get statistics about active loads
 	 * Returns current loading state for monitoring and debugging.
 	 *
-	 * @returns {Object} Active load statistics
-	 * @returns {number} Object.activeLoads - Number of active loading operations
-	 * @returns {string[]} Object.loadIds - Array of active load IDs
+	 * @returns {{ activeLoads: number, loadIds: string[] }} Active load statistics:
+	 *   `activeLoads` is the number of active loading operations, `loadIds` is the
+	 *   array of active load IDs.
 	 *
 	 * @example
 	 * const stats = progressiveLoader.getLoadStats();

--- a/src/services/sensor.js
+++ b/src/services/sensor.js
@@ -75,7 +75,7 @@ export default class Vegetation {
 		// Iterate over the entities and add labels for "temp_air" and "rh_air"
 		for (let i = 0; i < entities.length; i++) {
 			const entity = entities[i]
-			const measurement = entity.properties._measurement._value
+			const measurement = entity.properties?._measurement?._value
 
 			if (measurement) {
 				const tempAir = measurement.temp_air
@@ -102,7 +102,7 @@ export default class Vegetation {
 
 				if (tempAir !== undefined && rhAir !== undefined) {
 					const Cesium = getCesium()
-					entity.label = {
+					entity.label = new Cesium.LabelGraphics({
 						text:
 							'Temp: ' +
 							tempAir.toFixed(1) +
@@ -118,7 +118,7 @@ export default class Vegetation {
 						fillColor: Cesium.Color.BLUE,
 						backgroundColor: Cesium.Color.YELLOW,
 						eyeOffset: new Cesium.Cartesian3(0, 0, -100),
-					}
+					})
 				}
 			}
 

--- a/src/services/sensor.js
+++ b/src/services/sensor.js
@@ -75,7 +75,7 @@ export default class Vegetation {
 		// Iterate over the entities and add labels for "temp_air" and "rh_air"
 		for (let i = 0; i < entities.length; i++) {
 			const entity = entities[i]
-			const measurement = entity.properties?._measurement?._value
+			const measurement = entity.properties?._measurement?.getValue()
 
 			if (measurement) {
 				const tempAir = measurement.temp_air

--- a/src/services/traveltime.js
+++ b/src/services/traveltime.js
@@ -76,7 +76,7 @@ export default class Traveltime {
 	 * Calculates polygon centroids using bounding sphere method.
 	 *
 	 * @param {Array<Object>} traveldata - Travel time records with to_id and pt_m_walk_avg
-	 * @returns {void}
+	 * @returns {Promise<void>}
 	 *
 	 * @example
 	 * // traveldata format:
@@ -86,7 +86,7 @@ export default class Traveltime {
 		const Cesium = getCesium()
 		const geoJsonData = {
 			type: 'FeatureCollection',
-			features: [],
+			features: /** @type {Array<Object>} */ ([]),
 		}
 
 		if (!this.viewer || this.viewer.isDestroyed?.()) return
@@ -152,7 +152,7 @@ export default class Traveltime {
 
 			if (!dataSource) {
 				logger.error('Data source with name PopulationGrid not found.')
-				return []
+				return
 			}
 
 			// Get the entities of the data source
@@ -173,7 +173,7 @@ export default class Traveltime {
 	 * Labels scale with camera distance for readability.
 	 *
 	 * @param {Object} data - GeoJSON FeatureCollection with point features
-	 * @returns {void}
+	 * @returns {Promise<void>}
 	 *
 	 * Label styling:
 	 * - Font: 24px sans-serif

--- a/src/services/tree.js
+++ b/src/services/tree.js
@@ -33,15 +33,6 @@ import unifiedLoader from './unifiedLoader.js'
  * @class Tree
  */
 
-/**
- * A Cesium GeoJSON entity augmented with the internal `_properties` PropertyBag.
- * Cesium populates `_properties` with `ConstantProperty`-like wrappers whose
- * underlying value is read via `._value`. This mirrors the public `properties`
- * getter but is what the runtime code reads directly.
- *
- * @typedef {Cesium.Entity & { _properties?: Record<string, { _value?: any } | undefined> }} TreeEntity
- */
-
 export default class Tree {
 	/**
 	 * Creates a Tree service instance
@@ -247,24 +238,21 @@ export default class Tree {
 		const propsStore = usePropsStore()
 
 		// Extract serializable tree data (prevents DataCloneError)
-		const treeData = entities.map((entity) => {
-			const e = /** @type {TreeEntity} */ (entity)
-			return {
-				kohde_id: e._properties?._kohde_id?._value,
-				p_ala_m2: e._properties?._p_ala_m2?._value,
-			}
-		})
+		const treeData = entities.map((entity) => ({
+			kohde_id: entity.properties?.kohde_id?.getValue(),
+			p_ala_m2: entity.properties?.p_ala_m2?.getValue(),
+		}))
 
 		// Extract serializable building data (prevents DataCloneError)
 		const buildingData = new Map()
-		const buildingEntities = /** @type {TreeEntity[]} */ (buildingsDataSource.entities.values)
+		const buildingEntities = buildingsDataSource.entities.values
 		for (const entity of buildingEntities) {
-			const id = entity._properties?._id?._value || entity._properties?._hki_id?._value
+			const id = entity.properties?.id?.getValue() || entity.properties?.hki_id?.getValue()
 			if (id) {
 				buildingData.set(id, {
-					heatExposure: entity._properties?.avgheatexposuretobuilding?._value,
-					area_m2: entity._properties?._area_m2?._value,
-					hki_id: entity._properties?._hki_id?._value,
+					heatExposure: entity.properties?.avgheatexposuretobuilding?.getValue(),
+					area_m2: entity.properties?.area_m2?.getValue(),
+					hki_id: entity.properties?.hki_id?.getValue(),
 				})
 			}
 		}
@@ -348,7 +336,7 @@ export default class Tree {
 		const Cesium = getCesium()
 		const treeEntities = treeDataSource.entities.values
 		for (let i = 0; i < treeEntities.length; i++) {
-			const entity = /** @type {TreeEntity} */ (treeEntities[i])
+			const entity = treeEntities[i]
 
 			const polygon = /** @type {any} */ (entity.polygon)
 			if (polygon) {
@@ -356,8 +344,9 @@ export default class Tree {
 				polygon.outlineWidth = 3
 			}
 
-			if (entity._properties?._description && polygon) {
-				this.setTreePolygonMaterialColor(entity, entity._properties._description._value)
+			const description = entity.properties?.description?.getValue()
+			if (description && polygon) {
+				this.setTreePolygonMaterialColor(entity, description)
 			}
 		}
 	}

--- a/src/services/tree.js
+++ b/src/services/tree.js
@@ -32,6 +32,16 @@ import unifiedLoader from './unifiedLoader.js'
  *
  * @class Tree
  */
+
+/**
+ * A Cesium GeoJSON entity augmented with the internal `_properties` PropertyBag.
+ * Cesium populates `_properties` with `ConstantProperty`-like wrappers whose
+ * underlying value is read via `._value`. This mirrors the public `properties`
+ * getter but is what the runtime code reads directly.
+ *
+ * @typedef {Cesium.Entity & { _properties?: Record<string, { _value?: any } | undefined> }} TreeEntity
+ */
+
 export default class Tree {
 	/**
 	 * Creates a Tree service instance
@@ -44,11 +54,16 @@ export default class Tree {
 
 	/**
 	 * Asynchronously load tree data using unified loader with coordinated parallel loading
-	 * @param {string} postalCode - Optional postal code to load trees for. If not provided, uses global store.postalcode
+	 * @param {string|null} [postalCode] - Optional postal code to load trees for. If not provided, uses global store.postalcode
 	 */
 	async loadTrees(postalCode = null) {
 		// Use provided postal code or fall back to global store
 		const targetPostalCode = postalCode || this.store.postalcode
+
+		if (!targetPostalCode) {
+			logger.warn('loadTrees called without a postal code; skipping')
+			return []
+		}
 
 		try {
 			// Define all tree height categories
@@ -98,10 +113,16 @@ export default class Tree {
 	async loadTreesWithKoodi(koodi) {
 		logger.warn('loadTreesWithKoodi is deprecated, use loadTrees() instead')
 
+		const postalCode = this.store.postalcode
+		if (!postalCode) {
+			logger.warn('loadTreesWithKoodi called without a postal code; skipping')
+			return null
+		}
+
 		try {
 			const data = await unifiedLoader.loadLayer({
 				layerId: `trees_${koodi}`,
-				url: this.urlStore.tree(this.store.postalcode, koodi),
+				url: this.urlStore.tree(postalCode, koodi),
 				type: 'geojson',
 				processor: (data, metadata) => this.addTreesDataSource(data, koodi, metadata),
 				options: {
@@ -142,7 +163,7 @@ export default class Tree {
 				entities,
 				(entity) => {
 					try {
-						const description = entity.properties._kuvaus?._value
+						const description = entity.properties?._kuvaus?._value
 						if (description) {
 							this.setTreePolygonMaterialColor(entity, description)
 						}
@@ -188,17 +209,19 @@ export default class Tree {
 			entities = treeDataSource.entities.values
 		}
 
+		const postalCode = this.store.postalcode
+
 		// Find the data source for buildings
 		const buildingsDataSource = this.datasourceService.getDataSourceByName(
-			`Buildings ${this.store.postalcode}`
+			`Buildings ${postalCode}`
 		)
 
 		// If the data source isn't found, exit the function
-		if (!buildingsDataSource) {
+		if (!buildingsDataSource || !postalCode) {
 			return
 		}
 
-		fetch(this.urlStore.treeBuildingDistance(this.store.postalcode))
+		fetch(this.urlStore.treeBuildingDistance(postalCode))
 			.then((response) => response.json())
 			.then((data) => {
 				this.setPropertiesAndEmitEvent(data, entities, buildingsDataSource)
@@ -224,14 +247,17 @@ export default class Tree {
 		const propsStore = usePropsStore()
 
 		// Extract serializable tree data (prevents DataCloneError)
-		const treeData = entities.map((entity) => ({
-			kohde_id: entity._properties?._kohde_id?._value,
-			p_ala_m2: entity._properties?._p_ala_m2?._value,
-		}))
+		const treeData = entities.map((entity) => {
+			const e = /** @type {TreeEntity} */ (entity)
+			return {
+				kohde_id: e._properties?._kohde_id?._value,
+				p_ala_m2: e._properties?._p_ala_m2?._value,
+			}
+		})
 
 		// Extract serializable building data (prevents DataCloneError)
 		const buildingData = new Map()
-		const buildingEntities = buildingsDataSource.entities.values
+		const buildingEntities = /** @type {TreeEntity[]} */ (buildingsDataSource.entities.values)
 		for (const entity of buildingEntities) {
 			const id = entity._properties?._id?._value || entity._properties?._hki_id?._value
 			if (id) {
@@ -322,12 +348,15 @@ export default class Tree {
 		const Cesium = getCesium()
 		const treeEntities = treeDataSource.entities.values
 		for (let i = 0; i < treeEntities.length; i++) {
-			const entity = treeEntities[i]
+			const entity = /** @type {TreeEntity} */ (treeEntities[i])
 
-			entity.polygon.outlineColor = Cesium.Color.BLACK
-			entity.polygon.outlineWidth = 3
+			const polygon = /** @type {any} */ (entity.polygon)
+			if (polygon) {
+				polygon.outlineColor = Cesium.Color.BLACK
+				polygon.outlineWidth = 3
+			}
 
-			if (entity._properties._description && entity.polygon) {
+			if (entity._properties?._description && polygon) {
 				this.setTreePolygonMaterialColor(entity, entity._properties._description._value)
 			}
 		}

--- a/src/services/unifiedLoader.js
+++ b/src/services/unifiedLoader.js
@@ -45,7 +45,8 @@ import progressiveLoader from './progressiveLoader.js'
  * Layer loading configuration
  * @typedef {Object} LayerConfig
  * @property {string} layerId - Unique identifier for the layer (used for tracking and caching)
- * @property {string} url - Data source URL (HTTP/HTTPS endpoint)
+ * @property {string} [url] - Data source URL (HTTP/HTTPS endpoint); omit when supplying in-memory `data`
+ * @property {*} [data] - Pre-loaded in-memory data (alternative to `url`)
  * @property {string} [type='geojson'] - Data type: 'geojson', 'json', 'text', 'blob', 'wms', 'tiles'
  * @property {Function} [processor] - Function to process loaded data: (data, metadata) => Promise<void>
  * @property {LoadingOptions} [options={}] - Additional loading options
@@ -62,6 +63,8 @@ import progressiveLoader from './progressiveLoader.js'
  * @property {boolean} [background=false] - Load in background (low priority)
  * @property {string} [priority='normal'] - Loading priority: 'critical', 'high', 'normal', 'low', 'background'
  * @property {boolean} [cacheOnly=false] - Cache data but don't return it (for prefetching)
+ * @property {boolean} [enableYielding] - Hint to yield to the main thread between batches (consumed by some processors)
+ * @property {number} [yieldInterval] - Number of batches between yields when enableYielding is set
  */
 
 /**
@@ -178,7 +181,7 @@ class UnifiedLoader {
 	 * });
 	 */
 	async loadLayer(config) {
-		const { layerId, url, type = 'geojson', processor, options = {} } = config
+		const { layerId, url = '', type = 'geojson', processor, options = {} } = config
 
 		const {
 			cache = true,
@@ -330,12 +333,12 @@ class UnifiedLoader {
 	 *
 	 * @param {string} layerId - Layer identifier
 	 * @param {string} url - Data source URL
-	 * @param {Function} processor - Data processor function
-	 * @param {Object} options - Progressive loading options
+	 * @param {Function} [processor] - Data processor function
+	 * @param {Object} [options] - Progressive loading options
 	 * @returns {Promise<*>} Complete dataset
 	 * @private
 	 */
-	async loadProgressively(layerId, url, processor, options) {
+	async loadProgressively(layerId, url, processor, options = {}) {
 		return await progressiveLoader.loadData(url, {
 			...options,
 			onProgress: (current, total) => {
@@ -359,14 +362,14 @@ class UnifiedLoader {
 	 * - Only batches in progressive mode (non-progressive processors expect full data)
 	 *
 	 * @param {*} data - Loaded data to process
-	 * @param {Function} processor - Processing function: (data, metadata) => Promise<void>
-	 * @param {string} layerId - Layer identifier
+	 * @param {Function} [processor] - Processing function: (data, metadata) => Promise<void> (no-op when omitted)
+	 * @param {string} [layerId] - Layer identifier
 	 * @param {ProcessingMetadata} [metadata={}] - Processing metadata
 	 * @returns {Promise<void>}
 	 * @throws {Error} If processing fails
 	 * @private
 	 */
-	async processData(data, processor, layerId, metadata = {}) {
+	async processData(data, processor, layerId = '', metadata = {}) {
 		if (!processor || !data) return
 
 		// Auto-fix GeoJSON missing type property
@@ -486,21 +489,25 @@ class UnifiedLoader {
 		// caller's AbortSignal fires. Keeps backoff delays from leaking a
 		// pending timer (up to MAX_RETRY_DELAY_MS) after cancellation.
 		const sleep = (ms) =>
-			new Promise((resolve, reject) => {
-				if (options.signal?.aborted) {
-					reject(options.signal.reason ?? new DOMException('Aborted', 'AbortError'))
-					return
-				}
-				const onAbort = () => {
-					clearTimeout(timer)
-					reject(options.signal?.reason ?? new DOMException('Aborted', 'AbortError'))
-				}
-				const timer = setTimeout(() => {
-					options.signal?.removeEventListener('abort', onAbort)
-					resolve()
-				}, ms)
-				options.signal?.addEventListener('abort', onAbort)
-			})
+			new Promise(
+				/** @type {(resolve: (value?: any) => void, reject: (reason?: any) => void) => void} */ (
+					(resolve, reject) => {
+						if (options.signal?.aborted) {
+							reject(options.signal.reason ?? new DOMException('Aborted', 'AbortError'))
+							return
+						}
+						const onAbort = () => {
+							clearTimeout(timer)
+							reject(options.signal?.reason ?? new DOMException('Aborted', 'AbortError'))
+						}
+						const timer = setTimeout(() => {
+							options.signal?.removeEventListener('abort', onAbort)
+							resolve()
+						}, ms)
+						options.signal?.addEventListener('abort', onAbort)
+					}
+				)
+			)
 
 		let lastError
 
@@ -723,11 +730,10 @@ class UnifiedLoader {
 
 		// Report any failures
 		results.forEach((result, index) => {
-			if (result.status === 'rejected' || result.value?.error) {
-				logger.error(
-					`Failed to load layer ${configs[index].layerId}:`,
-					result.reason || result.value?.error
-				)
+			if (result.status === 'rejected') {
+				logger.error(`Failed to load layer ${configs[index].layerId}:`, result.reason)
+			} else if (result.value?.error) {
+				logger.error(`Failed to load layer ${configs[index].layerId}:`, result.value.error)
 			}
 		})
 

--- a/src/services/urbanheat.js
+++ b/src/services/urbanheat.js
@@ -1,6 +1,7 @@
 import { useBuildingStore } from '../stores/buildingStore.js'
 import { useGlobalStore } from '../stores/globalStore.js'
 import { usePropsStore } from '../stores/propsStore.js'
+import { useToggleStore } from '../stores/toggleStore.js'
 import { useURLStore } from '../stores/urlStore.js'
 import { requestIdle } from '../utils/idle.js'
 import logger from '../utils/logger.js'
@@ -156,7 +157,7 @@ export default class Urbanheat {
 		let total = 0
 		const urbanHeatData = []
 		const heatTimeseries = []
-		const toggleStore = useGlobalStore()
+		const toggleStore = useToggleStore()
 		const inHelsinki = toggleStore.helsinkiView
 		const targetDate = this.store.heatDataDate
 
@@ -193,7 +194,7 @@ export default class Urbanheat {
 	setPropertiesAndCreateCharts(entities, features) {
 		const propsStore = usePropsStore()
 		const heatData = this.calculateAverageExposure(features)
-		propsStore.setHeatHistogramData(heatData[0])
+		propsStore.setHeatHistogramData(heatData?.[0] ?? [])
 		// Register entities with cesiumEntityManager for non-reactive entity management
 		cesiumEntityManager.registerBuildingEntities(entities)
 	}
@@ -207,6 +208,10 @@ export default class Urbanheat {
 	async findUrbanHeatData(data, postalCode) {
 		const buildingStore = useBuildingStore()
 		const postcode = postalCode || this.store.postalcode
+		if (!postcode) {
+			logger.warn('[UrbanHeat] findUrbanHeatData called without a postal code; skipping')
+			return null
+		}
 		buildingStore.setBuildingFeatures(data, postcode)
 
 		try {

--- a/src/services/vegetation.js
+++ b/src/services/vegetation.js
@@ -93,7 +93,7 @@ export default class Vegetation {
 
 				// Process batch
 				for (const entity of batch) {
-					const category = entity.properties?._koodi?._value
+					const category = entity.properties?._koodi?.getValue()
 					if (category) {
 						this.setVegetationPolygonMaterialColor(entity, category)
 					}

--- a/src/services/vegetation.js
+++ b/src/services/vegetation.js
@@ -2,6 +2,7 @@ import { useGlobalStore } from '../stores/globalStore.js'
 import { useURLStore } from '../stores/urlStore.js'
 import { requestIdle } from '../utils/idle.js'
 import logger from '../utils/logger.js'
+import { encodeURLParam, validatePostalCode } from '../utils/validators.js'
 import { getCesium } from './cesiumProvider.js'
 import Datasource from './datasource.js'
 import unifiedLoader from './unifiedLoader.js'
@@ -43,9 +44,19 @@ export default class Vegetation {
 	 */
 	async loadVegetation() {
 		try {
+			// BUG FIX: urlStore has no `vegetation` getter, so the previous
+			// `this.urlStore.vegetation(...)` threw `TypeError: ... is not a function`
+			// at runtime. Build the vegetation collection URL here, mirroring the
+			// sibling `otherNature`/`tree` getters (validated postal code + encoded query).
+			if (this.store.postalcode == null) {
+				return
+			}
+			const validated = validatePostalCode(this.store.postalcode)
+			const url = `${this.urlStore.pygeoapiBase}/vegetation/items?f=json&limit=100000&postinumero=${encodeURLParam(validated)}`
+
 			const data = await unifiedLoader.loadLayer({
 				layerId: 'vegetation',
-				url: this.urlStore.vegetation(this.store.postalcode),
+				url,
 				type: 'geojson',
 				processor: (data) => this.addVegetationDataSource(data),
 				options: {
@@ -82,7 +93,7 @@ export default class Vegetation {
 
 				// Process batch
 				for (const entity of batch) {
-					const category = entity.properties._koodi?._value
+					const category = entity.properties?._koodi?._value
 					if (category) {
 						this.setVegetationPolygonMaterialColor(entity, category)
 					}

--- a/src/services/viewportBuildingLoader.js
+++ b/src/services/viewportBuildingLoader.js
@@ -31,7 +31,7 @@
  */
 
 import { useBuildingStore } from '../stores/buildingStore.js'
-import { useFeatureFlagStore } from '../stores/featureFlagStore.ts'
+import { useFeatureFlagStore } from '../stores/featureFlagStore'
 import { useGlobalStore } from '../stores/globalStore.js'
 import { useLoadingStore } from '../stores/loadingStore.js'
 import { useToggleStore } from '../stores/toggleStore.js'
@@ -885,7 +885,9 @@ export default class ViewportBuildingLoader {
 		if (polygon && properties?.avgheatexposuretobuilding) {
 			const Cesium = getCesium()
 			const heatExposureValue = properties.avgheatexposuretobuilding._value
-			polygon.material = new Cesium.Color(1, 1 - heatExposureValue, 0, heatExposureValue)
+			polygon.material = new Cesium.ColorMaterialProperty(
+				new Cesium.Color(1, 1 - heatExposureValue, 0, heatExposureValue)
+			)
 		}
 	}
 
@@ -897,11 +899,14 @@ export default class ViewportBuildingLoader {
 	 * @returns {Promise<void>}
 	 */
 	async setHelsinkiBuildingsHeight(entities) {
+		const Cesium = getCesium()
 		await processBatchAdaptive(
 			entities,
 			(entity) => {
 				if (entity.polygon) {
-					entity.polygon.extrudedHeight = calculateBuildingHeight(entity.properties)
+					entity.polygon.extrudedHeight = new Cesium.ConstantProperty(
+						calculateBuildingHeight(entity.properties)
+					)
 				}
 			},
 			{ processorName: 'viewportHeightExtrusion' }
@@ -931,10 +936,11 @@ export default class ViewportBuildingLoader {
 
 					// Set height based on floor count (3.2m per floor) or default
 					// Filter out invalid floor counts (>= 999 indicates data quality issue)
-					entity.polygon.extrudedHeight =
+					entity.polygon.extrudedHeight = new Cesium.ConstantProperty(
 						floorCount != null && floorCount < 999
 							? floorCount * FLOOR_HEIGHT
 							: DEFAULT_BUILDING_HEIGHT
+					)
 
 					// Try to get heat exposure from heat_timeseries for the current date
 					const heatTimeseries = entity.properties?.heat_timeseries?._value
@@ -1004,7 +1010,8 @@ export default class ViewportBuildingLoader {
 		const entityData = []
 		for (const entity of entities) {
 			if (entity.polygon?.material) {
-				const color = entity.polygon.material.color?.getValue?.(now)
+				const material = /** @type {Cesium.ColorMaterialProperty} */ (entity.polygon.material)
+				const color = material.color?.getValue?.(now)
 				if (color) {
 					entityData.push({
 						entity,
@@ -1435,6 +1442,7 @@ export default class ViewportBuildingLoader {
 			!this.prefetchCancelled
 		) {
 			const tile = this.prefetchQueue.shift()
+			if (tile === undefined) continue
 
 			// Skip if tile was loaded while in queue
 			if (this.loadedTiles.has(tile) || this.loadingTiles.has(tile)) {

--- a/src/services/visibilityLogger.js
+++ b/src/services/visibilityLogger.js
@@ -39,7 +39,7 @@ export function logVisibilityChange(type, name, oldValue, newValue, source) {
 		from: oldValue,
 		to: newValue,
 		source,
-		stack: new Error().stack.split('\n').slice(2, 6).join('\n'), // Caller info
+		stack: (new Error().stack ?? '').split('\n').slice(2, 6).join('\n'), // Caller info
 	}
 
 	visibilityLog.push(entry)
@@ -75,7 +75,7 @@ export function logBatchVisibilityChange(type, count, newValue, source) {
 		from: null,
 		to: newValue,
 		source,
-		stack: new Error().stack.split('\n').slice(2, 6).join('\n'),
+		stack: (new Error().stack ?? '').split('\n').slice(2, 6).join('\n'),
 	}
 
 	visibilityLog.push(entry)
@@ -249,7 +249,9 @@ export function findEntries(filter = {}) {
 
 // Make available globally for console access
 if (typeof window !== 'undefined') {
-	window.visibilityLog = {
+	// Debug-only global; not part of the typed Window surface.
+	const debugWindow = /** @type {Window & { visibilityLog?: object }} */ (window)
+	debugWindow.visibilityLog = {
 		getLog: getVisibilityLog,
 		clear: clearVisibilityLog,
 		analyze: analyzeBlinking,

--- a/src/services/vttFlood.js
+++ b/src/services/vttFlood.js
@@ -24,7 +24,7 @@ import {
 	VTT_MAX_EXTRUSION_M,
 	validateFrameNumber,
 	validateScenarioId,
-} from '../constants/vttFlood.ts'
+} from '../constants/vttFlood'
 import logger from '../utils/logger.js'
 import { getCesium } from './cesiumProvider.js'
 
@@ -38,6 +38,7 @@ const DIMENSION_KEYS = VTT_DIMENSIONS.map((d) => d.key)
  * @returns {Record<string, {min: number, max: number}>}
  */
 function computePropertyRanges(features) {
+	/** @type {Record<string, {min: number, max: number}>} */
 	const ranges = {}
 	for (const key of DIMENSION_KEYS) {
 		ranges[key] = { min: Number.POSITIVE_INFINITY, max: Number.NEGATIVE_INFINITY }
@@ -78,7 +79,13 @@ function computePropertyRanges(features) {
  *   AbortError propagates as-is so callers can distinguish cancellation from
  *   real failures.
  */
-export async function fetchSimulationFrame({ scenarioId, frameNumber, signal } = {}) {
+export async function fetchSimulationFrame(
+	{
+		scenarioId,
+		frameNumber,
+		signal,
+	} = /** @type {{scenarioId: string, frameNumber: number, signal?: AbortSignal}} */ ({})
+) {
 	const safeScenario = validateScenarioId(scenarioId)
 	const safeFrame = validateFrameNumber(frameNumber)
 
@@ -159,7 +166,13 @@ function extractRing(geometry) {
  * @param {string} params.dimension - Active dimension key (one of {@link VTT_DIMENSIONS}).
  * @returns {Promise<number>} Number of entities created.
  */
-export async function renderFlood({ viewer, frame, dimension } = {}) {
+export async function renderFlood(
+	{
+		viewer,
+		frame,
+		dimension,
+	} = /** @type {{viewer: Cesium.Viewer, frame: {features: Array<Object>, propertyRanges: Record<string, {min: number, max: number}>}, dimension: string}} */ ({})
+) {
 	if (!viewer || viewer.isDestroyed?.()) {
 		logger.warn('[VTTFlood] renderFlood: viewer not initialized; skipping')
 		return 0
@@ -216,10 +229,14 @@ export async function renderFlood({ viewer, frame, dimension } = {}) {
  * @param {Cesium.Viewer} params.viewer - Cesium viewer.
  * @returns {Promise<void>}
  */
-export async function clearFlood({ viewer } = {}) {
+export async function clearFlood({ viewer } = /** @type {{viewer: Cesium.Viewer}} */ ({})) {
 	if (!viewer || viewer.isDestroyed?.() || !viewer.dataSources) return
-	const sources = viewer.dataSources._dataSources || []
-	for (const ds of [...sources]) {
+	// Snapshot via the public DataSourceCollection API before mutating it.
+	const sources = /** @type {Array<Cesium.DataSource>} */ ([])
+	for (let i = 0; i < viewer.dataSources.length; i++) {
+		sources.push(viewer.dataSources.get(i))
+	}
+	for (const ds of sources) {
 		if (ds.name === VTT_FLOOD_LAYER_NAME) {
 			viewer.dataSources.remove(ds, true)
 		}

--- a/src/services/wms.js
+++ b/src/services/wms.js
@@ -2,6 +2,15 @@ import { useURLStore } from '../stores/urlStore.js'
 import { getGlobalWMSRetryHandler } from '../utils/wmsRetryHandler.js'
 import { getCesium } from './cesiumProvider.js'
 
+/** @typedef {import('../utils/wmsRetryHandler.js').WMSRetryHandler} WMSRetryHandler */
+
+/**
+ * Cesium ImageryLayer augmented with a stored error-listener remover.
+ * `createHelsinkiImageryLayer` attaches `_removeErrorHandler` so
+ * `removeHelsinkiImageryLayer` can detach the provider's error listener.
+ * @typedef {Cesium.ImageryLayer & { _removeErrorHandler?: () => void }} HelsinkiImageryLayer
+ */
+
 /**
  * WMS (Web Map Service) Integration Service
  * Provides utilities for creating and managing WMS imagery layers in Cesium.
@@ -87,7 +96,7 @@ export default class Wms {
 		}
 		const removeErrorListener = provider.errorEvent.addEventListener(errorHandler)
 
-		const layer = new Cesium.ImageryLayer(provider)
+		const layer = /** @type {HelsinkiImageryLayer} */ (new Cesium.ImageryLayer(provider))
 		layer._removeErrorHandler = removeErrorListener
 
 		return layer
@@ -98,7 +107,7 @@ export default class Wms {
 	 * Use this instead of directly calling imageryLayers.remove() to prevent listener leaks.
 	 *
 	 * @param {Cesium.ImageryLayerCollection} imageryLayers - The viewer's imagery layer collection
-	 * @param {Cesium.ImageryLayer} layer - The imagery layer to remove (created by createHelsinkiImageryLayer)
+	 * @param {HelsinkiImageryLayer} layer - The imagery layer to remove (created by createHelsinkiImageryLayer)
 	 */
 	removeHelsinkiImageryLayer(imageryLayers, layer) {
 		if (!layer) return

--- a/src/stores/backgroundMapStore.js
+++ b/src/stores/backgroundMapStore.js
@@ -31,10 +31,14 @@ export const useBackgroundMapStore = defineStore('backgroundMap', {
 	state: () => ({
 		hsyYear: 2024,
 		hsySelectArea: 'Askisto',
+		/** @type {Object|null} */
 		hSYWMSLayers: null,
 		ndviDate: '2022-06-26',
+		/** @type {Array<Object>} */
 		tiffLayers: [],
+		/** @type {Array<Object>} */
 		landcoverLayers: [],
+		/** @type {Array<Object>} */
 		floodLayers: [],
 	}),
 	actions: {

--- a/src/stores/buildingStore.js
+++ b/src/stores/buildingStore.js
@@ -13,16 +13,22 @@ import logger from '../utils/logger.js'
  * Manages selected building entity data and time-series date for heat exposure visualization.
  * Uses an LRU cache to limit memory usage by keeping only the most recently accessed postal codes.
  *
+ * @typedef {Object} FeatureCollection
+ * @property {string} type
+ * @property {Array<Object>} features
+ *
  * @typedef {Object} BuildingState
- * @property {Object|null} buildingFeatures - Accumulated building GeoJSON features with properties from loaded postal codes
+ * @property {FeatureCollection|null} buildingFeatures - Accumulated building GeoJSON features with properties from loaded postal codes
  * @property {string} timeseriesDate - Selected date for building heat time-series (YYYY-MM-DD)
  * @property {Map<string, number>} postalCodeCache - LRU cache tracking postal codes and their access timestamps
  * @property {number} maxPostalCodes - Maximum number of postal codes to keep in cache (default: 10)
  */
 export const useBuildingStore = defineStore('building', {
 	state: () => ({
+		/** @type {FeatureCollection|null} */
 		buildingFeatures: null,
 		timeseriesDate: '2023-06-23',
+		/** @type {Map<string, number>} */
 		postalCodeCache: new Map(),
 		// Must match MAX_LOADED_TILES in viewportBuildingLoader.js to prevent
 		// tooltip data being evicted while buildings are still visible on screen

--- a/src/stores/globalStore.js
+++ b/src/stores/globalStore.js
@@ -73,7 +73,9 @@ import logger from '../utils/logger.js'
 export const useGlobalStore = defineStore('global', {
 	state: () => ({
 		view: 'capitalRegion',
+		/** @type {string|null} */
 		postalcode: null,
+		/** @type {string|null} */
 		nameOfZone: null,
 		averageHeatExposure: 0,
 		averageTreeArea: 0,
@@ -96,9 +98,13 @@ export const useGlobalStore = defineStore('global', {
 			'2025-07-14': { min: 284.924407958, max: 328.2204589844 },
 		},
 		heatDataDate: '2022-06-28',
+		/** @type {Object|null} */
 		currentGridCell: null,
+		/** @type {Object|null} */
 		cesiumViewer: null,
+		/** @type {string|null} */
 		buildingAddress: null,
+		/** @type {Object|null} */
 		pickedEntity: null,
 		isLoading: false,
 		showBuildingInfo: true,
@@ -111,11 +117,16 @@ export const useGlobalStore = defineStore('global', {
 			stage: null,
 			startTime: null,
 			canCancel: false,
+			/** @type {Object|null} */
 			error: null,
+			/** @type {Object|null} */
 			partialData: null,
 			retryCount: 0,
+			/** @type {Object|null} */
 			previousViewState: null,
+			/** @type {Object|null} */
 			loadingProgress: null, // { current: number, total: number } for progressive updates (FR-3.2)
+			/** @type {{postalCode: string, postalCodeName: string}|null} */
 			pendingNavigation: null, // { postalCode: string, postalCodeName: string } for latest-wins pattern
 		},
 	}),

--- a/src/stores/globalStore.js
+++ b/src/stores/globalStore.js
@@ -189,14 +189,14 @@ export const useGlobalStore = defineStore('global', {
 		/**
 		 * Sets the selected postal code for data loading
 		 * Triggers loading of postal code-specific data layers.
-		 * @param {string} postalcode - Five-digit postal code (e.g., '00100')
+		 * @param {string|null} postalcode - Five-digit postal code (e.g., '00100'), or null to clear
 		 */
 		setPostalCode(postalcode) {
 			this.postalcode = postalcode
 		},
 		/**
 		 * Sets the name of the selected zone or neighborhood
-		 * @param {string} nameOfZone - Zone name (e.g., 'Alppila - Vallila')
+		 * @param {string|null} nameOfZone - Zone name (e.g., 'Alppila - Vallila'), or null to clear
 		 */
 		setNameOfZone(nameOfZone) {
 			this.nameOfZone = nameOfZone

--- a/src/stores/heatExposureStore.js
+++ b/src/stores/heatExposureStore.js
@@ -25,7 +25,9 @@ import { useURLStore } from './urlStore.js'
  */
 export const useHeatExposureStore = defineStore('heatExposure', {
 	state: () => ({
+		/** @type {Array<Object>|null} */
 		data: null, // Stores the raw Postal code data
+		/** @type {Map<string, Object>|null} */
 		dataByPostcode: null, // Map-based index for O(1) lookups
 	}),
 	getters: {

--- a/src/stores/loadingStore.js
+++ b/src/stores/loadingStore.js
@@ -205,6 +205,11 @@ export const useLoadingStore = defineStore('loading', {
 		},
 
 		// Update loading progress for a layer
+		/**
+		 * @param {string} layerName
+		 * @param {number} current
+		 * @param {string|null} [message]
+		 */
 		updateLayerProgress(layerName, current, message = null) {
 			if (this.loadingProgress[layerName]) {
 				this.loadingProgress[layerName].current = current

--- a/src/stores/loadingStore.js
+++ b/src/stores/loadingStore.js
@@ -42,7 +42,12 @@ export const useLoadingStore = defineStore('loading', {
 		isLoading: false,
 
 		// Stale loading cleanup timer ID (for automatic cleanup)
+		/** @type {ReturnType<typeof setInterval>|null} */
 		_staleCleanupTimer: null,
+
+		// beforeunload handler reference (registered lazily when the timer starts)
+		/** @type {(() => void)|null} */
+		_staleCleanupUnloadHandler: null,
 
 		// Individual layer loading states
 		layerLoading: {
@@ -458,7 +463,7 @@ export const useLoadingStore = defineStore('loading', {
 		 * Update cache status for a layer (called by unifiedLoader after caching)
 		 * @param {string} layerId - Layer identifier
 		 * @param {boolean} cached - Whether data is cached
-		 * @param {number} timestamp - Cache timestamp
+		 * @param {number|null} [timestamp] - Cache timestamp
 		 */
 		updateCacheStatus(layerId, cached, timestamp = null) {
 			// Extract base layer name from layerId (e.g., "viewport_buildings_hsy_2499_6025" -> dynamic)

--- a/src/stores/mitigationStore.js
+++ b/src/stores/mitigationStore.js
@@ -36,22 +36,41 @@ import { processBatchAdaptive } from '../utils/batchProcessor.js'
 import logger from '../utils/logger.js'
 
 /**
+ * @typedef {Object} CoolingCenter
+ * @property {number} euref_x - EUREF-FIN X coordinate
+ * @property {number} euref_y - EUREF-FIN Y coordinate
+ * @property {string|number} [grid_id] - Grid cell identifier the center sits in
+ * @property {number} [capacity] - Cooling capacity of the center
+ */
+
+/**
+ * @typedef {Object} GridCell
+ * @property {string|number} id - Grid cell identifier (grid_id)
+ * @property {number} x - EUREF-FIN X coordinate
+ * @property {number} y - EUREF-FIN Y coordinate
+ */
+
+/**
  * Mitigation Pinia Store
  * Models heat mitigation impacts with spatial decay and cumulative tracking.
  * Many methods already have inline JSDoc comments.
  */
 export const useMitigationStore = defineStore('mitigation', {
 	state: () => ({
+		/** @type {CoolingCenter[]} */
 		coolingCenters: [],
 		/** Version counter for coolingCenters - increment when array changes to enable efficient watching */
 		coolingCentersVersion: 0,
 		reachability: 1000,
 		maxReduction: 0.2,
 		minReduction: 0.04,
+		/** @type {Array<number|string>} */
 		affected: [],
 		impact: 0,
 		optimalEffect: 4.64,
+		/** @type {Object<string, number>} */
 		gridImpacts: {}, // Store impact for each grid_id
+		/** @type {GridCell[]} */
 		gridCells: [], // Add gridCells here
 		optimised: false,
 		parks2022CoolingConstant: 0.177,
@@ -62,6 +81,7 @@ export const useMitigationStore = defineStore('mitigation', {
 		heatReducedByParks: 0,
 		totalAreaEffected: 0,
 		percentageMax: 0,
+		/** @type {Object<string, number>} */
 		modifiedHeatIndices: {},
 		cumulativeCoolingArea: 0,
 		cumulativeHeatReduction: 0,
@@ -320,7 +340,7 @@ export const useMitigationStore = defineStore('mitigation', {
 		getCoolingCapacity(gridId) {
 			return this.coolingCenters
 				.filter((center) => center.grid_id === gridId)
-				.reduce((total, center) => total + center.capacity, 0)
+				.reduce((total, center) => total + (center.capacity ?? 0), 0)
 		},
 		getReductionValue(distance) {
 			return distance > this.reachability

--- a/src/stores/mitigationStore.js
+++ b/src/stores/mitigationStore.js
@@ -48,6 +48,7 @@ import logger from '../utils/logger.js'
  * @property {string|number} id - Grid cell identifier (grid_id)
  * @property {number} x - EUREF-FIN X coordinate
  * @property {number} y - EUREF-FIN Y coordinate
+ * @property {import('cesium').Entity} [entity] - Optional Cesium entity reference; intentionally omitted by setGridCells (see note there)
  */
 
 /**

--- a/src/stores/propsStore.js
+++ b/src/stores/propsStore.js
@@ -37,21 +37,36 @@ import { markRaw } from 'vue'
  * @property {Object} numericalSelect - Selected numerical attribute for charts
  * @property {string} socioEconomics - Selected socioeconomic area name
  * @property {string} statsIndex - Selected statistical index for visualization
+ * @property {Array<Object>|null} hSYWMSLayers - HSY WMS layer references (set via deprecated setHSYWMSLayers)
  */
 export const usePropsStore = defineStore('props', {
 	state: () => ({
+		/** @type {Object|null} */
 		gridBuildingProps: null,
+		/** @type {number|null} */
 		treeArea: null,
+		/** @type {number|null} */
 		buildingHeatExposure: null,
+		/** @type {Array<Object>|null} */
 		heatHistogramData: null,
+		/** @type {Array<Object>|null} */
 		treeBuildingDistanceData: null,
+		/** @type {Map<string, number>|null} */
 		treeAreasByBuildingId: null,
+		/** @type {Array<Object>|null} */
 		treeData: null,
+		/** @type {Map<string, Object>|null} */
 		buildingData: null,
+		/** @type {Array<Object>|null} */
 		postalcodeHeatTimeseries: null,
+		/** @type {Array<Object>|null} */
 		buildingHeatTimeseries: null,
+		/** @type {Object|null} */
 		heatFloodVulnerabilityEntity: null,
+		/** @type {Object|null} */
 		postalCodeData: null,
+		/** @type {Array<Object>|null} */
+		hSYWMSLayers: null,
 		categoricalSelect: { text: 'Facade Material', value: 'julkisivu_s' },
 		numericalSelect: { text: 'Area', value: 'area_m2' },
 		socioEconomics: 'Alppila - Vallila',

--- a/src/stores/socioEconomicsStore.js
+++ b/src/stores/socioEconomicsStore.js
@@ -33,15 +33,26 @@ import logger from '../utils/logger.js'
  * Socio-Economics Pinia Store
  * Manages Paavo postal code statistics with regional and Helsinki-specific aggregations.
  *
+ * @typedef {Object} MinMax
+ * @property {number|null} min
+ * @property {number|null} max
+ *
+ * @typedef {Object} SocioEconomicsStatistics
+ * @property {MinMax} ra_as_kpa
+ * @property {MinMax} hr_ktu
+ *
  * @typedef {Object} SocioEconomicsState
  * @property {Array<Object>|null} data - Paavo postal code statistics (filtered)
- * @property {Object|null} regionStatistics - Min/max values for Capital Region
- * @property {Object|null} helsinkiStatistics - Min/max values for Helsinki only
+ * @property {SocioEconomicsStatistics|null} regionStatistics - Min/max values for Capital Region
+ * @property {SocioEconomicsStatistics|null} helsinkiStatistics - Min/max values for Helsinki only
  */
 export const useSocioEconomicsStore = defineStore('socioEconomics', {
 	state: () => ({
+		/** @type {Array<Object>|null} */
 		data: null, // Stores the raw Paavo data
+		/** @type {SocioEconomicsStatistics|null} */
 		regionStatistics: null, // Stores min and max values for attributes
+		/** @type {SocioEconomicsStatistics|null} */
 		helsinkiStatistics: null,
 	}),
 	getters: {
@@ -150,6 +161,7 @@ export const useSocioEconomicsStore = defineStore('socioEconomics', {
 				.map((feature) => feature.properties)
 
 			// Single-pass calculation of both region and Helsinki statistics
+			if (!this.data) return
 			const stats = this.data.reduce(
 				(acc, item) => {
 					const raAsKpa = Number(item.ra_as_kpa)
@@ -234,6 +246,7 @@ export const useSocioEconomicsStore = defineStore('socioEconomics', {
 		 */
 		addRegionStatisticsToStore() {
 			// Single-pass min/max calculation for all attributes
+			if (!this.data) return
 			const stats = this.data.reduce(
 				(acc, item) => {
 					const raAsKpa = Number(item.ra_as_kpa)
@@ -275,6 +288,7 @@ export const useSocioEconomicsStore = defineStore('socioEconomics', {
 		 */
 		addHelsinkiStatisticsToStore() {
 			// Single-pass: filter Helsinki data and calculate min/max simultaneously
+			if (!this.data) return
 			const stats = this.data.reduce(
 				(acc, item) => {
 					// Skip non-Helsinki items

--- a/src/stores/urlStore.js
+++ b/src/stores/urlStore.js
@@ -206,6 +206,19 @@ export const useURLStore = defineStore('url', {
 				return `${state.pygeoapiBase}/othernature/items?f=json&limit=${limit}&postinumero=${encodeURLParam(validated)}`
 			},
 		/**
+		 * Generates URL for vegetation surfaces by postal code
+		 * @param {Object} state - Pinia state
+		 * @returns {(postinumero: string, limit?: number) => string} Function accepting postal code and optional limit, returning vegetation URL
+		 * @example
+		 * vegetation(state)('00100', 100000) // Vegetation in postal code 00100
+		 */
+		vegetation:
+			(state) =>
+			(postinumero, limit = 100000) => {
+				const validated = validatePostalCode(postinumero)
+				return `${state.pygeoapiBase}/vegetation/items?f=json&limit=${limit}&postinumero=${encodeURLParam(validated)}`
+			},
+		/**
 		 * Generates URL for tree canopy data by postal code and height category
 		 * @param {Object} state - Pinia state
 		 * @returns {(postinumero: string, koodi: string, limit?: number) => string} Function accepting postal code, height category code, and optional limit, returning tree URL

--- a/src/types/assets.d.ts
+++ b/src/types/assets.d.ts
@@ -1,0 +1,14 @@
+// Ambient module declarations for non-code asset imports.
+//
+// Vite resolves CSS (and other asset) imports as side-effect modules at build
+// time, but TypeScript has no built-in knowledge of these specifiers and reports
+// TS2307 ("Cannot find module ... or its corresponding type declarations").
+// Declaring them here lets `import('...css')` type-check while leaving the
+// literal specifier intact for Vite's bundler to process.
+//
+// This is types-only; it emits no runtime code.
+
+declare module '*.css' {
+	const content: string
+	export default content
+}

--- a/src/types/cesium-global.d.ts
+++ b/src/types/cesium-global.d.ts
@@ -1,0 +1,17 @@
+// Ambient global `Cesium` namespace for JSDoc type references in plain .js files.
+//
+// The `cesium` package ships its types as a flat ES module (no global namespace),
+// so JSDoc annotations like `/** @type {Cesium.Entity} */` cannot resolve `Cesium`
+// without this shim. Here we import the module's types and re-export them under a
+// global `namespace Cesium`, making `Cesium.*` resolvable everywhere in the project
+// without a per-file `import * as Cesium from 'cesium'`.
+//
+// This is types-only; it emits no runtime code.
+
+import * as CesiumModule from 'cesium';
+
+export {};
+
+declare global {
+	export import Cesium = CesiumModule;
+}

--- a/src/types/cesium-global.d.ts
+++ b/src/types/cesium-global.d.ts
@@ -8,10 +8,8 @@
 //
 // This is types-only; it emits no runtime code.
 
-import * as CesiumModule from 'cesium';
-
-export {};
+import * as CesiumModule from 'cesium'
 
 declare global {
-	export import Cesium = CesiumModule;
+	export import Cesium = CesiumModule
 }

--- a/src/utils/batchProcessor.js
+++ b/src/utils/batchProcessor.js
@@ -44,7 +44,7 @@ async function yieldToMain() {
 			globalThis.scheduler.yield().then(resolve)
 		} else {
 			// Fallback to requestIdleCallback (with WebKit/iOS-safe setTimeout shim)
-			requestIdle(resolve, { timeout: 50 })
+			requestIdle(() => resolve(), { timeout: 50 })
 		}
 	})
 }
@@ -146,6 +146,7 @@ function calculateOptimalSize(batchTimes) {
  * Process items in adaptive batches that maintain 60fps.
  * Automatically adjusts batch size based on measured performance.
  *
+ * @template T
  * @param {Array<T>} items - Items to process
  * @param {(item: T) => void | Promise<void>} processor - Function to process each item
  * @param {Object} [options={}] - Configuration options
@@ -226,6 +227,7 @@ export async function processBatchAdaptive(items, processor, options = {}) {
  * Processes an array of items in batches with optional yielding to main thread.
  * By default uses adaptive sizing; set adaptive: false for fixed-size legacy mode.
  *
+ * @template T
  * @param {Array<T>} items - Array of items to process.
  * @param {(item: T, index: number, batch: T[], batchIndex: number) => void | Promise<void>} processor -
  *        Function called for each item. Receives item, absolute index, current batch array, and batch index.
@@ -266,18 +268,17 @@ export async function processBatchAdaptive(items, processor, options = {}) {
  */
 export async function processBatch(items, processor, options = {}) {
 	const { yieldToMain: shouldYield = true, adaptive = true } = options
-	let { batchSize = INITIAL_BATCH_SIZE } = options
+	const { batchSize: batchSizeOption = INITIAL_BATCH_SIZE } = options
 
 	// Handle empty array
 	if (!items || items.length === 0) {
 		return
 	}
 
-	// Support adaptive batch sizing via function (forces legacy mode)
-	const hasDynamicBatchSize = typeof batchSize === 'function'
-	if (hasDynamicBatchSize) {
-		batchSize = batchSize(items.length)
-	}
+	// Support adaptive batch sizing via function (forces legacy mode).
+	// Resolve the union into a concrete number so downstream arithmetic is typed.
+	const hasDynamicBatchSize = typeof batchSizeOption === 'function'
+	const batchSize = hasDynamicBatchSize ? batchSizeOption(items.length) : batchSizeOption
 
 	// Use adaptive mode by default unless explicitly disabled or using dynamic batch size
 	if (adaptive && !hasDynamicBatchSize) {

--- a/src/utils/entityStyling.js
+++ b/src/utils/entityStyling.js
@@ -34,11 +34,7 @@ export const FLOOR_HEIGHT = 3.2
  * 2. Floor count (i_kerrlkm) * FLOOR_HEIGHT - Estimated from number of floors
  * 3. DEFAULT_BUILDING_HEIGHT - Fallback when no data available
  *
- * @param {Object} [properties] - Entity properties object from Cesium entity.
- * @param {Object} [properties.measured_height] - Measured height property.
- * @param {number} [properties.measured_height._value] - Height value in meters.
- * @param {Object} [properties.i_kerrlkm] - Floor count property (Finnish: kerrosluku).
- * @param {number} [properties.i_kerrlkm._value] - Number of floors.
+ * @param {import('cesium').PropertyBag | { measured_height?: { _value?: number }, i_kerrlkm?: { _value?: number } }} [properties] - Entity properties object (a Cesium PropertyBag, or a plain object with the same shape).
  * @returns {number} Building height in meters.
  *
  * @example

--- a/src/utils/idle.js
+++ b/src/utils/idle.js
@@ -59,12 +59,18 @@ export function requestIdle(callback, options) {
 	}
 	// WebKit fallback: invoke via setTimeout with a stub deadline so call sites
 	// using `deadline.timeRemaining()` / `deadline.didTimeout` keep working.
-	return setTimeout(() => {
-		callback({
-			didTimeout: false,
-			timeRemaining: () => 0,
-		})
-	}, 1)
+	// In the browser `setTimeout` returns a numeric handle; cast away the
+	// Node `Timeout` overload that @types/node otherwise resolves here.
+	return /** @type {number} */ (
+		/** @type {unknown} */ (
+			setTimeout(() => {
+				callback({
+					didTimeout: false,
+					timeRemaining: () => 0,
+				})
+			}, 1)
+		)
+	)
 }
 
 /**

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 /**
  * Development Logger Utility
  *

--- a/src/utils/preloadErrorHandler.js
+++ b/src/utils/preloadErrorHandler.js
@@ -24,6 +24,14 @@
 import logger from './logger.js'
 
 /**
+ * Window augmented with the idempotency flags this module stores on it.
+ * @typedef {Window & {
+ *   __r4cPreloadErrorHandlerInstalled?: boolean,
+ *   __r4cPreloadErrorHandlerCleanup?: (() => void) | null,
+ * }} PreloadHandlerWindow
+ */
+
+/**
  * Session-storage key used to short-circuit a reload-loop when even the
  * fresh `index.html` cannot recover. If we just reloaded for a preload
  * error and immediately hit another one, the problem is not stale chunks
@@ -60,7 +68,9 @@ const RELOAD_GUARD_WINDOW_MS = 10_000
  * installPreloadErrorHandler()
  */
 export function installPreloadErrorHandler(deps = {}) {
-	const win = deps.win ?? (typeof window !== 'undefined' ? window : null)
+	const win = /** @type {PreloadHandlerWindow | null} */ (
+		deps.win ?? (typeof window !== 'undefined' ? window : null)
+	)
 	if (!win) {
 		// Non-browser environment (SSR, unit-test without DOM) — no-op.
 		return () => {}
@@ -70,6 +80,7 @@ export function installPreloadErrorHandler(deps = {}) {
 	// and restricted iframes — accessing the property triggers the throw, not the
 	// later get/setItem calls. Without this guard, a crash at the top of main.js
 	// would block app boot for those users.
+	/** @type {Storage | null | undefined} */
 	let storage = deps.storage
 	if (storage === undefined) {
 		try {

--- a/src/version.js
+++ b/src/version.js
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 /**
  * @module version
  * @description Auto-generated version information module

--- a/tests/unit/services/building/buildingHighlighter.test.js
+++ b/tests/unit/services/building/buildingHighlighter.test.js
@@ -59,8 +59,9 @@ describe('BuildingHighlighter', () => {
 
 			highlighter.polygonOutlineToBlack(entity)
 
-			expect(entity.polygon.outlineColor).toBe(Cesium.Color.BLACK)
-			expect(entity.polygon.outlineWidth).toBe(8)
+			// Production wraps raw assignments in Cesium.ConstantProperty; read the value back.
+			expect(entity.polygon.outlineColor.getValue()).toBe(Cesium.Color.BLACK)
+			expect(entity.polygon.outlineWidth.getValue()).toBe(8)
 		})
 
 		it('should not throw error when entity is undefined', () => {
@@ -117,9 +118,10 @@ describe('BuildingHighlighter', () => {
 
 			highlighter.polygonOutlineToYellow(entity)
 
-			expect(entity.polygon.outline).toBe(true)
-			expect(entity.polygon.outlineColor).toBe(Cesium.Color.YELLOW)
-			expect(entity.polygon.outlineWidth).toBe(20)
+			// Production wraps raw assignments in Cesium.ConstantProperty; read the value back.
+			expect(entity.polygon.outline.getValue()).toBe(true)
+			expect(entity.polygon.outlineColor.getValue()).toBe(Cesium.Color.YELLOW)
+			expect(entity.polygon.outlineWidth.getValue()).toBe(20)
 		})
 
 		it('should not throw error when entity.polygon is undefined', () => {

--- a/tests/unit/services/featurepicker.test.js
+++ b/tests/unit/services/featurepicker.test.js
@@ -231,6 +231,9 @@ describe('FeaturePicker service', () => {
 				_entities: {
 					_array: [], // Fresh array for each test
 				},
+				// Production removeEntityByName() iterates the public values array;
+				// expose the same entities the legacy _entities._array held.
+				values: [],
 				remove: vi.fn(),
 			},
 			dataSources: {

--- a/tests/unit/services/sensor.test.js
+++ b/tests/unit/services/sensor.test.js
@@ -199,11 +199,11 @@ describe('Sensor Service - Error Handling', { tags: ['@unit', '@sensor'] }, () =
 				{
 					properties: {
 						_measurement: {
-							_value: {
+							getValue: () => ({
 								temp_air: 23.5,
 								rh_air: 65.2,
 								time: '2023-06-23T12:00:00Z',
-							},
+							}),
 						},
 					},
 					billboard: {},
@@ -234,7 +234,7 @@ describe('Sensor Service - Error Handling', { tags: ['@unit', '@sensor'] }, () =
 				{
 					properties: {
 						_measurement: {
-							_value: null, // No measurement
+							getValue: () => null, // No measurement
 						},
 					},
 				},

--- a/tests/unit/services/sensor.test.js
+++ b/tests/unit/services/sensor.test.js
@@ -16,6 +16,11 @@ vi.mock('@/services/cesiumProvider', () => ({
 			BLUE: 'BLUE',
 			YELLOW: 'YELLOW',
 		},
+		// Production now wraps label options in Cesium.LabelGraphics; store the options
+		// so the constructed label is inspectable.
+		LabelGraphics: vi.fn(function (options) {
+			Object.assign(this, options)
+		}),
 		HorizontalOrigin: {
 			CENTER: 'CENTER',
 		},
@@ -213,8 +218,10 @@ describe('Sensor Service - Error Handling', { tags: ['@unit', '@sensor'] }, () =
 			// Act
 			await sensor.addSensorDataSource(mockData)
 
-			// Assert
+			// Assert: label is a constructed LabelGraphics carrying the formatted text
 			expect(mockEntities[0].label).toBeDefined()
+			expect(mockEntities[0].label.text).toContain('Temp: 23.5°C')
+			expect(mockEntities[0].label.text).toContain('RH: 65.2%')
 			expect(mockEntities[0].billboard).toBeUndefined()
 			expect(mockEntities[0].point).toBeUndefined()
 			expect(mockEntities[0].polyline).toBeUndefined()

--- a/tests/unit/services/vttFlood.test.js
+++ b/tests/unit/services/vttFlood.test.js
@@ -46,6 +46,12 @@ function makeViewer() {
 		isDestroyed: () => false,
 		dataSources: {
 			_dataSources: sources,
+			// Production clearFlood() iterates via the public DataSourceCollection API
+			// (length + get(i)); back both with the same sources array.
+			get length() {
+				return sources.length
+			},
+			get: (i) => sources[i],
 			add: vi.fn((ds) => {
 				sources.push(ds)
 				return ds

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,6 +42,6 @@
 		// Library types
 		"lib": ["ES2020", "DOM", "DOM.Iterable"]
 	},
-	"include": ["src/**/*.js", "src/**/*.vue"],
+	"include": ["src/**/*.js", "src/**/*.vue", "src/**/*.d.ts"],
 	"exclude": ["node_modules", "dist", "tests", "**/*.spec.js", "**/*.test.js"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,11 +39,6 @@
 		"paths": {
 			"@/*": ["./src/*"]
 		},
-		// Silence the TS5101 deprecation warning for `baseUrl` until a follow-up
-		// PR migrates to `paths`-only resolution. Required for TypeScript 6.x;
-		// `baseUrl` is removed in TypeScript 7.0.
-		"ignoreDeprecations": "6.0",
-
 		// Library types
 		"lib": ["ES2020", "DOM", "DOM.Iterable"]
 	},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,8 +39,9 @@
 		"paths": {
 			"@/*": ["./src/*"]
 		},
-		// Library types
-		"lib": ["ES2020", "DOM", "DOM.Iterable"]
+		// Library types — ES2022 types Object.hasOwn (Biome's preferred form over
+		// Object.prototype.hasOwnProperty.call); widely supported by target browsers.
+		"lib": ["ES2022", "DOM", "DOM.Iterable"]
 	},
 	"include": ["src/**/*.js", "src/**/*.vue", "src/**/*.d.ts"],
 	"exclude": ["node_modules", "dist", "tests", "**/*.spec.js", "**/*.test.js"]


### PR DESCRIPTION
## What

Resolves the ~840 pre-existing `vue-tsc` type errors and pins the toolchain, so `vue-tsc --noEmit` exits **0** and the CI typecheck gate becomes blocking.

Fixes #721

## How it was diagnosed

The "~953" estimate came from CI's `bunx vue-tsc` silently pulling `typescript@latest` (6.0.3). Pinning `typescript@5.9.3` confirmed the **842 errors are genuine under 5.x too** — not a 6.x artifact. On 5.9.3 `baseUrl` is not a halting deprecation, so the `ignoreDeprecations: "6.0"` band-aid from #720 is removed and no `paths`-only migration is forced yet.

## Approach (5 commits)

1. **`build(deps)`** — pin `vue-tsc@3.3.3` + `typescript@5.9.3`, add a `typecheck` script. Stops the `bunx` drift that made TS5101 appear out of nowhere.
2. **`refactor(types)` foundation** — `src/types/cesium-global.d.ts` ambient shim (clears all 59 `Cesium` namespace errors) + typed Pinia store state (842 → 704).
3. **`refactor(types)` per-file** — guards (`?.`/`??`/early return), precise DOM casts, typed `ref` initializers, public Cesium APIs. 704 → 0.
4. **`test`** — adapt 4 unit-test files coupled to *private* Cesium internals to the public API the code now uses.
5. **`ci`** — make the typecheck job blocking via `bun run typecheck`.

## Verification

- ✅ `bun run typecheck` → **0 errors**
- ✅ `bun run lint` (biome) → clean
- ✅ `bun run test:unit` → **811 passed**, 4 skipped, 0 failed
- ✅ **No** `@ts-ignore` / `@ts-nocheck` / `@ts-expect-error` anywhere
- 12 narrow `/** @type {any} */` casts remain, each commented (window debug globals, runtime-assigned handles, Cesium `.d.ts` friction)

## Genuine runtime bugs fixed (surfaced by typing)

These are behavior changes — worth focused review:

- **mitt `eventBus.on()` returns `void`**, not an unsubscribe fn — several components stored & "called" it, leaking listeners on unmount (Scatterplot, SurveyScatterPlot, GridView, NearbyTreeArea).
- **Wrong store reads**: `helsinki.js`/`urbanheat.js` read `OtherNature`/`helsinkiView` off the wrong store → those layers never toggled.
- **Stale-arg calls**: `removeLandcover()`/`loadVegetation()`/`loadOtherNature()` passed args reading nonexistent `globalStore` props.
- **d3 `addTitle(..., margin)`** passed the whole margin object instead of `margin.top` → `NaN` title offsets (several charts).
- **`PostalCodeView`** read `store.urlStore.vegetation` (always `undefined`); restored the missing `urlStore.vegetation` getter.
- **`backgroundPreloader`** called nonexistent `progressiveLoader.loadChunked()`.
- **`CapitalRegion`** imported `@vueuse/core` (not a dependency) → replaced with a local debounce.
- **`entityPicker`** mutated the entity collection while iterating it.
- Stale `await provider.readyPromise` against Cesium 1.141 (removed API).

## Behavior-preserving migrations (why tests changed)

Production moved from private Cesium internals to public APIs — equivalent at runtime (real Cesium auto-coerces raw assignments and exposes `.values`):
- `entity._properties._value` → `entity.properties.getValue()`
- `viewer.entities._entities._array` → `viewer.entities.values`
- raw `polygon.outline = true` → `new Cesium.ConstantProperty(true)`

The 4 updated test files were asserting those private internals; they now assert the same values through the public API.

## Review guidance

This is large (119 files) but mechanical per-file. Highest-value review targets are the **genuine bug fixes** above. The `tsconfig` `lib` bump (ES2020 → ES2022) is to type `Object.hasOwn` (Biome's preferred form).

## Review feedback addressed (gemini-code-assist)

Follow-up commits responding to the inline review:

- **fix(charts):** `HeatHistogramHelsinki` still passed the whole `margin` object to `addTitle`/`addTitleWithLink` (the one chart missed by the `margin.top` sweep above), rendering a `NaN` title offset via `0 - top`. Both call sites now pass `margin.top`. Also made `SocioEconomicsChart`'s `heatData` consistently numeric (`Number()` on both ternary branches).
- **refactor(types):** finished the private→public Cesium read migration in the files this batch touched — `buildingFilter`, `tree`, `othernature`, `sensor`, `vegetation` now read via `ConstantProperty.getValue()` instead of `._value`, and the now-orphaned `TreeEntity` cast/typedef was removed. `sensor.test` mocks updated to the public surface. `vue-tsc` stays at 0; 811 unit tests pass.

## Follow-up

A pre-existing latent bug was found but **not** fixed (out of scope — needs a data-flow change, not a type fix): `CoolingCenterOptimiser` reads `bestCell.entity`, which `mitigationStore.setGridCells` intentionally never populates. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
