### PR TITLE
fix(ci): make Lighthouse CI survive hung Cesium loads

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -82,7 +82,7 @@ jobs:
           # (autorun exits before writing files when assertions fail)
 
           echo "=== Running lhci collect ==="
-          bunx @lhci/cli@0.14.x collect --config=lighthouserc.cjs 2>&1 | tee lighthouse-output.txt
+          bunx @lhci/cli@0.15.0 collect --config=lighthouserc.cjs 2>&1 | tee lighthouse-output.txt
           COLLECT_CODE=${PIPESTATUS[0]}
           echo "Collect exit code: $COLLECT_CODE"
 
@@ -100,12 +100,12 @@ jobs:
           fi
 
           echo "=== Running lhci upload ==="
-          bunx @lhci/cli@0.14.x upload --config=lighthouserc.cjs 2>&1 | tee -a lighthouse-output.txt
+          bunx @lhci/cli@0.15.0 upload --config=lighthouserc.cjs 2>&1 | tee -a lighthouse-output.txt
           UPLOAD_CODE=${PIPESTATUS[0]}
           echo "Upload exit code: $UPLOAD_CODE"
 
           echo "=== Running lhci assert ==="
-          bunx @lhci/cli@0.14.x assert --config=lighthouserc.cjs 2>&1 | tee -a lighthouse-output.txt
+          bunx @lhci/cli@0.15.0 assert --config=lighthouserc.cjs 2>&1 | tee -a lighthouse-output.txt
           ASSERT_CODE=${PIPESTATUS[0]}
           echo "Assert exit code: $ASSERT_CODE"
 

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -11,16 +11,24 @@
 module.exports = {
 	ci: {
 		collect: {
-			// Build the production bundle and start preview server
-			startServerCommand: 'bun run preview',
+			// Build the production bundle and start preview server.
+			// Call vite directly rather than via `bun run preview`: the bun
+			// script wrapper prints its own "$ vite preview --host" banner first
+			// and buffers vite's "➜  Local:" line, which can shadow the ready
+			// pattern and trip startServerReadyTimeout before navigation starts.
+			startServerCommand: 'bunx vite preview --host --port 4173',
 
-			// Pattern to detect when server is ready
-			// Vite outputs: "➜  Local:   http://localhost:4173/"
-			// Default pattern is /listen|ready/i which doesn't match Vite's output
-			startServerReadyPattern: 'Local:',
+			// Pattern to detect when server is ready.
+			// Vite outputs: "➜  Local:   http://localhost:4173/" — match the
+			// host:port directly so the wrapper banner can't shadow the match.
+			// Default pattern is /listen|ready/i which doesn't match Vite's output.
+			startServerReadyPattern: 'localhost:4173',
 
-			// Timeout for server startup (ms) - allow extra time for CI
-			startServerReadyTimeout: 30000,
+			// Timeout for server startup (ms) - allow extra time for CI.
+			// Raised from 30s: a premature timeout lets lhci navigate against an
+			// unconfirmed server, which is the first link in the PROTOCOL_TIMEOUT
+			// failure chain on this heavy CesiumJS app.
+			startServerReadyTimeout: 60000,
 
 			// Test URL - preview server runs on port 4173 by default
 			url: ['http://localhost:4173/'],


### PR DESCRIPTION
## Problem

The `Lighthouse CI` workflow fails on `main` and every PR. `lhci collect` dies with:

```
"runtimeError": { "code": "PROTOCOL_TIMEOUT",
  "message": "Waiting for DevTools protocol response has exceeded the allotted time. (Method: Network.getResponseBody)" }
```

then `ERROR: No lhr-*.json files found in .lighthouseci/` → `Lighthouse CI failed: No Lighthouse report files found` (exit 1). The existing source-map workaround (#831, `LIGHTHOUSE=true` drops Cesium maps) is already merged at the failing HEAD — it is not the cause now.

## Root cause (run 26872355387)

A four-step chain:

1. `startServerReadyTimeout: 30000` expires before `bun run preview` prints a line matching `'Local:'` (the bun-script wrapper banner shadows vite's `➜  Local:` line) → lhci navigates against an unconfirmed server.
2. The page never reaches load (`Timed out waiting for page load. Checking if page is hung...`) — Cesium keeps fetching tiles, so the network never quiets and the 90s `maxWaitForLoad` ceiling is hit.
3. The incomplete trace crashes the **RootCauses** gatherer: `Cannot read properties of undefined (reading 'frame_sequence')`, cascading to **TraceElements** and every LCP/layout/render-blocking audit. This is a Lighthouse **12.0/12.1** trace_engine bug — [GoogleChrome/lighthouse#16406](https://github.com/GoogleChrome/lighthouse/issues/16406), fixed by PR #16412 in a later 12.x. `@lhci/cli@0.14.x` bundles Lighthouse 12.0.0–12.1.0 (the broken range).
4. `Network.getResponseBody` PROTOCOL_TIMEOUT on the main document (SPA app-shell class — [GoogleChrome/lighthouse#10876](https://github.com/GoogleChrome/lighthouse/issues/10876)) makes lhci emit a `runtimeError` and **no `lhr-*.json`**.

## Fix (core only — no `skipAudits`)

The job only needs to **produce a report** (assertions are non-blocking `warn`). Two layered changes:

- **Pin `@lhci/cli@0.15.0`** (Lighthouse 12.6.1) so the `frame_sequence` trace_engine crash is gone (#16412). Replaces all three `@lhci/cli@0.14.x` calls in `lighthouse.yml`.
- **Harden server readiness**: call vite directly (`bunx vite preview --host --port 4173`), match `localhost:4173`, raise `startServerReadyTimeout` to 60s — so navigation doesn't start before the preview server is up.

Deliberately **not** skipping the six trace-element audits (`largest-contentful-paint-element`, `lcp-lazy-loaded`, `layout-shifts`, `non-composited-animations`, `prioritize-lcp-image`, `render-blocking-resources`) — pinning 0.15 should remove the crash class and keep those as real (non-blocking) signal. If CI still flakes on a Cesium hang, skipping them is the follow-up lever.

## Verification

This PR is its own verification vehicle — the `Lighthouse CI` workflow runs on PRs. Watch the check on this PR; success = an `lhr-*.json` is produced and the job is green.

```
LIGHTHOUSE=true bun run build && bunx @lhci/cli@0.15.0 collect --config=lighthouserc.cjs && ls -la .lighthouseci/lhr-*.json
```

Sources:
- https://github.com/GoogleChrome/lighthouse/issues/16406 (frame_sequence / trace_engine, fixed #16412)
- https://github.com/GoogleChrome/lighthouse/issues/10876 (Network.getResponseBody on main content, SPA app-shell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)