### PR TITLE
fix(ci): don't cancel a11y siblings when one viewport times out

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -288,7 +288,11 @@ jobs:
       SKIP_REQUIRES_DATABASE: 'true'
 
     strategy:
-      fail-fast: true
+      # Don't cancel desktop+mobile when one viewport times out. The tablet
+      # cross-view navigation specs are slow/flaky on CI (tracked in #784); a
+      # single viewport's timeout should not erase the signal from the other
+      # two, which pass within budget.
+      fail-fast: false
       matrix:
         viewport: [desktop, tablet, mobile]
 


### PR DESCRIPTION
## What

Stops a flaky tablet accessibility timeout from cancelling the desktop+mobile jobs and turning the whole **Test Suite** red. No app/source change. Relates to #784.

## Root cause (not a UI regression)

The reported hard failure on `main` (run 26872355474) is `building-filters.spec.ts:125 — expect(getByText('Building Filters')).not.toBeVisible() — Received: visible`, which looks like the `v-if="view !== 'grid'"` guard being broken. It is not:

- `src/components/controls/BuildingFiltersControl.vue` guards the section with `v-if="view !== 'grid'"`, bound to the live store. The guard is correct.
- The CI log shows `[navigateToView] Successfully navigated to gridView` — `globalStore.view` reached `'grid'`, so the panel did hide.
- The real error is `Test timeout of 50000ms exceeded` + `Tearing down "cesiumPage" exceeded the test timeout`, anchored at the `navigateToView('gridView')` call (line 124). The `not.toBeVisible()` → "Received: visible" is a teardown-time artifact of the interrupted assertion.

`navigateToView` is slow + flaky on the tablet viewport: the 2000ms `locator.click` times out under the WebGL canvas overlay, and the two-navigation specs bust the 50s per-test budget. This is the residual symptom tracked in **#784** (the original slow-path was fixed by #788).

## Why it blocked main

The `accessibility-tests` matrix used `fail-fast: true`, so the tablet failure cancelled the in-progress desktop+mobile jobs (which pass within budget) and the failed job turned the whole Test Suite red.

## Change

Set `fail-fast: false` on the `accessibility-tests` matrix. Desktop+mobile still run and still gate — this does **not** reduce gating strength, it only stops collateral cancellation while #784 is open. A genuine helper fix (store-driven view switch / viewer-lifecycle trace) is tracked under #784 and is out of scope here.

Refs: #784, #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)