### PR TITLE
test(perf): address Gemini review feedback on #845

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"test:integration": "vitest run tests/integration",
 		"test:e2e": "playwright test tests/e2e",
 		"test:e2e:mock": "playwright test tests/e2e --grep-invert @requires-database",
-		"test:performance": "vitest run tests/performance",
+		"test:performance": "vitest run --config vitest.performance.config.js",
 		"test:watch": "vitest",
 		"test:coverage": "vitest run --coverage",
 		"test:accessibility": "playwright test tests/e2e/accessibility",

--- a/tests/performance/load.test.ts
+++ b/tests/performance/load.test.ts
@@ -127,7 +127,7 @@ describe('Performance and Load Tests', { tags: ['@performance', '@integration'] 
 		// Unset in CI → no extra args, same launch as before.
 		browser = await chromium.launch({
 			args: process.env.PERF_TEST_CHROMIUM_ARGS
-				? process.env.PERF_TEST_CHROMIUM_ARGS.split(' ')
+				? process.env.PERF_TEST_CHROMIUM_ARGS.split(/\s+/).filter(Boolean)
 				: [],
 		})
 
@@ -523,7 +523,7 @@ describe('Performance and Load Tests', { tags: ['@performance', '@integration'] 
 			// the 10s test timeout) so the .catch() actually fires — the Cesium map
 			// streams tiles continuously and never reaches true 'networkidle'.
 			await page
-				.waitForLoadState('networkidle', { timeout: TEST_TIMEOUTS.ELEMENT_SCROLL })
+				.waitForLoadState('networkidle', { timeout: TEST_TIMEOUTS.WAIT_LONG })
 				.catch(() => {
 					// Continue if network doesn't become idle (expected for ongoing operations)
 				})
@@ -664,7 +664,7 @@ describe('Performance and Load Tests', { tags: ['@performance', '@integration'] 
 			// Normal interaction first
 			await page.locator('canvas').click({ position: { x: 400, y: 300 } })
 			await page
-				.waitForLoadState('networkidle', { timeout: TEST_TIMEOUTS.ELEMENT_SCROLL })
+				.waitForLoadState('networkidle', { timeout: TEST_TIMEOUTS.WAIT_LONG })
 				.catch(() => {})
 
 			// Enable network failure
@@ -691,7 +691,7 @@ describe('Performance and Load Tests', { tags: ['@performance', '@integration'] 
 			// Should recover and work normally
 			await page.locator('canvas').click({ position: { x: 300, y: 400 } })
 			await page
-				.waitForLoadState('networkidle', { timeout: TEST_TIMEOUTS.ELEMENT_SCROLL })
+				.waitForLoadState('networkidle', { timeout: TEST_TIMEOUTS.WAIT_LONG })
 				.catch(() => {})
 
 			// Vitest's expect has no Playwright toBeVisible matcher; use isVisible()

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -27,7 +27,6 @@ export default defineConfig({
 		include: [
 			'tests/unit/**/*.test.{js,ts}',
 			'tests/integration/**/*.test.{js,ts}',
-			'tests/performance/**/*.test.{js,ts}',
 		],
 		exclude: ['tests/**/*.spec.ts', 'tests/e2e/**/*'],
 		server: {

--- a/vitest.performance.config.js
+++ b/vitest.performance.config.js
@@ -13,7 +13,13 @@ export default {
 	...baseConfig,
 	test: {
 		...baseConfig.test,
+		// Perf tests drive a real Chromium via Playwright, not in-process Vue
+		// component tests — so skip the JSDOM environment and the unit-test
+		// setup. `setup.js` also touches `window` at module load, which throws
+		// under `environment: 'node'`, so the two must change together. `exclude`
+		// is inherited from `baseConfig.test` via the spread above.
+		environment: 'node',
+		setupFiles: [],
 		include: ['tests/performance/**/*.test.{js,ts}'],
-		exclude: ['tests/**/*.spec.ts', 'tests/e2e/**/*'],
 	},
 };

--- a/vitest.performance.config.js
+++ b/vitest.performance.config.js
@@ -1,0 +1,19 @@
+import baseConfig from './vitest.config.js';
+
+// Dedicated config for the performance suite.
+//
+// The performance tests drive a real Chromium instance against a running
+// preview/dev server, so they are slow and resource-intensive. Keeping them out
+// of the default `vitest.config.js` `include` ensures bare `vitest`, `test:watch`
+// and `test:coverage` stay fast and server-free. This config narrows discovery to
+// `tests/performance/**` so `vitest run --config vitest.performance.config.js`
+// (wired as `test:performance`) finds them — a bare path filter alone does not,
+// because Vitest only filters files already matched by `include`.
+export default {
+	...baseConfig,
+	test: {
+		...baseConfig.test,
+		include: ['tests/performance/**/*.test.{js,ts}'],
+		exclude: ['tests/**/*.spec.ts', 'tests/e2e/**/*'],
+	},
+};


### PR DESCRIPTION
## What

Addresses the three Gemini code-assist review comments on #845. Targets the PR's branch (`fix/perf-test-repair`) so merging this folds the fixes directly into #845.

## Review comments addressed

### 1. (high) Performance tests in default `include` degrade local DX — `vitest.config.js`

Gemini's concern is **valid and actually broader than stated**: with `tests/performance/**` in the default `include`, bare `vitest` (`test`, `test:watch`) *and* `vitest run --coverage` (`test:coverage`, `test:ci`) all pull in the slow, server-dependent performance suite — the coverage/CI job would fail since no preview server is running.

However, Gemini's *proposed fix* (only dropping the suite from `exclude`) does **not** work. Verified empirically with `vitest list`:

| Config | `vitest run tests/performance` discovers |
| --- | --- |
| perf in `include` | **12 tests** |
| perf removed from `include` (Gemini's suggestion) | **0 tests** — "No test files found" |

A bare positional path filter only narrows files **already matched by `include`**; it does not add to discovery. Removing perf from `include` therefore reintroduces the exact bug #845 fixes.

**Fix:** dedicated `vitest.performance.config.js` (narrows `include` to `tests/performance/**`), and `test:performance` now runs `vitest run --config vitest.performance.config.js`. Verified:
- `test:performance` config → 12 perf tests discovered.
- default `vitest` → 0 perf tests (857 unit/integration), fast and server-free.

### 2. (medium) Robust `PERF_TEST_CHROMIUM_ARGS` parsing — `load.test.ts`

Split on any whitespace and filter empties (`.split(/\s+/).filter(Boolean)`) so stray/leading/consecutive spaces don't pass empty strings to Chromium.

### 3. (medium) Semantic timeout constant — `load.test.ts`

`ELEMENT_SCROLL` → `WAIT_LONG` for the `networkidle` waits (both 3000ms; `WAIT_LONG` is the correct general long-wait constant). Applied to all three occurrences sharing the pattern, not just the flagged line.

## Verification

```
vitest list --config vitest.performance.config.js   # 12 perf tests
vitest list                                          # 0 perf tests, 857 unit/integration
```

## Related

- Parent PR: #845

https://claude.ai/code/session_01QMjFU5qaAi1YayDZXVfT1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMjFU5qaAi1YayDZXVfT1U)_