### PR TITLE
docs(testing): distill Vitest-driven Playwright perf-suite knowledge

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -264,6 +264,43 @@ cesiumTest('test name', async ({ cesiumPage }, testInfo) => {
 })
 ```
 
+## Vitest-Driven Playwright Suites (`tests/performance/`)
+
+`tests/performance/load.test.ts` is a **Vitest** suite that drives a real Chromium via the `playwright` Node library directly — it does **not** use the Playwright test runner or the `cesium-fixture`. That hybrid has gotchas the rest of the E2E suite (Playwright-runner specs) never hits. When editing or adding tests here:
+
+| Trap                 | Playwright-runner spec                | Vitest-driven suite                                                                                                                                                                         |
+| -------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Visibility assert    | `await expect(locator).toBeVisible()` | **No `toBeVisible` matcher** — use `expect(await locator.isVisible()).toBe(true)`                                                                                                           |
+| Memory / heap        | `page.metrics()`                      | **No `page.metrics()`** (Puppeteer-only) — `page.evaluate(() => (performance as any).memory?.usedJSHeapSize ?? 0)` (Chromium-only, works under SwiftShader)                                 |
+| Response timing      | `response.timing()`                   | **No `response.timing()`** (Puppeteer-only) — use `response.request().timing()` if ever needed                                                                                              |
+| Server               | `webServer` auto-starts               | **No auto-start** — a preview/dev server must already be running (`just test-performance` handles this)                                                                                     |
+| Modal dismissal      | `cesiumPage` fixture dismisses it     | **Must dismiss manually** — replicate `removeBlockingOverlays` (see below)                                                                                                                  |
+| Per-test time budget | spec timeout                          | bounded by the **global `testTimeout` (10s)** — a test whose own threshold (e.g. `SESSION_DURATION` 45s) exceeds it needs an explicit per-test timeout: `it('…', async () => { … }, 60000)` |
+
+**`networkidle` never settles on the Cesium map.** The 3D globe streams tiles continuously, so `page.waitForLoadState('networkidle')` hangs until it times out. Use `'load'` instead. If you must bound a `networkidle` wait, cap it **below** the 10s test timeout (`TEST_TIMEOUTS.ELEMENT_SCROLL` = 3s) and `.catch(() => {})` so the catch actually fires.
+
+**Floating map controls intercept canvas clicks.** Tests that `canvas.click()` at map coordinates collide with the nav drawer (`.control-panel`), camera/zoom/compass controls (`.camera-controls-container`, `.zoom-controls`, `.compass-assembly`), and the compact timeline — each swallows the click and Playwright retries for 30s. Inject a helper (mirroring `tests/fixtures/cesium-fixture.ts` `removeBlockingOverlays`) that removes the disclaimer dialog + scrims and sets `pointer-events: none` on those control containers, then call it after `waitForSelector('canvas')`.
+
+**Software-rendering skip.** Headless Chromium (CI **and** local headless) uses SwiftShader, so GPU-bound metrics like FPS aren't representative. Detect and `ctx.skip()` at runtime:
+
+```ts
+it('…fps…', async (ctx) => {
+	const renderer = await page.evaluate(() => {
+		const gl = document.createElement('canvas').getContext('webgl');
+		const ext = gl?.getExtension('WEBGL_debug_renderer_info');
+		return ext ? (gl!.getParameter(ext.UNMASKED_RENDERER_WEBGL) as string) : '';
+	});
+	if (/swiftshader|llvmpipe|software/i.test(renderer)) {
+		await page.close();
+		ctx.skip();
+		return;
+	}
+	// …real-GPU measurement…
+});
+```
+
+The viewer is exposed as `window.__viewer` (double underscore, gated on `VITE_E2E_TEST`) — never `window.cesiumViewer`. The Performance Tests CI job runs **only on push-to-`main`, not on PRs**, and is not a merge gate, so a PR check won't catch breakage here — verify locally with `just test-performance`.
+
 ## Feature Flag Defaults Affect Test Assertions
 
 The Pinia store defaults determine what's visible in tests without explicit setup:

--- a/justfile
+++ b/justfile
@@ -307,6 +307,24 @@ lighthouse-local:
     LIGHTHOUSE=true bun run build
     bunx @lhci/cli@0.14.x collect --config=lighthouserc.cjs
 
+# swgl=1 forces software rendering (mimics the no-GPU runner; FPS test skips).
+# The CI Performance Tests job runs only on push-to-main (not PRs) — use this to
+# verify before merging. See .claude/rules/testing.md "Vitest-Driven Playwright Suites".
+# Reproduce the CI perf run locally: build, serve the prod bundle on :4173, run the suite, tear down.
+[group: "testing"]
+test-performance swgl="0":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    VITE_E2E_TEST=true bun run build
+    bun run preview >/tmp/r4c-perf-preview.log 2>&1 &
+    PREVIEW_PID=$!
+    trap 'kill "$PREVIEW_PID" 2>/dev/null || true' EXIT
+    until curl -fsS -o /dev/null http://localhost:4173/ 2>/dev/null; do sleep 1; done
+    if [ "{{ swgl }}" = "1" ]; then
+        export PERF_TEST_CHROMIUM_ARGS="--use-gl=swiftshader --disable-gpu"
+    fi
+    CI=true bun run test:performance
+
 # Run a single test file (fast iteration during test fixes)
 [group: "testing"]
 test-file file *args:


### PR DESCRIPTION
## What

Captures the reusable testing knowledge surfaced while repairing the performance test suite (#845), so the next person editing `tests/performance/` doesn't rediscover it.

## Changes

- **`.claude/rules/testing.md`** — new "Vitest-Driven Playwright Suites" section. Documents how `tests/performance/load.test.ts` (a Vitest suite driving Playwright directly, no `cesium-fixture`) differs from the Playwright-runner specs the rest of the rule covers:
  - No `page.metrics()` / `response.timing()` (Puppeteer-only) and no `expect(locator).toBeVisible()` matcher in Vitest.
  - No `webServer` auto-start; bounded by the global `testTimeout` (10s) → needs per-test timeouts.
  - `networkidle` never settles on the tile-streaming Cesium map → use `'load'`.
  - Floating map controls intercept canvas clicks → `removeBlockingOverlays` need.
  - Software-GL FPS skip pattern; `window.__viewer` (not `cesiumViewer`).
- **`justfile`** — new `test-performance` recipe (build + preview + run + teardown, `swgl=1` for software rendering) mirroring the push-to-main-only CI job, so the suite is verifiable locally before merge.

## Verification

- `just --dump` parses; `test-performance` lists cleanly under the `testing` group.
- Docs/config only — no runtime code changed. Pre-commit (prettier/biome/conventional-commit) passed.

## Related

- Follows the perf-suite repair: #845
- Sibling CI repairs: #841 (Lighthouse), #842 (a11y fail-fast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
