### PR TITLE
fix(cooling-center): resolve grid entity from datasource by grid_id (#839)

### DIFF
--- a/src/components/CoolingCenterOptimiser.vue
+++ b/src/components/CoolingCenterOptimiser.vue
@@ -39,6 +39,7 @@ import { ref } from 'vue'
 import { getCesium } from '../services/cesiumProvider.js'
 import { useGlobalStore } from '../stores/globalStore.js'
 import { useMitigationStore } from '../stores/mitigationStore'
+import logger from '../utils/logger.js'
 
 const numCoolingCenters = ref(25)
 const mitigationStore = useMitigationStore()
@@ -46,6 +47,36 @@ const globalStore = useGlobalStore()
 const { optimalEffect } = mitigationStore
 
 let coolingCentersDataSource = globalStore.cesiumViewer.dataSources?.getByName('cooling_centers')[0]
+
+/**
+ * Builds a Map of grid_id → live Cesium entity from the `250m_grid` datasource.
+ *
+ * The mitigation store intentionally does NOT keep Cesium entity references on
+ * its grid cells (see `setGridCells` — storing entities triggers `DataCloneError`
+ * when Pinia state is cloned for the Cesium workers). The optimiser therefore
+ * resolves the entity for a chosen cell from the live datasource at the moment
+ * it's needed, keyed by the cell's `grid_id`.
+ *
+ * @returns {Map<string, import('cesium').Entity>} grid_id → entity lookup
+ */
+const buildGridEntityMap = () => {
+	/** @type {Map<string, import('cesium').Entity>} */
+	const entityMap = new Map()
+	const gridDataSource = globalStore.cesiumViewer.dataSources?.getByName('250m_grid')?.[0]
+	if (!gridDataSource) {
+		logger.warn(
+			'[CoolingCenterOptimiser] "250m_grid" datasource not found; cannot resolve grid entities for cooling centers.'
+		)
+		return entityMap
+	}
+	for (const entity of gridDataSource.entities.values) {
+		const gridId = entity.properties?.grid_id?.getValue()
+		if (gridId != null) {
+			entityMap.set(String(gridId), entity)
+		}
+	}
+	return entityMap
+}
 
 const shuffleArray = (array) => {
 	for (let i = array.length - 1; i > 0; i--) {
@@ -67,6 +98,9 @@ const removeOldData = async () => {
 const findOptimalCoolingCenters = async () => {
 	await removeOldData()
 	mitigationStore.setOptimised(true)
+	// Resolve grid entities from the live datasource (the store cells don't carry
+	// entity references — see buildGridEntityMap). Built once per run, not per cell.
+	const gridEntityMap = buildGridEntityMap()
 	const highImpactGrids = mitigationStore.gridCells.filter(
 		(cell) => mitigationStore.getGridImpact(cell.id) > 4
 	)
@@ -93,11 +127,18 @@ const findOptimalCoolingCenters = async () => {
 			// re-widen via the declared GridCell type before reading members.
 			const selectedCell = /** @type {import('../stores/mitigationStore.js').GridCell} */ (bestCell)
 			if (!isCoolingCenterTooClose(selectedCell)) {
-				// BUG (pre-existing): mitigationStore.setGridCells intentionally does
-				// NOT store the Cesium entity reference on grid cells, so `.entity` is
-				// always undefined here and addCoolingCenter() receives undefined. Left
-				// as-is to preserve runtime behavior; tracked separately.
-				addCoolingCenter(selectedCell.entity)
+				// Resolve the Cesium entity for this cell from the live datasource by
+				// grid_id (the store does not keep entity references — see
+				// buildGridEntityMap). Skip cells whose entity can't be found rather
+				// than calling addCoolingCenter(undefined), which would throw.
+				const entity = gridEntityMap.get(String(selectedCell.id))
+				if (entity) {
+					addCoolingCenter(entity)
+				} else {
+					logger.warn(
+						`[CoolingCenterOptimiser] No grid entity found for cell "${selectedCell.id}"; skipping cooling center placement.`
+					)
+				}
 				availableGrids.splice(availableGrids.indexOf(selectedCell), 1)
 			} else {
 				availableGrids.splice(availableGrids.indexOf(bestCell), 1)

--- a/src/components/CoolingCenterOptimiser.vue
+++ b/src/components/CoolingCenterOptimiser.vue
@@ -62,7 +62,10 @@ let coolingCentersDataSource = globalStore.cesiumViewer.dataSources?.getByName('
 const buildGridEntityMap = () => {
 	/** @type {Map<string, import('cesium').Entity>} */
 	const entityMap = new Map()
-	const gridDataSource = globalStore.cesiumViewer.dataSources?.getByName('250m_grid')?.[0]
+	// cesiumViewer is null until the viewer finishes loading (globalStore inits
+	// it to null); the optional chain lets this helper degrade gracefully to the
+	// empty-map + warn path below instead of throwing if called too early.
+	const gridDataSource = globalStore.cesiumViewer?.dataSources?.getByName('250m_grid')?.[0]
 	if (!gridDataSource) {
 		logger.warn(
 			'[CoolingCenterOptimiser] "250m_grid" datasource not found; cannot resolve grid entities for cooling centers.'

--- a/src/stores/mitigationStore.js
+++ b/src/stores/mitigationStore.js
@@ -48,7 +48,12 @@ import logger from '../utils/logger.js'
  * @property {string|number} id - Grid cell identifier (grid_id)
  * @property {number} x - EUREF-FIN X coordinate
  * @property {number} y - EUREF-FIN Y coordinate
- * @property {import('cesium').Entity} [entity] - Optional Cesium entity reference; intentionally omitted by setGridCells (see note there)
+ *
+ * @note No Cesium entity reference is stored on grid cells: setGridCells
+ *       intentionally extracts only serializable fields to avoid DataCloneError
+ *       when state is cloned for the Cesium workers. Consumers that need the live
+ *       entity (e.g. CoolingCenterOptimiser) resolve it from the datasource by
+ *       grid_id at the moment it's needed.
  */
 
 /**

--- a/tests/integration/viewportBuildingLoader.test.js
+++ b/tests/integration/viewportBuildingLoader.test.js
@@ -59,6 +59,13 @@ const cesiumMock = {
 	ColorMaterialProperty: vi.fn(function (color) {
 		this.color = { getValue: vi.fn(() => color) }
 	}),
+	// viewportBuildingLoader.setHelsinkiBuildingsHeight wraps extrudedHeight in
+	// `new Cesium.ConstantProperty(...)`; without this the mock throws
+	// "Cesium.ConstantProperty is not a constructor". Mirrors tests/setup.js.
+	ConstantProperty: vi.fn(function (value) {
+		this._value = value
+		this.getValue = vi.fn(() => value)
+	}),
 	JulianDate: {
 		now: vi.fn(() => ({})),
 	},

--- a/tests/unit/components/CoolingCenterOptimiser.test.js
+++ b/tests/unit/components/CoolingCenterOptimiser.test.js
@@ -81,8 +81,34 @@ vi.mock('@turf/turf', () => ({
 
 // Mock stores - will be initialized in beforeEach
 let mockCoolingCentersDataSource
+let mockGridDataSource
 let mockGlobalStore
 let mockMitigationStore
+
+/**
+ * Builds a mock grid entity exposing the public Cesium property surface
+ * (`.getValue()`) plus a polygon hierarchy, mirroring the live `250m_grid`
+ * datasource entities the optimiser resolves at runtime.
+ */
+const makeGridEntity = (gridId, x, y) => ({
+	properties: {
+		grid_id: { getValue: () => gridId },
+		euref_x: { getValue: () => x },
+		euref_y: { getValue: () => y },
+	},
+	polygon: {
+		hierarchy: {
+			getValue: () => ({
+				positions: [
+					{ x: 0, y: 0, z: 0 },
+					{ x: 1, y: 0, z: 0 },
+					{ x: 1, y: 1, z: 0 },
+					{ x: 0, y: 1, z: 0 },
+				],
+			}),
+		},
+	},
+})
 
 // Mock stores
 vi.mock('../../../src/stores/globalStore.js', () => ({
@@ -107,10 +133,24 @@ describe('CoolingCenterOptimiser Component', () => {
 			},
 		}
 
+		// Live grid datasource the optimiser resolves entities from by grid_id.
+		mockGridDataSource = {
+			name: '250m_grid',
+			entities: {
+				values: [
+					makeGridEntity('grid_001', TEST_COORDINATES.TEST_POINT_1.X, TEST_COORDINATES.TEST_POINT_1.Y),
+					makeGridEntity('grid_002', 1500, 2500),
+					makeGridEntity('grid_003', 2000, 3000),
+				],
+			},
+		}
+
 		mockGlobalStore = {
 			cesiumViewer: {
 				dataSources: {
-					getByName: vi.fn(() => [mockCoolingCentersDataSource]),
+					getByName: vi.fn((name) =>
+						name === '250m_grid' ? [mockGridDataSource] : [mockCoolingCentersDataSource]
+					),
 					add: vi.fn(),
 					remove: vi.fn(),
 				},
@@ -120,79 +160,12 @@ describe('CoolingCenterOptimiser Component', () => {
 		mockMitigationStore = {
 			resetStore: vi.fn(),
 			optimised: false,
+			// Store cells carry only serializable fields — NO entity reference.
+			// The optimiser resolves entities from the 250m_grid datasource by id.
 			gridCells: [
-				{
-					id: 'grid_001',
-					x: TEST_COORDINATES.TEST_POINT_1.X,
-					y: TEST_COORDINATES.TEST_POINT_1.Y,
-					entity: {
-						properties: {
-							grid_id: { getValue: () => 'grid_001' },
-							euref_x: { getValue: () => TEST_COORDINATES.TEST_POINT_1.X },
-							euref_y: { getValue: () => TEST_COORDINATES.TEST_POINT_1.Y },
-						},
-						polygon: {
-							hierarchy: {
-								getValue: () => ({
-									positions: [
-										{ x: 0, y: 0, z: 0 },
-										{ x: 1, y: 0, z: 0 },
-										{ x: 1, y: 1, z: 0 },
-										{ x: 0, y: 1, z: 0 },
-									],
-								}),
-							},
-						},
-					},
-				},
-				{
-					id: 'grid_002',
-					x: 1500,
-					y: 2500,
-					entity: {
-						properties: {
-							grid_id: { getValue: () => 'grid_002' },
-							euref_x: { getValue: () => 1500 },
-							euref_y: { getValue: () => 2500 },
-						},
-						polygon: {
-							hierarchy: {
-								getValue: () => ({
-									positions: [
-										{ x: 0, y: 0, z: 0 },
-										{ x: 1, y: 0, z: 0 },
-										{ x: 1, y: 1, z: 0 },
-										{ x: 0, y: 1, z: 0 },
-									],
-								}),
-							},
-						},
-					},
-				},
-				{
-					id: 'grid_003',
-					x: 2000,
-					y: 3000,
-					entity: {
-						properties: {
-							grid_id: { getValue: () => 'grid_003' },
-							euref_x: { getValue: () => 2000 },
-							euref_y: { getValue: () => 3000 },
-						},
-						polygon: {
-							hierarchy: {
-								getValue: () => ({
-									positions: [
-										{ x: 0, y: 0, z: 0 },
-										{ x: 1, y: 0, z: 0 },
-										{ x: 1, y: 1, z: 0 },
-										{ x: 0, y: 1, z: 0 },
-									],
-								}),
-							},
-						},
-					},
-				},
+				{ id: 'grid_001', x: TEST_COORDINATES.TEST_POINT_1.X, y: TEST_COORDINATES.TEST_POINT_1.Y },
+				{ id: 'grid_002', x: 1500, y: 2500 },
+				{ id: 'grid_003', x: 2000, y: 3000 },
 			],
 			getGridImpact: vi.fn((id) => {
 				const impacts = {
@@ -316,6 +289,47 @@ describe('CoolingCenterOptimiser Component', () => {
 					grid_id: 'grid_002',
 				})
 			)
+		})
+
+		// Regression for #839: the store does NOT keep entity references on grid
+		// cells, so the optimiser must resolve the entity from the live 250m_grid
+		// datasource by grid_id. Previously it read the always-undefined
+		// `cell.entity` and passed undefined into addCoolingCenter().
+		it('should resolve the grid entity from the datasource by grid_id (#839)', async () => {
+			wrapper.vm.numCoolingCenters = 1
+			await wrapper.vm.$nextTick()
+			await wrapper.vm.findOptimalCoolingCenters()
+
+			// The datasource was queried for the grid layer...
+			expect(mockGlobalStore.cesiumViewer.dataSources.getByName).toHaveBeenCalledWith('250m_grid')
+
+			// ...and the resolved entity's coordinates (from the datasource, not the
+			// bare store cell) flow into the stored cooling center.
+			expect(mockMitigationStore.addCoolingCenter).toHaveBeenCalledWith({
+				grid_id: 'grid_002',
+				euref_x: 1500,
+				euref_y: 2500,
+				capacity: 1000,
+			})
+
+			// A visual box entity was added for the resolved center. Note
+			// removeOldData() reassigns coolingCentersDataSource to a fresh
+			// CustomDataSource, so assert against the live component reference.
+			expect(wrapper.vm.coolingCentersDataSource.entities.add).toHaveBeenCalledWith(
+				expect.objectContaining({ id: expect.stringContaining('cooling_grid_002') })
+			)
+		})
+
+		it('should skip placement when no entity matches the cell id (#839)', async () => {
+			// Datasource has no entities → no grid_id resolves.
+			mockGridDataSource.entities.values = []
+			wrapper.vm.numCoolingCenters = 1
+			await wrapper.vm.$nextTick()
+			await wrapper.vm.findOptimalCoolingCenters()
+
+			// No undefined entity passed into addCoolingCenter; placement skipped.
+			expect(mockMitigationStore.addCoolingCenter).not.toHaveBeenCalled()
+			expect(mockCoolingCentersDataSource.entities.add).not.toHaveBeenCalled()
 		})
 	})
 


### PR DESCRIPTION
## What

`src/components/CoolingCenterOptimiser.vue` read `bestCell.entity` and passed it to `addCoolingCenter(...)`, but `mitigationStore.setGridCells` **intentionally** does not store Cesium entity references on grid cells (to avoid `DataCloneError` when state is cloned for the Cesium workers). So `bestCell.entity` was always `undefined`, and `addCoolingCenter(undefined)` would throw / no-op — no cooling centers were ever actually placed by the optimiser.

## How

- Added `buildGridEntityMap()` which resolves the live entities from the `250m_grid` datasource (the same datasource `setGridCells` reads from), keyed by `grid_id`. The map is built **once per optimisation run**, not per cell.
- `findOptimalCoolingCenters` now looks up the chosen cell's entity from that map by `String(selectedCell.id)` and passes the real entity into `addCoolingCenter`.
- Cells whose entity can't be resolved are **skipped with a `logger.warn`** instead of passing `undefined` downstream (defensive against a missing/empty datasource).
- Dropped the now-dead `entity?` field from the `GridCell` typedef in `mitigationStore.js` and documented why no entity is stored.

## Tests

- Updated `tests/unit/components/CoolingCenterOptimiser.test.js`:
  - The mock store's `gridCells` now carry only serializable fields (`id`/`x`/`y`), matching what `setGridCells` actually produces.
  - Added a mock `250m_grid` datasource; `getByName` now dispatches by name.
  - **New regression test** (`#839`): verifies the optimiser queries `getByName('250m_grid')`, that the resolved entity's coordinates flow into the stored cooling center, and that a visual box entity is added.
  - **New test**: when no entity matches the cell id, placement is skipped (no `undefined` reaches `addCoolingCenter`).

All 27 tests pass; `biome check` and `vue-tsc --noEmit` clean for the touched files.

Closes #839

## References

- PR #838 (type cleanup that surfaced this)
- `src/components/CoolingCenterOptimiser.vue`, `src/stores/mitigationStore.js` `setGridCells`

https://claude.ai/code/session_01CrZTPHxyjbKd4pXae58YS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CrZTPHxyjbKd4pXae58YS5)_