### PR TITLE
fix(tests): add ConstantProperty to viewportBuildingLoader integration mock

### DIFF
--- a/tests/integration/viewportBuildingLoader.test.js
+++ b/tests/integration/viewportBuildingLoader.test.js
@@ -59,6 +59,9 @@ const cesiumMock = {
 	ColorMaterialProperty: vi.fn(function (color) {
 		this.color = { getValue: vi.fn(() => color) }
 	}),
+	ConstantProperty: vi.fn(function (value) {
+		this.getValue = vi.fn(() => value)
+	}),
 	JulianDate: {
 		now: vi.fn(() => ({})),
 	},


### PR DESCRIPTION
## Problem

The **Integration Tests** CI check is red on every PR (surfaced while merging dependency PRs #857–#864). It is a genuine pre-existing failure on `master`, not environmental — 45 pass, 1 fails.

Failing test: `tests/integration/viewportBuildingLoader.test.js` → "should apply heat exposure processing when in Helsinki view".

Error: `TypeError: Cesium.ConstantProperty is not a constructor`, thrown from `setHelsinkiBuildingsHeight()` via `processBuildings()`.

## Root cause

The test file defines a **local minimal** `cesiumMock` and overrides the comprehensive global mock (`tests/setup.js`) via `vi.mock('cesium', …)` + `vi.mock('@/services/cesiumProvider', …)`. The local mock was missing `ConstantProperty`, which the global mock defines. When `setHelsinkiBuildingsHeight()` runs `new Cesium.ConstantProperty(...)`, the constructor is `undefined` → throw.

This is exactly the drift the recently-landed rule (`.claude/rules/testing.md` "Mocking Cesium Entity Properties") warns about: test mocks must expose `getValue()`.

## Fix

Add `ConstantProperty` to the local `cesiumMock`, matching the `tests/setup.js` convention (constructor storing the value behind a `getValue()`). No production code changes — production is correct; only the test mock was incomplete.

## Verification

- `bunx vitest run tests/integration/viewportBuildingLoader.test.js` → 29/29 pass
- `bun run test:integration` → 46/46 pass (was 45/46)

Unblocks the recurring red **Integration Tests** check for #862 (release 1.52.0) and others.

## Optional follow-ups (out of scope)

- `tests/mocks/cesium-mock.ts` and `tests/fixtures/cesium-fixture.ts` define `ConstantProperty: class {}` (empty, no `getValue()`) — same latent drift; align in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)