### PR TITLE
fix(nginx): send SNI to api.digitransit.fi to fix geocoding 502

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -133,6 +133,10 @@ server {
         access_log off;
         set $digitransit_key "${VITE_DIGITRANSIT_KEY}";
         proxy_set_header digitransit-subscription-key $digitransit_key;
+        # api.digitransit.fi is fronted by Cloudflare, which rejects the TLS
+        # handshake when no SNI is sent. nginx omits SNI by default, so this
+        # must be enabled or the upstream call fails the handshake (-> 502).
+        proxy_ssl_server_name on;
         # Simple geocoding request to verify API key works
         proxy_pass https://api.digitransit.fi/geocoding/v1/search?text=helsinki&size=1;
         proxy_connect_timeout 5s;
@@ -382,6 +386,12 @@ server {
         # Use nginx environment variable substitution
         set $digitransit_key "${VITE_DIGITRANSIT_KEY}";
         proxy_set_header digitransit-subscription-key $digitransit_key;
+
+        # api.digitransit.fi is fronted by Cloudflare, which rejects the TLS
+        # handshake when no SNI is sent. nginx omits SNI by default (see the
+        # matching setting on /hsy-action), so without this the upstream TLS
+        # handshake fails and the client sees nginx's own 502 Bad Gateway.
+        proxy_ssl_server_name on;
 
         proxy_pass https://api.digitransit.fi;
         rewrite ^/digitransit(.*)$ $1 break;

--- a/src/components/Geocoding.vue
+++ b/src/components/Geocoding.vue
@@ -137,9 +137,21 @@ const processAddressData = (data) => {
 const filterSearchResults = async () => {
 	if (searchQuery.value.length > 2) {
 		try {
-			const response = await fetch(
-				`/digitransit/geocoding/v1/autocomplete?text=${searchQuery.value}`
-			)
+			const url = `/digitransit/geocoding/v1/autocomplete?text=${encodeURIComponent(searchQuery.value)}`
+			const response = await fetch(url)
+			if (!response.ok) {
+				throw new Error(
+					`Geocoding request failed: ${response.status} ${response.statusText} (${url})`
+				)
+			}
+			// Guard against the SPA/auth catch-all: a 302 redirect or nginx 502
+			// returns HTML, and response.json() would throw an opaque SyntaxError.
+			const contentType = response.headers.get('content-type') ?? ''
+			if (!contentType.toLowerCase().includes('application/json')) {
+				throw new Error(
+					`Geocoding returned non-JSON (content-type: ${contentType || 'missing'}) — digitransit proxy/auth misconfiguration for ${url}`
+				)
+			}
 			const data = await response.json()
 
 			// Store the full address objects in addressData

--- a/src/components/Geocoding.vue
+++ b/src/components/Geocoding.vue
@@ -146,8 +146,10 @@ const filterSearchResults = async () => {
 			}
 			// Guard against the SPA/auth catch-all: a 302 redirect or nginx 502
 			// returns HTML, and response.json() would throw an opaque SyntaxError.
+			// Match any JSON media type (application/json, application/geo+json,
+			// application/problem+json) — only HTML/redirect bodies should fail here.
 			const contentType = response.headers.get('content-type') ?? ''
-			if (!contentType.toLowerCase().includes('application/json')) {
+			if (!contentType.toLowerCase().includes('json')) {
 				throw new Error(
 					`Geocoding returned non-JSON (content-type: ${contentType || 'missing'}) — digitransit proxy/auth misconfiguration for ${url}`
 				)

--- a/src/components/UnifiedSearch.vue
+++ b/src/components/UnifiedSearch.vue
@@ -437,8 +437,10 @@ const fetchAddressResults = async () => {
 		}
 		// Guard against the SPA/auth catch-all: a 302 redirect or nginx 502
 		// returns HTML, and response.json() would throw an opaque SyntaxError.
+		// Match any JSON media type (application/json, application/geo+json,
+		// application/problem+json) — only HTML/redirect bodies should fail here.
 		const contentType = response.headers.get('content-type') ?? ''
-		if (!contentType.toLowerCase().includes('application/json')) {
+		if (!contentType.toLowerCase().includes('json')) {
 			throw new Error(
 				`Geocoding returned non-JSON (content-type: ${contentType || 'missing'}) — digitransit proxy/auth misconfiguration for ${url}`
 			)

--- a/src/components/UnifiedSearch.vue
+++ b/src/components/UnifiedSearch.vue
@@ -428,7 +428,21 @@ const fetchAddressResults = async () => {
 
 	try {
 		isLoading.value = true
-		const response = await fetch(`/digitransit/geocoding/v1/autocomplete?text=${searchQuery.value}`)
+		const url = `/digitransit/geocoding/v1/autocomplete?text=${encodeURIComponent(searchQuery.value)}`
+		const response = await fetch(url)
+		if (!response.ok) {
+			throw new Error(
+				`Geocoding request failed: ${response.status} ${response.statusText} (${url})`
+			)
+		}
+		// Guard against the SPA/auth catch-all: a 302 redirect or nginx 502
+		// returns HTML, and response.json() would throw an opaque SyntaxError.
+		const contentType = response.headers.get('content-type') ?? ''
+		if (!contentType.toLowerCase().includes('application/json')) {
+			throw new Error(
+				`Geocoding returned non-JSON (content-type: ${contentType || 'missing'}) — digitransit proxy/auth misconfiguration for ${url}`
+			)
+		}
 		const data = await response.json()
 
 		addressResults.value = processAddressData(data.features)


### PR DESCRIPTION
## What

Geocoding on r4c-beta returns **502 Bad Gateway** (#854). Root cause: nginx fails the TLS handshake to `api.digitransit.fi` because it sends no SNI.

`api.digitransit.fi` is fronted by **Cloudflare**, which rejects handshakes without SNI. nginx leaves `proxy_ssl_server_name` **off** by default, so the `/digitransit` and `/status/digitransit` upstream calls fail the handshake → client sees nginx's own 502.

## Evidence (end-to-end)

| Probe | Result |
|---|---|
| in-pod `curl localhost/digitransit/geocoding/...` | **502** |
| `dig api.digitransit.fi` | `141.101.90.97` (Cloudflare) |
| `openssl s_client` **with** `-servername` | handshake OK, `CN=digitransit.fi` |
| `openssl s_client -noservername` | `tls alert handshake failure` (alert 40) |
| direct `curl https://api.digitransit.fi/...` (sends SNI) | 401 — i.e. reachable, just needs key |

Dev is unaffected because Vite's node proxy sends SNI by default. The `/hsy-action` location already sets `proxy_ssl_server_name on` for the same reason — this just applies the same to the digitransit routes.

## Changes

1. **`nginx/default.conf.template`** — `proxy_ssl_server_name on;` on `/digitransit` and `/status/digitransit`. **This is the fix.**
2. **`Geocoding.vue` / `UnifiedSearch.vue`** — defense-in-depth: check `response.ok` + content-type before `response.json()`, throw a proper `Error` with URL + status, and `encodeURIComponent` the search text. A 302 (OAuth-gated beta) or 502 returns HTML, and the old `response.json()` threw an opaque `SyntaxError` that surfaced in Sentry as a bare promise rejection. Per `.claude/rules/code-quality.md` "Guard `response.json()` Against SPA Catch-All".

## Deployment note

The nginx change ships in the image, so it reaches r4c-beta only after merge → new image → ArgoCD Image Updater bumps `values-beta.yaml`.

## Not in scope

- **#855** (`/feature-flags/health` 404) is a separate root cause (GOFF relay route), untouched here.

## Test

- `bun run lint` clean.
- Existing digitransit mocks all return `application/json`, so the new content-type guard passes through — no test changes needed.

Fixes #854

🤖 Generated with [Claude Code](https://claude.com/claude-code)