### PR TITLE
feat(perf): add dev-gated performance counters (window.__perfStats)

### DIFF
--- a/src/composables/useViewerInitialization.js
+++ b/src/composables/useViewerInitialization.js
@@ -12,6 +12,7 @@ import { useGraphicsStore } from '../stores/graphicsStore.js'
 import { usePropsStore } from '../stores/propsStore.js'
 import logger from '../utils/logger.js'
 import { loadWithRetry } from '../utils/moduleLoader.js'
+import { PERF_STATS_ENABLED, perfStats } from '../utils/perfStats.js'
 
 /**
  * Vue 3 composable for Cesium viewer initialization
@@ -160,6 +161,18 @@ export function useViewerInitialization() {
 		}
 
 		viewer.value = new Cesium.Viewer('cesiumContainer', viewerOptions)
+
+		// Count requestRender() calls for render-pressure attribution. Patched
+		// once per viewer instance (each new viewer gets a fresh scene); dev/E2E
+		// only, inert in production.
+		if (PERF_STATS_ENABLED && viewer.value?.scene) {
+			const scene = viewer.value.scene
+			const originalRequestRender = scene.requestRender.bind(scene)
+			scene.requestRender = () => {
+				perfStats.recordRequestRender()
+				return originalRequestRender()
+			}
+		}
 
 		store.setCesiumViewer(viewer.value)
 

--- a/src/services/cacheService.js
+++ b/src/services/cacheService.js
@@ -218,6 +218,35 @@ class CacheService {
 	 * const cached = await cacheService.getData('buildings-00100', 5 * 60 * 1000);
 	 */
 	async getData(key, maxAge = null) {
+		const { result, size } = await this._lookup(key, maxAge)
+
+		// Perf stats are recorded only here, not in `_lookup`, so that
+		// `hasValidData` (which also calls `_lookup`) does not double-count
+		// hits/misses against an actual `getData` retrieval.
+		if (PERF_STATS_ENABLED) {
+			if (result) {
+				perfStats.recordCacheHit(size)
+			} else {
+				perfStats.recordCacheMiss()
+			}
+		}
+
+		return result
+	}
+
+	/**
+	 * Internal cache lookup shared by {@link getData} and {@link hasValidData}.
+	 * Performs the IndexedDB read, expiry check, and expired-entry removal, but
+	 * does NOT record perf stats — the caller decides whether the lookup counts
+	 * as a hit/miss. This prevents `hasValidData` from inflating cache counters.
+	 *
+	 * @param {string} key - Cache key to retrieve
+	 * @param {number|null} [maxAge=null] - Override TTL for this retrieval (milliseconds)
+	 * @returns {Promise<{result: CacheResult|null, size: number}>} The cache
+	 *   result (null on miss/expired) and the raw stored byte size on a hit.
+	 * @private
+	 */
+	async _lookup(key, maxAge = null) {
 		const db = await this.init()
 
 		const transaction = db.transaction(['layers'], 'readonly')
@@ -230,8 +259,7 @@ class CacheService {
 				const result = request.result
 
 				if (!result) {
-					if (PERF_STATS_ENABLED) perfStats.recordCacheMiss()
-					resolve(null)
+					resolve({ result: null, size: 0 })
 					return
 				}
 
@@ -241,20 +269,20 @@ class CacheService {
 
 				if (age > maxAgeToUse) {
 					// Data is expired, remove it
-					if (PERF_STATS_ENABLED) perfStats.recordCacheMiss()
 					void this.removeData(key)
-					resolve(null)
+					resolve({ result: null, size: 0 })
 					return
 				}
 
-				if (PERF_STATS_ENABLED) perfStats.recordCacheHit(result.size || 0)
-
 				resolve({
-					data: result.data,
-					timestamp: result.timestamp,
-					age: age,
-					cached: true,
-					metadata: result.metadata,
+					result: {
+						data: result.data,
+						timestamp: result.timestamp,
+						age: age,
+						cached: true,
+						metadata: result.metadata,
+					},
+					size: result.size || 0,
 				})
 			}
 
@@ -278,8 +306,10 @@ class CacheService {
 	 * }
 	 */
 	async hasValidData(key, maxAge = null) {
-		const cached = await this.getData(key, maxAge)
-		return cached !== null
+		// Use `_lookup` (not `getData`) so a hit/miss check does not record perf
+		// stats — only an actual `getData` retrieval counts toward the counters.
+		const { result } = await this._lookup(key, maxAge)
+		return result !== null
 	}
 
 	/**

--- a/src/services/cacheService.js
+++ b/src/services/cacheService.js
@@ -27,6 +27,8 @@
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API|IndexedDB API Documentation}
  */
 
+import { PERF_STATS_ENABLED, perfStats } from '../utils/perfStats.js'
+
 /**
  * Cache entry metadata structure
  * @typedef {Object} CacheEntry
@@ -228,6 +230,7 @@ class CacheService {
 				const result = request.result
 
 				if (!result) {
+					if (PERF_STATS_ENABLED) perfStats.recordCacheMiss()
 					resolve(null)
 					return
 				}
@@ -238,10 +241,13 @@ class CacheService {
 
 				if (age > maxAgeToUse) {
 					// Data is expired, remove it
+					if (PERF_STATS_ENABLED) perfStats.recordCacheMiss()
 					void this.removeData(key)
 					resolve(null)
 					return
 				}
+
+				if (PERF_STATS_ENABLED) perfStats.recordCacheHit(result.size || 0)
 
 				resolve({
 					data: result.data,

--- a/src/services/hostConcurrencyLimiter.js
+++ b/src/services/hostConcurrencyLimiter.js
@@ -26,6 +26,7 @@
  */
 
 import logger from '../utils/logger.js'
+import { PERF_STATS_ENABLED, perfStats } from '../utils/perfStats.js'
 
 /**
  * Default per-host concurrent request budget. Conservative on purpose — most
@@ -123,14 +124,19 @@ export async function acquireHostSlot(url, signal) {
 
 	if (state.active < getLimit(hostKey)) {
 		state.active += 1
+		if (PERF_STATS_ENABLED) perfStats.recordLimiterAcquire(hostKey, 0)
 		return makeReleaser(hostKey, state)
 	}
 
 	// Park in the queue, waiting for someone to release.
 	return new Promise((resolve, reject) => {
+		const enqueuedAt = PERF_STATS_ENABLED ? performance.now() : 0
 		const wake = () => {
 			signal?.removeEventListener('abort', onAbort)
 			state.active += 1
+			if (PERF_STATS_ENABLED) {
+				perfStats.recordLimiterAcquire(hostKey, performance.now() - enqueuedAt)
+			}
 			resolve(makeReleaser(hostKey, state))
 		}
 		const onAbort = () => {
@@ -145,15 +151,17 @@ export async function acquireHostSlot(url, signal) {
 		}
 		signal?.addEventListener('abort', onAbort, { once: true })
 		state.queue.push(wake)
+		if (PERF_STATS_ENABLED) perfStats.recordLimiterEnqueue(hostKey, state.queue.length)
 	})
 }
 
-function makeReleaser(_hostKey, state) {
+function makeReleaser(hostKey, state) {
 	let released = false
 	return () => {
 		if (released) return
 		released = true
 		state.active = Math.max(0, state.active - 1)
+		if (PERF_STATS_ENABLED) perfStats.recordLimiterRelease(hostKey)
 		const next = state.queue.shift()
 		if (next) next()
 	}

--- a/src/services/unifiedLoader.js
+++ b/src/services/unifiedLoader.js
@@ -312,6 +312,12 @@ class UnifiedLoader {
 				perfStats.recordNetworkBytes(Number.isFinite(contentLength) ? contentLength : 0)
 			}
 
+			// `response.json()/.text()/.blob()` stream the body from the network
+			// before parsing, so this span measures body download + parse time,
+			// not pure CPU-bound deserialization. On slow links it is dominated by
+			// transfer time. Kept as one combined "body read" metric on purpose:
+			// awaiting `.text()` first to isolate `JSON.parse` would double-buffer
+			// large payloads and drop blob handling.
 			const deserializeStart = PERF_STATS_ENABLED ? performance.now() : 0
 			let data
 			switch (type) {

--- a/src/services/unifiedLoader.js
+++ b/src/services/unifiedLoader.js
@@ -37,6 +37,7 @@
 
 import { useLoadingStore } from '../stores/loadingStore.js'
 import { requestIdle } from '../utils/idle.js'
+import { PERF_STATS_ENABLED, perfStats } from '../utils/perfStats.js'
 import cacheService from './cacheService.js'
 import { acquireHostSlot } from './hostConcurrencyLimiter.js'
 import progressiveLoader from './progressiveLoader.js'
@@ -304,6 +305,14 @@ class UnifiedLoader {
 				retries
 			)
 
+			// Network byte count (Content-Length; absent on chunked/gzip-without-length
+			// responses, in which case it reads 0).
+			if (PERF_STATS_ENABLED) {
+				const contentLength = Number(response.headers.get('content-length'))
+				perfStats.recordNetworkBytes(Number.isFinite(contentLength) ? contentLength : 0)
+			}
+
+			const deserializeStart = PERF_STATS_ENABLED ? performance.now() : 0
 			let data
 			switch (type) {
 				case 'json':
@@ -319,6 +328,7 @@ class UnifiedLoader {
 				default:
 					data = await response.json()
 			}
+			if (PERF_STATS_ENABLED) perfStats.recordDeserialize(performance.now() - deserializeStart)
 
 			this.loadingStore.updateLayerProgress(layerId, 100, 100)
 			return data

--- a/src/utils/perfStats.js
+++ b/src/utils/perfStats.js
@@ -1,0 +1,191 @@
+/// <reference types="vite/client" />
+/**
+ * @module utils/perfStats
+ *
+ * Dev/E2E-gated performance counters for bottleneck attribution.
+ *
+ * Exposes a flat, JSON-serializable counter object on `window.__perfStats`
+ * (in dev and E2E builds only) so a measurement harness — human or browser
+ * agent — can read durable evidence after a scripted interaction:
+ *
+ *   JSON.stringify(window.__perfStats)        // snapshot counters
+ *   window.__perfStats.reset()                // zero between trials
+ *
+ * Three subsystems are instrumented (see call sites):
+ * - `limiter`: per-host queue-wait time injected by the 3-concurrent cap in
+ *   {@link module:services/hostConcurrencyLimiter}.
+ * - `cache`: hit/miss counts, bytes served from IndexedDB vs the network, and
+ *   cumulative JSON deserialize time — {@link module:services/cacheService}
+ *   and {@link module:services/unifiedLoader}.
+ * - `render`: how many times `viewer.scene.requestRender()` fired (patched once
+ *   at viewer init in {@link module:composables/useViewerInitialization}).
+ *
+ * Gating: {@link PERF_STATS_ENABLED} is computed once at module load. It is true
+ * in dev (`import.meta.env.DEV`) and in any E2E build (`VITE_E2E_TEST=true`),
+ * and false in a production build — where it folds to a static `false` so the
+ * guarded call sites (`if (PERF_STATS_ENABLED) perfStats.recordX(...)`) become
+ * dead code the bundler can drop. When disabled, no recorder runs, nothing is
+ * allocated per request, and nothing is logged: zero behaviour change.
+ */
+
+/**
+ * Whether perf counters are active. Evaluated once; statically replaced by
+ * Vite so the production build can tree-shake the guarded call sites.
+ *
+ * @type {boolean}
+ */
+export const PERF_STATS_ENABLED =
+	import.meta.env.DEV === true || import.meta.env.VITE_E2E_TEST === 'true'
+
+/**
+ * Per-host limiter counters.
+ * @typedef {Object} LimiterHostStats
+ * @property {number} acquired - Total slots acquired (fast path + queued).
+ * @property {number} queuedCount - Acquisitions that had to wait in the queue.
+ * @property {number} queueWaitMsTotal - Summed queue-wait time (ms); avg =
+ *   queueWaitMsTotal / queuedCount.
+ * @property {number} inFlight - Slots currently held (mirrors live `active`).
+ * @property {number} queueDepthHWM - High-water mark of queue depth.
+ */
+
+/**
+ * The live counter object exposed as `window.__perfStats`. Methods are
+ * non-enumerable-by-omission for JSON (functions serialize to undefined and
+ * are dropped), so `JSON.stringify(perfStats)` yields only the data fields.
+ */
+export const perfStats = {
+	/** @type {boolean} */
+	enabled: PERF_STATS_ENABLED,
+
+	/** @type {{ hosts: Record<string, LimiterHostStats> }} */
+	limiter: { hosts: {} },
+
+	cache: {
+		hits: 0,
+		misses: 0,
+		bytesFromCache: 0,
+		bytesFromNetwork: 0,
+		deserializeMsTotal: 0,
+		deserializeCount: 0,
+	},
+
+	render: { requestRenderCount: 0 },
+
+	/**
+	 * Get-or-create the counter bucket for a limiter host key.
+	 * @param {string} hostKey
+	 * @returns {LimiterHostStats}
+	 */
+	_host(hostKey) {
+		let bucket = this.limiter.hosts[hostKey]
+		if (!bucket) {
+			bucket = {
+				acquired: 0,
+				queuedCount: 0,
+				queueWaitMsTotal: 0,
+				inFlight: 0,
+				queueDepthHWM: 0,
+			}
+			this.limiter.hosts[hostKey] = bucket
+		}
+		return bucket
+	},
+
+	/**
+	 * Record a slot acquisition. `waitMs > 0` means it was parked in the queue.
+	 * @param {string} hostKey
+	 * @param {number} waitMs - Time spent queued before the slot was granted.
+	 */
+	recordLimiterAcquire(hostKey, waitMs) {
+		const bucket = this._host(hostKey)
+		bucket.acquired += 1
+		bucket.inFlight += 1
+		if (waitMs > 0) {
+			bucket.queuedCount += 1
+			bucket.queueWaitMsTotal += waitMs
+		}
+	},
+
+	/**
+	 * Record that a request was parked in the queue at the given depth, updating
+	 * the high-water mark.
+	 * @param {string} hostKey
+	 * @param {number} depth - Queue length immediately after enqueue.
+	 */
+	recordLimiterEnqueue(hostKey, depth) {
+		const bucket = this._host(hostKey)
+		if (depth > bucket.queueDepthHWM) bucket.queueDepthHWM = depth
+	},
+
+	/**
+	 * Record a slot release (decrements in-flight).
+	 * @param {string} hostKey
+	 */
+	recordLimiterRelease(hostKey) {
+		const bucket = this._host(hostKey)
+		bucket.inFlight = Math.max(0, bucket.inFlight - 1)
+	},
+
+	/**
+	 * Record an IndexedDB cache hit and the bytes it served.
+	 * @param {number} bytes - Stored entry size (0 if unknown).
+	 */
+	recordCacheHit(bytes) {
+		this.cache.hits += 1
+		this.cache.bytesFromCache += bytes || 0
+	},
+
+	/** Record an IndexedDB cache miss (absent or expired). */
+	recordCacheMiss() {
+		this.cache.misses += 1
+	},
+
+	/**
+	 * Record bytes fetched from the network (Content-Length; 0 when absent,
+	 * e.g. chunked or gzip-without-length responses).
+	 * @param {number} bytes
+	 */
+	recordNetworkBytes(bytes) {
+		this.cache.bytesFromNetwork += bytes || 0
+	},
+
+	/**
+	 * Record time spent deserializing a network response body (JSON/text parse).
+	 * @param {number} ms
+	 */
+	recordDeserialize(ms) {
+		this.cache.deserializeMsTotal += ms
+		this.cache.deserializeCount += 1
+	},
+
+	/** Record one `viewer.scene.requestRender()` call. */
+	recordRequestRender() {
+		this.render.requestRenderCount += 1
+	},
+
+	/**
+	 * Zero every counter in place (preserves the exposed object identity so a
+	 * captured `window.__perfStats` reference keeps pointing at live data).
+	 */
+	reset() {
+		for (const key of Object.keys(this.limiter.hosts)) {
+			delete this.limiter.hosts[key]
+		}
+		this.cache.hits = 0
+		this.cache.misses = 0
+		this.cache.bytesFromCache = 0
+		this.cache.bytesFromNetwork = 0
+		this.cache.deserializeMsTotal = 0
+		this.cache.deserializeCount = 0
+		this.render.requestRenderCount = 0
+	},
+}
+
+// Expose on window for the measurement harness — dev/E2E only.
+if (PERF_STATS_ENABLED && typeof window !== 'undefined') {
+	// This custom global isn't part of the standard Window type; widen to attach.
+	const debugWindow = /** @type {Window & { __perfStats?: typeof perfStats }} */ (window)
+	debugWindow.__perfStats = perfStats
+}
+
+export default perfStats

--- a/src/utils/perfStats.js
+++ b/src/utils/perfStats.js
@@ -15,8 +15,9 @@
  * - `limiter`: per-host queue-wait time injected by the 3-concurrent cap in
  *   {@link module:services/hostConcurrencyLimiter}.
  * - `cache`: hit/miss counts, bytes served from IndexedDB vs the network, and
- *   cumulative JSON deserialize time — {@link module:services/cacheService}
- *   and {@link module:services/unifiedLoader}.
+ *   cumulative response-body read+deserialize time (download + parse, not pure
+ *   parse) — {@link module:services/cacheService} and
+ *   {@link module:services/unifiedLoader}.
  * - `render`: how many times `viewer.scene.requestRender()` fired (patched once
  *   at viewer init in {@link module:composables/useViewerInitialization}).
  *
@@ -150,7 +151,10 @@ export const perfStats = {
 	},
 
 	/**
-	 * Record time spent deserializing a network response body (JSON/text parse).
+	 * Record time spent reading and deserializing a network response body. This
+	 * spans the body download (`response.json()/.text()/.blob()` stream the body
+	 * from the network) plus the parse, so it is NOT pure CPU parse time and is
+	 * dominated by transfer time on slow links.
 	 * @param {number} ms
 	 */
 	recordDeserialize(ms) {

--- a/tests/unit/services/cacheService.test.js
+++ b/tests/unit/services/cacheService.test.js
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for cacheService perf-stats recording.
+ *
+ * Focused regression coverage for the getData/hasValidData split: only an
+ * actual `getData` retrieval may record a cache hit/miss; `hasValidData` must
+ * not, even though it shares the same `_lookup` internal. Stubbing `_lookup`
+ * keeps these tests free of IndexedDB.
+ *
+ * Tags: @unit
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { cacheService } from '../../../src/services/cacheService.js'
+import { perfStats } from '../../../src/utils/perfStats.js'
+
+describe('cacheService perf-stats recording', () => {
+	beforeEach(() => {
+		perfStats.reset()
+		vi.restoreAllMocks()
+	})
+
+	it('getData records a hit (with stored size) on a lookup hit', async () => {
+		vi.spyOn(cacheService, '_lookup').mockResolvedValue({
+			result: { data: {}, timestamp: 0, age: 0, cached: true, metadata: {} },
+			size: 2048,
+		})
+
+		const result = await cacheService.getData('key')
+
+		expect(result).not.toBeNull()
+		expect(perfStats.cache.hits).toBe(1)
+		expect(perfStats.cache.bytesFromCache).toBe(2048)
+		expect(perfStats.cache.misses).toBe(0)
+	})
+
+	it('getData records a miss on a lookup miss', async () => {
+		vi.spyOn(cacheService, '_lookup').mockResolvedValue({ result: null, size: 0 })
+
+		const result = await cacheService.getData('key')
+
+		expect(result).toBeNull()
+		expect(perfStats.cache.misses).toBe(1)
+		expect(perfStats.cache.hits).toBe(0)
+	})
+
+	it('hasValidData does NOT record stats (no double-count with getData)', async () => {
+		const lookup = vi.spyOn(cacheService, '_lookup').mockResolvedValue({
+			result: { data: {}, timestamp: 0, age: 0, cached: true, metadata: {} },
+			size: 1024,
+		})
+
+		const exists = await cacheService.hasValidData('key')
+
+		expect(exists).toBe(true)
+		expect(lookup).toHaveBeenCalledTimes(1)
+		// The hit/miss counters and served-bytes total stay flat.
+		expect(perfStats.cache.hits).toBe(0)
+		expect(perfStats.cache.misses).toBe(0)
+		expect(perfStats.cache.bytesFromCache).toBe(0)
+	})
+})

--- a/tests/unit/utils/perfStats.test.js
+++ b/tests/unit/utils/perfStats.test.js
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for perfStats dev/E2E-gated performance counters.
+ *
+ * Vitest runs in `test` mode, so `import.meta.env.DEV` is true and
+ * PERF_STATS_ENABLED resolves to true — the counters are live here.
+ *
+ * Tags: @unit
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { PERF_STATS_ENABLED, perfStats } from '../../../src/utils/perfStats.js'
+
+describe('perfStats', () => {
+	beforeEach(() => {
+		perfStats.reset()
+	})
+
+	it('is enabled under the test runner (DEV mode)', () => {
+		expect(PERF_STATS_ENABLED).toBe(true)
+		expect(perfStats.enabled).toBe(true)
+	})
+
+	it('exposes a flat, JSON-serializable shape (methods omitted)', () => {
+		const snapshot = JSON.parse(JSON.stringify(perfStats))
+		expect(snapshot).toEqual({
+			enabled: true,
+			limiter: { hosts: {} },
+			cache: {
+				hits: 0,
+				misses: 0,
+				bytesFromCache: 0,
+				bytesFromNetwork: 0,
+				deserializeMsTotal: 0,
+				deserializeCount: 0,
+			},
+			render: { requestRenderCount: 0 },
+		})
+		// Methods must not survive serialization.
+		expect(snapshot.reset).toBeUndefined()
+		expect(snapshot.recordCacheHit).toBeUndefined()
+	})
+
+	describe('limiter counters', () => {
+		it('records fast-path acquire (no wait) and release', () => {
+			perfStats.recordLimiterAcquire('pygeoapi', 0)
+			const host = perfStats.limiter.hosts.pygeoapi
+			expect(host.acquired).toBe(1)
+			expect(host.inFlight).toBe(1)
+			expect(host.queuedCount).toBe(0)
+			expect(host.queueWaitMsTotal).toBe(0)
+
+			perfStats.recordLimiterRelease('pygeoapi')
+			expect(perfStats.limiter.hosts.pygeoapi.inFlight).toBe(0)
+		})
+
+		it('accumulates queue-wait time and count so avg is derivable', () => {
+			perfStats.recordLimiterAcquire('pygeoapi', 12)
+			perfStats.recordLimiterAcquire('pygeoapi', 8)
+			const host = perfStats.limiter.hosts.pygeoapi
+			expect(host.queuedCount).toBe(2)
+			expect(host.queueWaitMsTotal).toBe(20)
+			expect(host.queueWaitMsTotal / host.queuedCount).toBe(10)
+		})
+
+		it('tracks queue-depth high-water mark', () => {
+			perfStats.recordLimiterEnqueue('pygeoapi', 1)
+			perfStats.recordLimiterEnqueue('pygeoapi', 4)
+			perfStats.recordLimiterEnqueue('pygeoapi', 2)
+			expect(perfStats.limiter.hosts.pygeoapi.queueDepthHWM).toBe(4)
+		})
+
+		it('never lets in-flight go negative on extra releases', () => {
+			perfStats.recordLimiterRelease('wms')
+			expect(perfStats.limiter.hosts.wms.inFlight).toBe(0)
+		})
+	})
+
+	describe('cache counters', () => {
+		it('records hits with served bytes and misses', () => {
+			perfStats.recordCacheHit(2048)
+			perfStats.recordCacheHit(1024)
+			perfStats.recordCacheMiss()
+			expect(perfStats.cache.hits).toBe(2)
+			expect(perfStats.cache.bytesFromCache).toBe(3072)
+			expect(perfStats.cache.misses).toBe(1)
+		})
+
+		it('records network bytes and cumulative deserialize time', () => {
+			perfStats.recordNetworkBytes(5000)
+			perfStats.recordNetworkBytes(0) // Content-Length absent
+			perfStats.recordDeserialize(3.5)
+			perfStats.recordDeserialize(1.5)
+			expect(perfStats.cache.bytesFromNetwork).toBe(5000)
+			expect(perfStats.cache.deserializeMsTotal).toBe(5)
+			expect(perfStats.cache.deserializeCount).toBe(2)
+		})
+	})
+
+	describe('render counter', () => {
+		it('counts requestRender calls', () => {
+			perfStats.recordRequestRender()
+			perfStats.recordRequestRender()
+			expect(perfStats.render.requestRenderCount).toBe(2)
+		})
+	})
+
+	describe('flag off (production build)', () => {
+		afterEach(() => {
+			vi.unstubAllEnvs()
+			vi.resetModules()
+		})
+
+		it('reports disabled and does not expose window.__perfStats', async () => {
+			vi.resetModules()
+			vi.stubEnv('DEV', false)
+			vi.stubEnv('VITE_E2E_TEST', '')
+			// Clear any exposure left by the live (flag-on) import above.
+			const testWindow = /** @type {{ __perfStats?: unknown }} */ (window)
+			testWindow.__perfStats = undefined
+
+			const mod = await import('../../../src/utils/perfStats.js')
+
+			expect(mod.PERF_STATS_ENABLED).toBe(false)
+			expect(mod.perfStats.enabled).toBe(false)
+			expect(testWindow.__perfStats).toBeUndefined()
+		})
+	})
+
+	describe('reset()', () => {
+		it('zeroes every counter in place, preserving object identity', () => {
+			const limiterRef = perfStats.limiter
+			const cacheRef = perfStats.cache
+
+			perfStats.recordLimiterAcquire('pygeoapi', 5)
+			perfStats.recordCacheHit(999)
+			perfStats.recordNetworkBytes(123)
+			perfStats.recordDeserialize(2)
+			perfStats.recordRequestRender()
+
+			perfStats.reset()
+
+			expect(perfStats.limiter).toBe(limiterRef) // same reference
+			expect(perfStats.cache).toBe(cacheRef)
+			expect(perfStats.limiter.hosts).toEqual({})
+			expect(perfStats.cache.hits).toBe(0)
+			expect(perfStats.cache.bytesFromCache).toBe(0)
+			expect(perfStats.cache.bytesFromNetwork).toBe(0)
+			expect(perfStats.cache.deserializeMsTotal).toBe(0)
+			expect(perfStats.cache.deserializeCount).toBe(0)
+			expect(perfStats.render.requestRenderCount).toBe(0)
+		})
+	})
+})


### PR DESCRIPTION
## Purpose

Wave 0 of the performance investigation needs **durable, attributable** bottleneck evidence. This adds a flat, JSON-serializable counter object on `window.__perfStats`, populated **only in dev and E2E builds** and fully **inert in production** (no recorders run, no window exposure — verified absent from the production bundle).

A measurement harness (human or browser agent) reads it after a scripted interaction:

```js
JSON.stringify(window.__perfStats)   // snapshot counters
window.__perfStats.reset()           // zero between trials
```

## What's instrumented

| Subsystem | File | Counters |
|---|---|---|
| Concurrency cap | `hostConcurrencyLimiter.js` | per-host queue-wait time (`queueWaitMsTotal` + `queuedCount` → avg derivable), `inFlight`, `queueDepthHWM` — quantifies latency the 3-concurrent cap injects |
| Cache + network | `cacheService.getData` / `unifiedLoader.loadStandard` | `hits`, `misses`, `bytesFromCache`, `bytesFromNetwork` (Content-Length), `deserializeMsTotal`/`deserializeCount` (JSON parse time) |
| Render pressure | `useViewerInitialization.js` | `requestRenderCount` via a one-time per-viewer `scene.requestRender` monkey-patch (least invasive vs touching every call site) |

### Counter shape

```json
{
  "enabled": true,
  "limiter": {
    "hosts": {
      "pygeoapi": { "acquired": 42, "queuedCount": 30, "queueWaitMsTotal": 18450, "inFlight": 0, "queueDepthHWM": 27 }
    }
  },
  "cache": {
    "hits": 12, "misses": 7,
    "bytesFromCache": 9437184, "bytesFromNetwork": 14680064,
    "deserializeMsTotal": 312.5, "deserializeCount": 7
  },
  "render": { "requestRenderCount": 184 }
}
```

## Gating (dev/E2E only)

`PERF_STATS_ENABLED = import.meta.env.DEV || VITE_E2E_TEST === 'true'`, mirroring the existing `window.__viewer` / `window.globalStore` convention. In a production build this folds to `false` — the window-exposure side-effect is tree-shaken (`__perfStats` is absent from `dist/`) and every call site is guarded by a cheap `if (PERF_STATS_ENABLED)`, so there is **zero per-request allocation or logging when off**.

A known limitation, documented in code: `bytesFromNetwork` reads `Content-Length`, which is absent on chunked / gzip-without-length responses (reads 0 there). Cache hit/miss is recorded at the `cacheService` IndexedDB boundary.

## Verification

- `bun run lint` — clean (src + new test file)
- `vue-tsc --noEmit` — clean
- Full unit suite — 824 passed / 4 skipped, including a new `tests/unit/utils/perfStats.test.js` (11 cases: counters increment with flag on; flag-off path reports disabled and does not expose `window.__perfStats`)
- `bun run build` — succeeds; confirmed `__perfStats` does not appear in the production bundle

### Smoke test for the lead

Start a dev/E2E server (`bun run dev:test`), then in the page console:

```js
window.__perfStats.reset()
// drill into one postal code (e.g. 00100)
JSON.stringify(window.__perfStats)
```

After one postal-code click expect: `cache.misses` or `cache.hits` > 0, `cache.bytesFromNetwork` > 0 (cold) or `bytesFromCache` > 0 (warm), `limiter.hosts.pygeoapi.acquired` > 0 (and `queueDepthHWM` > 0 on a heavy area like 00100), and `render.requestRenderCount` > 0.

## Notes

- Labels: applied `enhancement`. `project:r4c` was requested but **does not exist** in this repo's label set (only `project:ict`, `project:reusable-workflows`, `project:gateway-migration`) — skipped.
- Dev/E2E-only instrumentation; no production behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Review feedback (Gemini, 2026-06-10)
- `cacheService`: split `getData` into a stats-free `_lookup()` so `hasValidData()` no longer double-counts cache hits/misses (+regression test).
- Clarified in code/JSDoc that the deserialize metric spans body download + parse (not pure CPU parse), kept as one combined metric on purpose.
- Rest-params suggestion on the `requestRender` patch declined: Cesium `requestRender(): void` takes zero args, so `...args` only adds per-call array allocation to a hot path in a perf tool.
