### PR TITLE
perf(data): drop unused properties from grid index and minify (−60% wire)

### DIFF
--- a/docs/data/GRID_INDEX.md
+++ b/docs/data/GRID_INDEX.md
@@ -1,0 +1,88 @@
+# Grid Index (`r4c_stats_grid_index.json`)
+
+`public/assets/data/r4c_stats_grid_index.json` is the 250 m socio-economic /
+climate-vulnerability statistics grid (6,710 `MultiPolygon` features). It is
+**lazy-loaded** when the user opens the 250 m SosEco grid view
+(`SosEco250mGrid.vue`) and parsed in a Web Worker
+(`src/workers/geojsonParser.worker.js`).
+
+## Consumed properties
+
+Grid-file consumers (`SosEco250mGrid.vue`, `useGridStyling.js`, the geojson
+worker, `mitigationStore.js`, `LandcoverToParks.vue`,
+`CoolingCenterOptimiser.vue`) read:
+
+- **Identity / position**: `grid_id`, `euref_x`, `euref_y`, `kunta`,
+  `missing_values`, `final_avg_conditional`
+- **Derived indices** (the visualised values): `heat_index`, `flood_index`,
+  `sensitivity`, `heat_exposure`, `flood_exposure`, `green`, `vegetation`,
+  `trees`, `water`
+- **Dynamically-selectable index components** read via
+  `entity.properties[selectedIndex]` in `useGridStyling.js` (option lists in
+  `PopGridLegend.vue` / `StatisticalGridOptions.vue`): `flood_prepare`,
+  `flood_respond`, `flood_recover`, `heat_prepare`, `heat_respond`, `age`,
+  `info`, `tenure`, `social_networks`, `overcrowding`
+
+## Slimming (dropped properties)
+
+The served file previously also carried 9 raw landcover-area / total-green
+**inputs** that have **zero consumers** in `src/` or `tests/`. They are the raw
+material the vulnerability pipeline already folds into the derived indices
+above, so they are dead weight on the wire and in the parse:
+
+```
+field_m2_2022   sea_m2_2022      total_green
+tree2_m2_2022   tree10_m2_2022   tree15_m2_2022   tree20_m2_2022
+vegetation_m2_2022   water_m2_2022
+```
+
+> ⚠️ These `*_m2_<year>` landcover keys are **NOT** unique to this file. The
+> sibling `public/assets/data/hsy_po.json` (postal-code landcover, loaded as
+> `propsStore.postalCodeData`) carries `*_m2_2016..2024` keys that **are**
+> consumed by `PieChart.vue` (dynamic `` `${key}_${year}` ``) and `ndvi_*` keys
+> consumed by `NDVIChart.vue`. **Do not slim `hsy_po.json`.** The drop applies
+> only to the grid index, whose own consumers never read these keys.
+
+### How the served file is slimmed
+
+`scripts/slim-grid-index.mjs` performs the transform reproducibly: it drops the
+9 keys and minifies (removes the `indent=4` pretty-print whitespace).
+
+```bash
+node scripts/slim-grid-index.mjs          # slim public/assets/data/r4c_stats_grid_index.json in place
+node scripts/slim-grid-index.mjs --check  # report bytes only, no write
+```
+
+The transform is idempotent. A regression test
+(`tests/unit/data/grid-index-slim.test.js`) asserts the feature count (6,710),
+geometry integrity, absence of the 9 dropped keys, presence of every consumed
+key, and that the file is minified.
+
+### Byte impact (raw 9.31 MB → 5.47 MB, −41 %)
+
+| Encoding   | Before (B) | After (B) | Saved   |
+| ---------- | ---------- | --------- | ------- |
+| raw        | 9,314,409  | 5,467,419 | −41.3 % |
+| gzip -9    | 1,864,062  | 1,279,869 | −31.3 % |
+| brotli -11 | 1,338,452  | 925,458   | −30.9 % |
+
+Combined with server-side compression (handled separately), the wire saving vs
+the current production nginx gzip-1 baseline is **≈ −60 %** (WO-6 row C2).
+
+## Upstream pipeline adoption (drop at the source)
+
+The grid is produced by the in-repo vulnerability pipeline under
+`scripts/vulnerability/` (`combine_for_index.py` → `calculate_index.py` →
+`combine.py`). `combine.py` already strips socio-economic intermediate columns
+via a `columns_to_remove` list and pretty-prints with `indent=4`. To make the
+client-side `slim-grid-index.mjs` redundant, the pipeline should:
+
+1. Append the 9 keys above to `columns_to_remove` in
+   `scripts/vulnerability/combine.py` (note `total_green` is consumed _during_
+   index calculation as `i_16` → `flood_exposure`; it is only redundant in the
+   **output**, so drop it after the index step, not before).
+2. Change `save_geojson()` to emit compact JSON
+   (`json.dump(data, f, separators=(",", ":"))` instead of `indent=4`).
+
+Once the pipeline emits the slimmed/minified file, `slim-grid-index.mjs` becomes
+a no-op and can be retired.

--- a/docs/data/README.md
+++ b/docs/data/README.md
@@ -4,9 +4,10 @@ This folder contains documentation for the data models and GeoJSON structures us
 
 ## Contents
 
-| Document                                           | Description                                                 |
-| -------------------------------------------------- | ----------------------------------------------------------- |
-| [BUILDING_PROPERTIES.md](./BUILDING_PROPERTIES.md) | Comprehensive reference for all building GeoJSON properties |
+| Document                                           | Description                                                                                         |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| [BUILDING_PROPERTIES.md](./BUILDING_PROPERTIES.md) | Comprehensive reference for all building GeoJSON properties                                         |
+| [GRID_INDEX.md](./GRID_INDEX.md)                   | 250 m stats grid (`r4c_stats_grid_index.json`) properties, slimming, and upstream-pipeline adoption |
 
 ## Quick Reference
 

--- a/scripts/slim-grid-index.mjs
+++ b/scripts/slim-grid-index.mjs
@@ -81,9 +81,19 @@ function parseArgs(argv) {
 	const args = { check: false, in: DEFAULT_FILE, out: null };
 	for (let i = 0; i < argv.length; i++) {
 		const a = argv[i];
-		if (a === '--check') args.check = true;
-		else if (a === '--in') args.in = resolve(argv[++i]);
-		else if (a === '--out') args.out = resolve(argv[++i]);
+		if (a === '--check') {
+			args.check = true;
+		} else if (a === '--in') {
+			const val = argv[i + 1];
+			if (!val || val.startsWith('-')) throw new Error('Missing value for --in');
+			args.in = resolve(val);
+			i++;
+		} else if (a === '--out') {
+			const val = argv[i + 1];
+			if (!val || val.startsWith('-')) throw new Error('Missing value for --out');
+			args.out = resolve(val);
+			i++;
+		}
 	}
 	if (!args.out) args.out = args.in;
 	return args;
@@ -95,8 +105,8 @@ function main() {
 	const bytesBefore = statSync(args.in).size;
 
 	const geojson = JSON.parse(rawBefore);
-	const featureCount = geojson.features.length;
 	slimGridIndex(geojson);
+	const featureCount = geojson.features.length;
 
 	// Minify: no indent, compact separators. Trailing newline keeps the output
 	// idempotent with the repo's end-of-file-fixer pre-commit hook.

--- a/scripts/slim-grid-index.mjs
+++ b/scripts/slim-grid-index.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * slim-grid-index.mjs — reproducibly slim public/assets/data/r4c_stats_grid_index.json
+ *
+ * WHAT IT DOES
+ *   1. Drops 9 property keys that have ZERO consumers anywhere in src/ or tests/.
+ *      These are raw landcover-area / total-green inputs that the upstream
+ *      vulnerability pipeline already folds into the *derived* indices
+ *      (heat_exposure, flood_exposure, green, vegetation, trees, water). The
+ *      derived indices are what the frontend reads; the raw inputs are dead
+ *      weight in the served file.
+ *   2. Minifies (drops the indent=4 pretty-print whitespace).
+ *
+ * DROPPED KEYS (all *_m2_2022 landcover-area + total_green):
+ *   field_m2_2022, sea_m2_2022, total_green, tree2_m2_2022, tree10_m2_2022,
+ *   tree15_m2_2022, tree20_m2_2022, vegetation_m2_2022, water_m2_2022
+ *
+ * VERIFIED-UNUSED (grep src/ tests/ docs/ for the literal names AND dynamic
+ *   `${key}_${year}` constructions): the only dynamic landcover read,
+ *   PieChart.vue's `${key}_${year}`, targets propsStore.postalCodeData
+ *   (= public/assets/data/hsy_po.json), NOT this grid file. The grid file is
+ *   consumed solely by SosEco250mGrid.vue + the geojson worker, which read
+ *   grid_id, euref_x/y, heat_index, flood_index, green, vegetation, trees,
+ *   water, kunta, final_avg_conditional, missing_values — none of the 9 keys.
+ *
+ * UPSTREAM ADOPTION (so the data pipeline can drop these at the source):
+ *   In scripts/vulnerability/combine.py, append the 9 keys above to the
+ *   existing `columns_to_remove` list (which already strips socioeconomic
+ *   intermediate columns), and change save_geojson() to dump compact JSON
+ *   (json.dump(data, f, separators=(",", ":")) instead of indent=4). Then this
+ *   client-side slimming script becomes a no-op and can be retired.
+ *
+ * USAGE
+ *   node scripts/slim-grid-index.mjs                 # slim in place
+ *   node scripts/slim-grid-index.mjs --check         # report bytes, do not write
+ *   node scripts/slim-grid-index.mjs --in FILE --out FILE
+ *
+ * The transform is idempotent: re-running on an already-slimmed file is a no-op
+ * (the keys are already gone; output stays minified).
+ */
+
+import { readFileSync, writeFileSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_FILE = resolve(__dirname, '../public/assets/data/r4c_stats_grid_index.json');
+
+export const DROPPED_KEYS = Object.freeze([
+	'field_m2_2022',
+	'sea_m2_2022',
+	'total_green',
+	'tree2_m2_2022',
+	'tree10_m2_2022',
+	'tree15_m2_2022',
+	'tree20_m2_2022',
+	'vegetation_m2_2022',
+	'water_m2_2022',
+]);
+
+/**
+ * Drop the unused keys from every feature's properties. Mutates in place and
+ * returns the same object for convenience.
+ * @param {{ features?: Array<{ properties?: Record<string, unknown> }> }} geojson
+ */
+export function slimGridIndex(geojson) {
+	if (!geojson || !Array.isArray(geojson.features)) {
+		throw new Error('Input is not a GeoJSON FeatureCollection with a features array');
+	}
+	for (const feature of geojson.features) {
+		const props = feature?.properties;
+		if (!props) continue;
+		for (const key of DROPPED_KEYS) {
+			delete props[key];
+		}
+	}
+	return geojson;
+}
+
+function parseArgs(argv) {
+	const args = { check: false, in: DEFAULT_FILE, out: null };
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === '--check') args.check = true;
+		else if (a === '--in') args.in = resolve(argv[++i]);
+		else if (a === '--out') args.out = resolve(argv[++i]);
+	}
+	if (!args.out) args.out = args.in;
+	return args;
+}
+
+function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const rawBefore = readFileSync(args.in, 'utf8');
+	const bytesBefore = statSync(args.in).size;
+
+	const geojson = JSON.parse(rawBefore);
+	const featureCount = geojson.features.length;
+	slimGridIndex(geojson);
+
+	// Minify: no indent, compact separators. Trailing newline keeps the output
+	// idempotent with the repo's end-of-file-fixer pre-commit hook.
+	const minified = `${JSON.stringify(geojson)}\n`;
+	const bytesAfter = Buffer.byteLength(minified, 'utf8');
+
+	const pct = (100 * (bytesBefore - bytesAfter)) / bytesBefore;
+	console.log(`features:        ${featureCount}`);
+	console.log(`dropped keys:    ${DROPPED_KEYS.length} (${DROPPED_KEYS.join(', ')})`);
+	console.log(`raw before:      ${bytesBefore.toLocaleString()} B`);
+	console.log(`raw after:       ${bytesAfter.toLocaleString()} B`);
+	console.log(`raw saved:       ${(bytesBefore - bytesAfter).toLocaleString()} B (${pct.toFixed(1)}%)`);
+
+	if (args.check) {
+		console.log('--check: no file written');
+		return;
+	}
+	writeFileSync(args.out, minified);
+	console.log(`wrote:           ${args.out}`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+	main();
+}

--- a/tests/unit/data/grid-index-slim.test.js
+++ b/tests/unit/data/grid-index-slim.test.js
@@ -1,0 +1,117 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { DROPPED_KEYS, slimGridIndex } from '../../../scripts/slim-grid-index.mjs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const GRID_FILE = resolve(__dirname, '../../../public/assets/data/r4c_stats_grid_index.json')
+
+// Keys that src/ consumers actually read from the grid index file. Drive this
+// list from the WO-6 property census + the PR verification table:
+//   - Direct reads (SosEco250mGrid.vue, useGridStyling.js, the geojson worker,
+//     LandcoverToParks.vue, mitigationStore.js, CoolingCenterOptimiser.vue).
+//   - Selectable statsIndex values resolved dynamically via
+//     `entity.properties[selectedIndex]` in useGridStyling.js, whose option
+//     lists live in PopGridLegend.vue / StatisticalGridOptions.vue. Only the
+//     options that exist as grid-file keys are listed here (combined_* and
+//     avgheatexposure options belong to the population-grid layer).
+const REQUIRED_KEYS = [
+	// direct reads
+	'grid_id',
+	'euref_x',
+	'euref_y',
+	'heat_index',
+	'flood_index',
+	'green',
+	'vegetation',
+	'trees',
+	'water',
+	'kunta',
+	'heat_exposure',
+	'flood_exposure',
+	'final_avg_conditional',
+	'missing_values',
+	// dynamically-selectable index components
+	'sensitivity',
+	'flood_prepare',
+	'flood_respond',
+	'flood_recover',
+	'heat_prepare',
+	'heat_respond',
+	'age',
+	'info',
+	'tenure',
+	'social_networks',
+	'overcrowding',
+]
+
+const FEATURE_COUNT = 6710
+
+describe('r4c_stats_grid_index.json slimming', { tags: ['@unit'] }, () => {
+	const raw = readFileSync(GRID_FILE, 'utf8')
+	const data = JSON.parse(raw)
+	const keyUnion = new Set(data.features.flatMap((f) => Object.keys(f.properties ?? {})))
+
+	it('is a FeatureCollection with the full feature count unchanged', () => {
+		expect(data.type).toBe('FeatureCollection')
+		expect(data.features).toHaveLength(FEATURE_COUNT)
+	})
+
+	it('keeps geometry intact for every feature', () => {
+		for (const feature of data.features) {
+			expect(feature.geometry).toBeTruthy()
+			expect(feature.geometry.type).toBe('MultiPolygon')
+			expect(Array.isArray(feature.geometry.coordinates)).toBe(true)
+			expect(feature.geometry.coordinates.length).toBeGreaterThan(0)
+		}
+	})
+
+	it('has dropped all 9 unused property keys from every feature', () => {
+		for (const dropped of DROPPED_KEYS) {
+			expect(keyUnion.has(dropped)).toBe(false)
+		}
+	})
+
+	it('still contains every key that src/ consumers read', () => {
+		const missing = REQUIRED_KEYS.filter((k) => !keyUnion.has(k))
+		expect(missing).toEqual([])
+	})
+
+	it('is minified (no pretty-print whitespace)', () => {
+		// A single trailing newline (end-of-file-fixer) is allowed; there must be
+		// no internal newlines and no ": " pretty-print separators.
+		expect(raw.replace(/\n$/, '')).not.toContain('\n')
+		expect(raw).not.toMatch(/: /) // compact separators, no ": " after keys
+	})
+})
+
+describe('slimGridIndex() transform', { tags: ['@unit'] }, () => {
+	it('drops exactly the listed keys and is idempotent', () => {
+		const input = {
+			type: 'FeatureCollection',
+			features: [
+				{
+					properties: {
+						grid_id: 'a',
+						heat_index: 1,
+						total_green: 99,
+						vegetation_m2_2022: 12,
+						water_m2_2022: 3,
+					},
+					geometry: { type: 'MultiPolygon', coordinates: [[[[0, 0]]]] },
+				},
+			],
+		}
+		const out = slimGridIndex(structuredClone(input))
+		expect(Object.keys(out.features[0].properties).sort()).toEqual(['grid_id', 'heat_index'])
+		// idempotent
+		const again = slimGridIndex(structuredClone(out))
+		expect(Object.keys(again.features[0].properties).sort()).toEqual(['grid_id', 'heat_index'])
+	})
+
+	it('throws on a non-FeatureCollection input', () => {
+		expect(() => slimGridIndex({})).toThrow()
+		expect(() => slimGridIndex(null)).toThrow()
+	})
+})

--- a/tests/unit/data/grid-index-slim.test.js
+++ b/tests/unit/data/grid-index-slim.test.js
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 import { DROPPED_KEYS, slimGridIndex } from '../../../scripts/slim-grid-index.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -49,9 +49,15 @@ const REQUIRED_KEYS = [
 const FEATURE_COUNT = 6710
 
 describe('r4c_stats_grid_index.json slimming', { tags: ['@unit'] }, () => {
-	const raw = readFileSync(GRID_FILE, 'utf8')
-	const data = JSON.parse(raw)
-	const keyUnion = new Set(data.features.flatMap((f) => Object.keys(f.properties ?? {})))
+	let raw
+	let data
+	let keyUnion
+
+	beforeAll(() => {
+		raw = readFileSync(GRID_FILE, 'utf8')
+		data = JSON.parse(raw)
+		keyUnion = new Set(data.features.flatMap((f) => Object.keys(f.properties ?? {})))
+	})
 
 	it('is a FeatureCollection with the full feature count unchanged', () => {
 		expect(data.type).toBe('FeatureCollection')


### PR DESCRIPTION
## Summary

Slims `public/assets/data/r4c_stats_grid_index.json` (the lazy-loaded 250 m
SosEco / climate-vulnerability stats grid, 6,710 features) by **dropping 9
property keys that have zero consumers in `src/` or `tests/`** and **minifying**
(removing the `indent=4` pretty-print whitespace).

Implements WO-6 finding **C1/C2** from the performance investigation. Raw
**9.31 MB → 5.47 MB (−41%)**; combined with server-side compression (handled by
a separate agent — this PR does **not** touch `nginx/` or the `Dockerfile`) the
wire saving vs today's nginx gzip-1 baseline is **≈ −60%**.

## Verification table — re-verified the 9 unused keys myself

For each key I grepped `src/`, `tests/`, and `docs/` for the literal name **and**
dynamic-access patterns (`${key}_${year}`, `properties[selectedIndex]`,
statsIndex option lists in `propsStore`/`PopGridLegend`/`StatisticalGridOptions`).

| Key | literal in src/tests | dynamic-construction consumer | grid-file consumer? | Verdict |
|---|---|---|---|---|
| `field_m2_2022` | none | none on grid file | no | **drop** |
| `sea_m2_2022` | none | none on grid file | no | **drop** |
| `total_green` | none | none on grid file (used only as pipeline input `i_16`) | no | **drop** |
| `tree2_m2_2022` | none | none on grid file | no | **drop** |
| `tree10_m2_2022` | none | none on grid file | no | **drop** |
| `tree15_m2_2022` | none | none on grid file | no | **drop** |
| `tree20_m2_2022` | none | none on grid file | no | **drop** |
| `vegetation_m2_2022` | none | none on grid file | no | **drop** |
| `water_m2_2022` | none | none on grid file | no | **drop** |

**Key dynamic-access finding (WO-6 missed it):** `PieChart.vue` constructs
`` `${key}_${year}` `` (→ `tree20_m2_2022`, `vegetation_m2_2022`, …) and reads it
from **`propsStore.postalCodeData`**, which is **`hsy_po.json`** (a *different*
file), **not** the grid index. `NDVIChart.vue` likewise reads `ndvi_*` from
`hsy_po.json`. The grid index is consumed **only** by `SosEco250mGrid.vue` + the
geojson worker (and `useGridStyling.js` / `mitigationStore.js` /
`LandcoverToParks.vue` / `CoolingCenterOptimiser.vue`), which read
`grid_id`, `euref_x/y`, `kunta`, `missing_values`, `final_avg_conditional`, and
the **derived indices** `heat_index`, `flood_index`, `sensitivity`,
`heat_exposure`, `flood_exposure`, `green`, `vegetation`, `trees`, `water`
(+ the selectable index components `flood_prepare/respond/recover`,
`heat_prepare/respond`, `age`, `info`, `tenure`, `social_networks`,
`overcrowding`). None of the 9 keys appears in any selectable-index list.

### Sibling files (`public/assets/data/`)

| File | Has any of the 9 keys? | Action |
|---|---|---|
| `r4c_stats_grid_index.json` | yes (all 9) | **slimmed** |
| `hsy_po.json` | yes (`*_m2_<year>`) | **left alone** — consumed by `PieChart.vue` / `NDVIChart.vue` |
| `hsy_populationgrid.json` | no | left alone |
| `travel_time_grid.json` | no | left alone |
| `hki_po_clipped.json` | no | left alone |

## Byte table

| Encoding | Before (B) | After (B) | Saved |
|---|---|---|---|
| raw | 9,314,409 | 5,467,419 | −41.3% |
| gzip -9 | 1,864,062 | 1,279,869 | −31.3% |
| brotli -11 | 1,338,452 | 925,458 | −30.9% |

Coordinate truncation (WO-6 C3, ~3% marginal) was **skipped** per the approved decision.

## Dropped-key list

`field_m2_2022`, `sea_m2_2022`, `total_green`, `tree2_m2_2022`,
`tree10_m2_2022`, `tree15_m2_2022`, `tree20_m2_2022`, `vegetation_m2_2022`,
`water_m2_2022`

## Provenance / upstream data pipeline

The grid is produced in-repo by `scripts/vulnerability/` (`combine_for_index.py`
→ `calculate_index.py` → `combine.py`). `combine.py` already strips
socio-economic intermediate columns via a `columns_to_remove` list and
pretty-prints with `indent=4`. **To adopt the drop at the source** (making the
client-side script redundant): append the 9 keys to `columns_to_remove` (drop
`total_green` *after* the index step — it is consumed as `i_16` →
`flood_exposure` during calculation), and switch `save_geojson()` to
`json.dump(data, f, separators=(",", ":"))`. Documented in
[`docs/data/GRID_INDEX.md`](docs/data/GRID_INDEX.md) and the
`scripts/slim-grid-index.mjs` header.

## What this PR adds

- `scripts/slim-grid-index.mjs` — reproducible, idempotent transform (drop 9
  keys + minify). `--check` reports bytes without writing.
- `tests/unit/data/grid-index-slim.test.js` — data-integrity check: feature
  count unchanged (6,710), every feature's geometry intact (`MultiPolygon` with
  coordinates), all 9 keys absent, every consumed key present, file minified.
- `docs/data/GRID_INDEX.md` (+ README link) — properties, slimming rationale,
  byte impact, upstream adoption.
- The regenerated `r4c_stats_grid_index.json`.

## Checks

- `bun run test:unit` — 820 passed (incl. 7 new)
- `bun run lint` (Biome) — clean
- `bun run build` — green
- pre-commit hooks — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Review follow-up (0b61221):** hardened `slim-grid-index.mjs` arg parsing (validate `--in`/`--out` values) and validation order, and moved the test's synchronous file I/O into a `beforeAll` hook. Per Gemini review on this PR. Data file and transform behavior unchanged.