### PR TITLE
fix(nginx): data cache headers, precompression, HSY stale-on-error tile cache

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -245,6 +245,15 @@ server {
     # revalidation cost is negligible, so a tight bound on staleness is free.
     location /assets/data/ {
         add_header Cache-Control "public, max-age=3600, must-revalidate" always;
+        # An add_header at this level suppresses ALL inherited server-level
+        # add_header directives (nginx headers module: inherited "if and only
+        # if there are no add_header directives defined on the current level").
+        # Re-declare the global security headers so data responses keep them
+        # (#877 review). X-Cache-Status is intentionally not re-added: it is
+        # $upstream_cache_status, which is empty for local static-file serving.
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         etag on;
         access_log off;
         try_files $uri =404;
@@ -326,6 +335,15 @@ server {
     # times out, or is mid-refresh, so users keep seeing the map.
     location /wms/proxy {
         proxy_pass https://kartta.hsy.fi;
+
+        # kartta.hsy.fi is fronted by a Microsoft-Azure-Application-Gateway
+        # (WO-4) that needs SNI to route the TLS handshake. nginx omits SNI by
+        # default (proxy_ssl_server_name off), so enable it here — matching
+        # /hsy-action — to avoid intermittent handshake failures surfacing as
+        # 502s (#877 review). The HTTP Host header is already kartta.hsy.fi via
+        # the server-level `proxy_set_header Host $proxy_host`, and proxy_ssl_name
+        # defaults to $proxy_host, so SNI is sent as kartta.hsy.fi automatically.
+        proxy_ssl_server_name on;
 
         # Cache key covers the full GetMap query string (LAYERS/BBOX/WIDTH/…),
         # so each distinct tile is a distinct cache entry.

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -205,12 +205,24 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
 
-    # Enable gzip compression for static assets
+    # Serve build-time precompressed siblings (.gz, written by
+    # scripts/precompress.mjs at gzip level 9) when present — zero per-request
+    # CPU and a far better ratio than the on-the-fly level-1 default. Covers the
+    # big static JSON payloads (e.g. the 8.9 MB grid index, 2.33 MB -> 1.86 MB
+    # wire; WO-6) and the hashed JS/CSS bundles. Falls back to dynamic gzip
+    # below for anything without a .gz (notably proxied pygeoapi JSON).
+    gzip_static on;
+
+    # On-the-fly gzip for dynamic/proxied responses that have no precompressed
+    # sibling — primarily the uncompressed multi-MB GeoJSON arriving from
+    # pygeoapi (WO-2: origin sends no Content-Encoding). Level 6 is the sane
+    # bandwidth/CPU midpoint (stock default is level 1).
     gzip on;
+    gzip_comp_level 6;
     gzip_vary on;
     gzip_min_length 1000;
     gzip_proxied any;
-    gzip_types text/plain text/css text/xml text/javascript application/javascript application/json application/xml+rss application/x-javascript;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/json application/geo+json application/xml+rss application/x-javascript;
     gzip_disable "MSIE [1-6]\.";
 
     # Rule 1: NEVER cache index.html (always check for new version)

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -318,32 +318,53 @@ server {
         proxy_set_header Host $pygeoapi_host;
     }
 
+    # HSY landcover WMS GetMap tiles. HSY's upstream is flaky under load —
+    # it returns 504s (Microsoft-Azure-Application-Gateway, ~20 s TTFB; WO-4)
+    # rather than throttling, and is periodically fully down, which breaks
+    # testing and stakeholder demos. This block makes the proxy resilient:
+    # cache 200 tiles for a long time and serve them STALE when HSY errors,
+    # times out, or is mid-refresh, so users keep seeing the map.
     location /wms/proxy {
         proxy_pass https://kartta.hsy.fi;
+
+        # Cache key covers the full GetMap query string (LAYERS/BBOX/WIDTH/…),
+        # so each distinct tile is a distinct cache entry.
         proxy_cache_key $request_uri;
 
-        # Use WMS-specific cache
+        # Only cache GET/HEAD (nginx default) + 200s. Landcover layers are
+        # near-static annual datasets, so a 7-day validity is safe and means a
+        # cold cache fills once then serves locally for a week.
         proxy_cache wms_cache;
-        proxy_cache_valid 200 7d;        # Cache successful responses for 7 days
-        proxy_cache_valid 404 60m;       # Cache not-found for 1 hour
-        proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
+        proxy_cache_methods GET HEAD;
+        proxy_cache_valid 200 7d;
+
+        # Resilience: serve a previously-cached tile when HSY errors, times
+        # out, or while a background refresh is in flight ("updating"). With
+        # background_update the refresh happens out-of-band so the user never
+        # waits on HSY; with cache_lock, concurrent identical misses collapse
+        # to a single upstream request (also avoids tipping HSY into its
+        # 504-under-load behavior).
+        proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
         proxy_cache_background_update on;
         proxy_cache_lock on;
 
-        # Optimize for tile delivery
+        # X-Cache-Status (HIT/MISS/STALE/UPDATING) is inherited from the
+        # server-level add_header for observability; no add_header here so the
+        # inherited security + cache-status headers are preserved.
+
+        # Buffers sized for raster tiles (~7-30 KB per WO-2/WO-4).
         proxy_buffers 8 256k;
         proxy_buffer_size 256k;
         proxy_busy_buffers_size 256k;
         proxy_temp_file_write_size 256k;
 
-        # Increase timeouts for large tiles
-        proxy_connect_timeout 60s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
+        # SHORT timeouts so a hung HSY fails over to a stale tile in seconds
+        # instead of hanging ~20 s on the upstream Azure gateway timeout.
+        # Healthy GetMap responds in ~0.2 s (WO-2), so 10 s is generous.
+        proxy_connect_timeout 3s;
+        proxy_send_timeout 10s;
+        proxy_read_timeout 10s;
 
-        # Enable compression
-        gzip on;
-        gzip_types image/jpeg image/png image/gif;
         rewrite ^/wms/proxy(.*)$ /geoserver/wms$1 break;
     }
 

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -221,6 +221,23 @@ server {
         try_files $uri =404;
     }
 
+    # Rule 2a: Unhashed runtime data files (e.g. r4c_stats_grid_index.json) —
+    # MUST NOT be immutable-cached. These filenames carry no content hash, so
+    # the immutable Rule 2 below served them "public, max-age=31536000,
+    # immutable", meaning a returning visitor kept up-to-1-year-stale grid data
+    # after a redeploy that changed the file (WO-6 BUG #1 — a correctness bug).
+    # This more-specific prefix wins over /assets/ (nginx longest-prefix match).
+    # Short max-age bounds staleness to 1h; ETag (on by default for static
+    # files) makes revalidation a cheap 304 when the file is unchanged. 1h is
+    # chosen over a longer window because data redeploys are infrequent and the
+    # revalidation cost is negligible, so a tight bound on staleness is free.
+    location /assets/data/ {
+        add_header Cache-Control "public, max-age=3600, must-revalidate" always;
+        etag on;
+        access_log off;
+        try_files $uri =404;
+    }
+
     # Rule 2: Aggressively cache hashed assets (they're immutable)
     location /assets/ {
         add_header Cache-Control "public, max-age=31536000, immutable" always;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"dev": "vite --host",
 		"dev:test": "VITE_E2E_TEST=true vite --host",
-		"build": "NODE_OPTIONS='--max-old-space-size=3072' vite build",
+		"build": "NODE_OPTIONS='--max-old-space-size=3072' vite build && bun scripts/precompress.mjs",
 		"build:analyze": "NODE_OPTIONS='--max-old-space-size=3072' vite build --mode analyze",
 		"preview": "vite preview --host",
 		"lint": "biome check src/",

--- a/scripts/precompress.mjs
+++ b/scripts/precompress.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Build-time static precompression.
+ *
+ * Walks the build output (`dist/`) and writes a level-9 gzip sibling
+ * (`<file>.gz`) for every compressible asset above a size threshold. nginx
+ * serves these directly via `gzip_static on;` — no per-request CPU and a far
+ * better ratio than nginx's default on-the-fly gzip level 1.
+ *
+ * Why a script (not a bundle-scoped vite plugin): the heaviest compressible
+ * payload — `assets/data/r4c_stats_grid_index.json` (8.9 MB, WO-6) — is a
+ * `public/` asset copied verbatim into `dist/`, NOT a rollup bundle chunk.
+ * Walking `dist/` guarantees it is covered; a generateBundle-hook plugin may
+ * silently skip copied public assets.
+ *
+ * Run with `bun scripts/precompress.mjs` (the build image is `oven/bun`, which
+ * has no `node` binary). bun implements `node:zlib` / `node:fs`.
+ *
+ * Brotli (`.br`) is intentionally NOT emitted here: stock `nginx:1.31` has no
+ * brotli module, so `.br` files would ship dead weight. Adding `brotli_static`
+ * is a tracked follow-up that also adds `.br` generation here.
+ */
+import { gzipSync, constants } from 'node:zlib';
+import { readdirSync, readFileSync, writeFileSync, statSync } from 'node:fs';
+import { join, extname } from 'node:path';
+
+const DIST = 'dist';
+// Only precompress text-like assets; binary/image/font formats are already
+// compressed and would only waste bytes + build time.
+const COMPRESSIBLE = new Set([
+	'.js',
+	'.mjs',
+	'.css',
+	'.json',
+	'.html',
+	'.svg',
+	'.xml',
+	'.txt',
+	'.map',
+	'.wasm',
+]);
+// Mirror nginx `gzip_min_length 1000` — tiny files don't benefit.
+const MIN_BYTES = 1024;
+
+let count = 0;
+let rawTotal = 0;
+let gzTotal = 0;
+
+/** @param {string} dir */
+function walk(dir) {
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			walk(full);
+			continue;
+		}
+		if (!entry.isFile()) continue;
+		if (entry.name.endsWith('.gz') || entry.name.endsWith('.br')) continue;
+		if (!COMPRESSIBLE.has(extname(entry.name).toLowerCase())) continue;
+
+		const size = statSync(full).size;
+		if (size < MIN_BYTES) continue;
+
+		const buf = readFileSync(full);
+		const gz = gzipSync(buf, { level: constants.Z_BEST_COMPRESSION });
+		// Skip if compression doesn't actually help (e.g. already-dense data).
+		if (gz.length >= size) continue;
+
+		writeFileSync(`${full}.gz`, gz);
+		count += 1;
+		rawTotal += size;
+		gzTotal += gz.length;
+	}
+}
+
+try {
+	statSync(DIST);
+} catch {
+	console.error(`precompress: "${DIST}/" not found — run after \`vite build\`.`);
+	process.exit(1);
+}
+
+walk(DIST);
+
+const pct = rawTotal > 0 ? ((1 - gzTotal / rawTotal) * 100).toFixed(1) : '0.0';
+console.log(
+	`precompress: gzip-9 wrote ${count} .gz files — ` +
+		`${(rawTotal / 1e6).toFixed(2)} MB → ${(gzTotal / 1e6).toFixed(2)} MB (-${pct}%)`
+);


### PR DESCRIPTION
Three delivery-layer fixes in `nginx/default.conf.template` + the build, from the Wave-0 performance investigation (`tmp/perf-investigation/`). Evidence: WO-6 (static bytes/cache), WO-2 (upstream timing), WO-4 (tile streaming under trace).

## 1. Static-data cache-header bug — stale data (correctness)

WO-6 BUG #1: the unhashed `/assets/data/*.json` files (incl. the **8.9 MB** `r4c_stats_grid_index.json`) matched the broad `location /assets/` block and were served `Cache-Control: public, max-age=31536000, immutable`. `immutable` suppresses revalidation, so a returning visitor kept **up-to-1-year-stale grid data** after a redeploy that changed the file.

**Fix:** a more-specific `location /assets/data/` (wins via nginx longest-prefix match) with `max-age=3600, must-revalidate` + ETag → staleness bounded to 1h, revalidation is a cheap 304. Hashed build assets keep their immutable caching. 1h chosen because data redeploys are infrequent and revalidation cost is negligible — a tight staleness bound is free.

## 2. Compression

Prod nginx shipped stock **gzip level 1** with no precompression (grid index = 2.33 MB wire; WO-6).

- **Build-time precompression** (`scripts/precompress.mjs`, gzip-9 over `dist/`, wired into `bun run build`) + **`gzip_static on;`** → nginx serves `.gz` siblings with zero per-request CPU. Grid index **2.33 MB → 1.86 MB wire** (-20% vs gzip-1; full build: 52.9 MB → 12.0 MB, -77%).
- A **script** (not a bundle-scoped vite plugin) so the `public/` `assets/data/*.json` files are guaranteed covered; runs under `bun` so it works in the `oven/bun` build image.
- **Dynamic gzip level 6** + `application/geo+json` in `gzip_types` for proxied pygeoapi JSON (WO-2: origin sends no `Content-Encoding`; this is the in-repo half of the ~6× win).

## 3. HSY WMS resilience (stale-on-error)

HSY's WMS returns **504s under load** (Microsoft-Azure-Application-Gateway, ~20 s TTFB; WO-4) instead of throttling, and is periodically fully down — breaking testing/demos. Hardened the existing `/wms/proxy` tile cache (tiles ~7-30 KB, WO-2/WO-4):

- Added **`updating`** to `proxy_cache_use_stale` → concurrent requests get a stale tile instantly while a background refresh runs (`background_update` already on).
- **Timeouts 60s → 3s connect / 10s read/send** → a hung HSY fails over to stale in seconds, not ~20 s. Healthy GetMap is ~0.2 s (WO-2).
- Restricted to **GET/HEAD + 200 only** (dropped the 404 negative-cache); `proxy_cache_valid 200 7d` (landcover = near-static annual data).
- `proxy_cache_lock on` collapses concurrent identical misses (also avoids tripping HSY's 504-under-load).
- `X-Cache-Status` is inherited from the server-level `add_header` for observability.

## deploy/values.yaml

**No change needed.** Kyverno read-only-rootfs + the cache paths `/tmp/nginx_{,wms_}cache` already live on the existing writable `tmp` emptyDir mount.

## Verification (`docker compose build && up -d`)

```
# nginx -t inside container
nginx: configuration file /etc/nginx/nginx.conf test is successful

# (a) /assets/data/ grid index — short max-age + ETag + precompressed gzip
HTTP/1.1 200 OK
Content-Length: 1889525        # the .gz, served via gzip_static
Content-Encoding: gzip
ETag: "6a292d9d-1cd4f5"
Cache-Control: public, max-age=3600, must-revalidate

# (b) hashed Cesium JS — still immutable + precompressed gzip
HTTP/1.1 200 OK
Content-Length: 1311778
Content-Encoding: gzip
Cache-Control: public, max-age=31536000, immutable

# (c) /wms/proxy GetMap fired twice
request 1 -> X-Cache-Status: MISS  (200 image/png from HSY)
request 2 -> X-Cache-Status: HIT

# rendered /wms/proxy directives (post-envsubst)
proxy_cache_methods GET HEAD;  proxy_cache_valid 200 7d;
proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
proxy_cache_background_update on;  proxy_cache_lock on;
proxy_connect_timeout 3s;  proxy_read_timeout 10s;
```

- **(d) stale-on-error** is hard to simulate locally (can't force HSY to 504). Verified via `nginx -t` + the rendered directives above. **Manual prod check:** request a previously-cached tile while HSY is returning 504 (or block `kartta.hsy.fi`) → expect `HTTP/1.1 200` with `X-Cache-Status: STALE` instead of an error.
- Build green; **813 unit tests pass**; `biome check src/` clean.
- The local `/pygeoapi/` proxy returns 502 in docker compose — a container DNS/resolver artifact (WO-6 anomaly #1), not prod behavior; dynamic-gzip on pygeoapi is config-verified, not curl-verified locally.

## Follow-ups

- **Brotli image + `brotli_static` (.br)** — deferred because stock `nginx:1.31` has no brotli module; switching the base image fights the Renovate `nginx:1.31` pin and the Debian `apt-get` dbmate install. Tracked: **#876** (would add another -28% to -43% on the largest static assets per WO-6).
- **pygeoapi `/wms/proxy`-style stale-on-error caching** — explicitly **deferred**. More dangerous (large bodies, data freshness): the `/pygeoapi/` location already inherits `proxy_cache global_cache` (60m, stale-on-error). Any extension there should keep validity short and stale-on-error only; not changed in this PR.

---

## Review follow-up (724a625)

Addressed Gemini Code Assist review:

- **`/assets/data/` security headers** — an `add_header` at a `location` level suppresses *all* inherited server-level `add_header` directives (nginx headers module rule). The new block was silently dropping `X-Content-Type-Options`, `X-Frame-Options`, and `Referrer-Policy` from data responses. Re-declared those three headers in the block. Kept the explicit `public, max-age=3600, must-revalidate` rather than switching to `expires 1h` (which emits only `max-age`, dropping the deliberately-set `public`/`must-revalidate`).
- **`/wms/proxy` SNI** — enabled `proxy_ssl_server_name on` so nginx sends SNI to the `kartta.hsy.fi` Azure Application Gateway (matches `/hsy-action`), preventing intermittent TLS-handshake 502s.

Re-verified in container: `nginx -t` ok; data JSON returns `max-age=3600` + ETag + gzip + the three security headers; `/wms/proxy` MISS→HIT 200 with no 502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

