### PR TITLE
fix(wms): graceful degradation when HSY API is flaky or down

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -150,6 +150,7 @@ import { useFeatureFlagStore } from './stores/featureFlagStore'
 import { useGlobalStore } from './stores/globalStore.js'
 import { useGraphicsStore } from './stores/graphicsStore.js'
 import { useLoadingStore } from './stores/loadingStore.js'
+import { useServiceHealthStore } from './stores/serviceHealthStore.js'
 import { useToggleStore } from './stores/toggleStore.js'
 import { useUserStore } from './stores/userStore'
 import logger from './utils/logger.js'
@@ -160,6 +161,7 @@ const loadingStore = useLoadingStore()
 const featureFlagStore = useFeatureFlagStore()
 const graphicsStore = useGraphicsStore()
 const userStore = useUserStore()
+const serviceHealthStore = useServiceHealthStore()
 
 const { sidebarOffset: timelineOffset } = useSidebarOffset(0)
 const { sidebarOffset: disclaimerOffset } = useSidebarOffset(12)
@@ -276,6 +278,10 @@ const handleCacheCleared = (sourceId) => {
 
 // Initialize services on mount
 onMounted(async () => {
+	// Wire the upstream-degradation notice (circuit breaker → snackbar). Done
+	// outside the try so a downstream init failure can't leave it unsubscribed.
+	serviceHealthStore.init()
+
 	try {
 		await userStore.fetchUserInfo()
 		await initializeFeatureFlags(userStore)
@@ -310,6 +316,7 @@ onMounted(async () => {
 onBeforeUnmount(async () => {
 	stopLevelUrlWatcher()
 	loadingStore.stopStaleCleanupTimer()
+	serviceHealthStore.teardown()
 
 	if (featureFlagStore.isEnabled('backgroundPreload')) {
 		const { default: backgroundPreloader } = await import('./services/backgroundPreloader.js')

--- a/src/constants/timing.js
+++ b/src/constants/timing.js
@@ -25,4 +25,18 @@ export const TIMING = {
 	WMS_RETRY_DELAY_BASE_MS: 1000,
 	WMS_RETRY_MAX_DELAY_MS: 8000,
 	WMS_RETRY_JITTER_MS: 200,
+
+	// Per-attempt fetch timeout. Bounds a single request so a hung upstream
+	// (e.g. HSY's Azure App Gateway, which holds ~20s before returning 504)
+	// cannot pin a hostConcurrencyLimiter slot for the full gateway timeout.
+	// Kept well under 20s so the request aborts, retries, and degrades while
+	// the gateway is still hanging.
+	FETCH_TIMEOUT_MS: 12000,
+
+	// Per-host circuit breaker: after this many consecutive failures the
+	// breaker opens and requests to that host fast-fail for the cooldown
+	// window, instead of every request independently paying the full
+	// timeout + retry penalty against a service that is clearly down.
+	CIRCUIT_BREAKER_FAILURE_THRESHOLD: 5,
+	CIRCUIT_BREAKER_COOLDOWN_MS: 30000,
 }

--- a/src/pages/CesiumViewer.vue
+++ b/src/pages/CesiumViewer.vue
@@ -90,6 +90,29 @@
 				</v-btn>
 			</template>
 		</v-snackbar>
+		<!--
+			Upstream Service Degradation Notice
+			Purpose: Inform the user when HSY map-data services are flaky/down
+			Behavior: Non-blocking, persistent while degraded, auto-clears on recovery
+			Use case: HSY WMS/pygeoapi returning 504 or down — circuit breaker open.
+			Gated on serviceHealthStore.initialized so it never flashes before the
+			breaker subscription is wired (store-init-gating, code-quality.md).
+		-->
+		<v-snackbar
+			v-if="serviceHealthStore.initialized"
+			:model-value="serviceHealthStore.isAnyServiceDegraded"
+			:timeout="-1"
+			color="warning"
+			location="top"
+			multi-line
+			role="status"
+			aria-live="polite"
+		>
+			<div class="d-flex align-center">
+				<v-icon class="mr-2"> mdi-alert </v-icon>
+				<div>{{ serviceHealthStore.degradedMessage }}</div>
+			</div>
+		</v-snackbar>
 	</div>
 </template>
 
@@ -149,6 +172,7 @@ import { useViewportLoading } from '../composables/useViewportLoading.js'
 import { useBuildingStore } from '../stores/buildingStore.js'
 import { useFeatureFlagStore } from '../stores/featureFlagStore'
 import { useGlobalStore } from '../stores/globalStore.js'
+import { useServiceHealthStore } from '../stores/serviceHealthStore.js'
 import { useToggleStore } from '../stores/toggleStore.js'
 import logger from '../utils/logger.js'
 
@@ -170,6 +194,7 @@ export default {
 		const toggleStore = useToggleStore()
 		const buildingStore = useBuildingStore()
 		const featureFlagStore = useFeatureFlagStore()
+		const serviceHealthStore = useServiceHealthStore()
 
 		const shouldShowBuildingInformation = computed(() => {
 			return store.showBuildingInfo && buildingStore.buildingFeatures && !store.isLoading
@@ -361,6 +386,7 @@ export default {
 			store,
 			toggleStore,
 			buildingStore,
+			serviceHealthStore,
 			viewer,
 			shouldShowBuildingInformation,
 			showMapClickLoadingOverlay,

--- a/src/pages/CesiumViewer.vue
+++ b/src/pages/CesiumViewer.vue
@@ -100,7 +100,7 @@
 		-->
 		<v-snackbar
 			v-if="serviceHealthStore.initialized"
-			:model-value="serviceHealthStore.isAnyServiceDegraded"
+			:model-value="serviceHealthStore.isHsyDegraded"
 			:timeout="-1"
 			color="warning"
 			location="top"

--- a/src/services/hostCircuitBreaker.js
+++ b/src/services/hostCircuitBreaker.js
@@ -1,0 +1,276 @@
+/**
+ * @module services/hostCircuitBreaker
+ *
+ * Per-host circuit breaker for HTTP fetches, a sibling to
+ * {@link module:services/hostConcurrencyLimiter}.
+ *
+ * Why: when an upstream is down (HSY's Azure App Gateway returning 504 for an
+ * entire session, or the service hard-down) every request independently pays
+ * the full per-attempt timeout plus retry/backoff penalty, holding a
+ * concurrency slot the whole time. The viewport loader's 3-per-host budget is
+ * exhausted by hung requests and the map stops filling — the user-reported
+ * "HSY down basically breaks the whole app". Retrying a service that is clearly
+ * down also just hammers it.
+ *
+ * The breaker tracks consecutive failures per host. After
+ * {@link FAILURE_THRESHOLD} it OPENS: subsequent {@link canRequest} calls
+ * return false (callers fast-fail without holding a slot) for
+ * {@link COOLDOWN_MS}. After the cooldown the breaker goes HALF-OPEN and lets
+ * one probe through; a success closes it, a failure re-opens it.
+ *
+ * Host keying matches the concurrency limiter exactly (see
+ * {@link extractHostKey}), so a degraded `pygeoapi` proxy prefix or a degraded
+ * `kartta.hsy.fi` hostname is tracked as one breaker each.
+ *
+ * State changes are broadcast to subscribers via {@link onBreakerChange} so the
+ * UI (serviceHealthStore) can surface a non-blocking "layers unavailable"
+ * notice and clear it on recovery.
+ */
+
+import { TIMING } from '../constants/timing.js'
+import logger from '../utils/logger.js'
+import { extractHostKey } from './hostConcurrencyLimiter.js'
+
+/** Consecutive failures before the breaker opens. */
+export const FAILURE_THRESHOLD = TIMING.CIRCUIT_BREAKER_FAILURE_THRESHOLD
+
+/** How long the breaker stays open before allowing a half-open probe. */
+export const COOLDOWN_MS = TIMING.CIRCUIT_BREAKER_COOLDOWN_MS
+
+/** @type {{ failureThreshold: number, cooldownMs: number }} */
+const config = {
+	failureThreshold: FAILURE_THRESHOLD,
+	cooldownMs: COOLDOWN_MS,
+}
+
+/**
+ * @typedef {'closed' | 'open' | 'half-open'} BreakerState
+ */
+
+/**
+ * @typedef {Object} BreakerChangeEvent
+ * @property {string} hostKey
+ * @property {BreakerState} state
+ */
+
+/**
+ * Per-host breaker records.
+ * @type {Map<string, { state: BreakerState, failures: number, openedAt: number }>}
+ */
+const breakers = new Map()
+
+/** @type {Set<(event: BreakerChangeEvent) => void>} */
+const listeners = new Set()
+
+/**
+ * @param {string} hostKey
+ */
+function getBreaker(hostKey) {
+	let breaker = breakers.get(hostKey)
+	if (!breaker) {
+		breaker = { state: 'closed', failures: 0, openedAt: 0 }
+		breakers.set(hostKey, breaker)
+	}
+	return breaker
+}
+
+/**
+ * @param {BreakerChangeEvent} event
+ */
+function emit(event) {
+	for (const listener of listeners) {
+		try {
+			listener(event)
+		} catch (error) {
+			logger.error('[hostCircuitBreaker] listener threw:', error?.message || error)
+		}
+	}
+}
+
+/**
+ * Subscribe to breaker state transitions. Returns an unsubscribe function.
+ *
+ * @param {(event: BreakerChangeEvent) => void} listener
+ * @returns {() => void}
+ */
+export function onBreakerChange(listener) {
+	listeners.add(listener)
+	return () => {
+		listeners.delete(listener)
+	}
+}
+
+/**
+ * @param {string} hostKey
+ * @param {{ state: BreakerState, failures: number, openedAt: number }} breaker
+ */
+function open(hostKey, breaker) {
+	const wasOpen = breaker.state === 'open'
+	breaker.state = 'open'
+	breaker.openedAt = Date.now()
+	if (!wasOpen) {
+		logger.warn(
+			`[hostCircuitBreaker] OPEN for "${hostKey}" after ${breaker.failures} consecutive failures — fast-failing for ${config.cooldownMs}ms`
+		)
+		emit({ hostKey, state: 'open' })
+	}
+}
+
+/**
+ * @param {string} hostKey
+ * @param {{ state: BreakerState, failures: number, openedAt: number }} breaker
+ */
+function halfOpen(hostKey, breaker) {
+	if (breaker.state === 'half-open') return
+	breaker.state = 'half-open'
+	logger.info(`[hostCircuitBreaker] half-open probe window for "${hostKey}"`)
+	emit({ hostKey, state: 'half-open' })
+}
+
+/**
+ * @param {string} hostKey
+ * @param {{ state: BreakerState, failures: number, openedAt: number }} breaker
+ */
+function close(hostKey, breaker) {
+	const wasDegraded = breaker.state !== 'closed'
+	breaker.state = 'closed'
+	breaker.failures = 0
+	breaker.openedAt = 0
+	if (wasDegraded) {
+		logger.info(`[hostCircuitBreaker] CLOSED (recovered) for "${hostKey}"`)
+		emit({ hostKey, state: 'closed' })
+	}
+}
+
+/**
+ * Whether a request to this URL's host is currently permitted.
+ *
+ * - closed / half-open → true
+ * - open and still in cooldown → false (caller should fast-fail)
+ * - open and past cooldown → transitions to half-open and allows one probe
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+export function canRequest(url) {
+	const hostKey = extractHostKey(url)
+	const breaker = getBreaker(hostKey)
+
+	if (breaker.state !== 'open') {
+		return true
+	}
+
+	if (Date.now() - breaker.openedAt >= config.cooldownMs) {
+		halfOpen(hostKey, breaker)
+		return true
+	}
+
+	return false
+}
+
+/**
+ * Record a successful request. Closes the breaker (clears degraded state).
+ *
+ * @param {string} url
+ */
+export function recordSuccess(url) {
+	const hostKey = extractHostKey(url)
+	const breaker = getBreaker(hostKey)
+	close(hostKey, breaker)
+}
+
+/**
+ * Record a failed request (timeout, network error, or retriable 5xx/429).
+ * Non-retriable 4xx responses are NOT outages and must not be recorded here.
+ *
+ * @param {string} url
+ */
+export function recordFailure(url) {
+	const hostKey = extractHostKey(url)
+	const breaker = getBreaker(hostKey)
+
+	// A failed half-open probe means the host is still down — re-open.
+	if (breaker.state === 'half-open') {
+		breaker.failures = Math.max(breaker.failures, config.failureThreshold)
+		open(hostKey, breaker)
+		return
+	}
+
+	// Already open: stay open (cooldown timer governs the next probe).
+	if (breaker.state === 'open') {
+		return
+	}
+
+	breaker.failures += 1
+	if (breaker.failures >= config.failureThreshold) {
+		open(hostKey, breaker)
+	}
+}
+
+/**
+ * Whether the host serving this URL is currently degraded (breaker open).
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+export function isHostDegraded(url) {
+	const breaker = breakers.get(extractHostKey(url))
+	return !!breaker && breaker.state === 'open'
+}
+
+/**
+ * Host keys whose breaker is currently open (degraded).
+ *
+ * @returns {string[]}
+ */
+export function getDegradedHostKeys() {
+	const out = []
+	for (const [hostKey, breaker] of breakers) {
+		if (breaker.state === 'open') out.push(hostKey)
+	}
+	return out
+}
+
+/**
+ * Snapshot of breaker state for debugging / telemetry.
+ *
+ * @returns {Record<string, { state: BreakerState, failures: number }>}
+ */
+export function inspectBreaker() {
+	/** @type {Record<string, { state: BreakerState, failures: number }>} */
+	const out = {}
+	for (const [hostKey, breaker] of breakers) {
+		out[hostKey] = { state: breaker.state, failures: breaker.failures }
+	}
+	return out
+}
+
+/**
+ * Override breaker thresholds (mainly for tests and per-host tuning).
+ *
+ * @param {{ failureThreshold?: number, cooldownMs?: number }} overrides
+ */
+export function setBreakerConfig(overrides = {}) {
+	if (overrides.failureThreshold != null) {
+		if (!Number.isFinite(overrides.failureThreshold) || overrides.failureThreshold < 1) {
+			throw new Error('failureThreshold must be ≥ 1')
+		}
+		config.failureThreshold = Math.floor(overrides.failureThreshold)
+	}
+	if (overrides.cooldownMs != null) {
+		if (!Number.isFinite(overrides.cooldownMs) || overrides.cooldownMs < 0) {
+			throw new Error('cooldownMs must be ≥ 0')
+		}
+		config.cooldownMs = overrides.cooldownMs
+	}
+}
+
+/**
+ * Reset all breaker state and config. Intended for tests.
+ */
+export function __resetForTests() {
+	breakers.clear()
+	listeners.clear()
+	config.failureThreshold = FAILURE_THRESHOLD
+	config.cooldownMs = COOLDOWN_MS
+}

--- a/src/services/landcover.js
+++ b/src/services/landcover.js
@@ -144,7 +144,7 @@ export const removeLandcover = () => {
 					layer._removeErrorHandler()
 					layer._removeErrorHandler = undefined
 				}
-				if (store.cesiumViewer.imageryLayers.contains(layer)) {
+				if (store.cesiumViewer?.imageryLayers?.contains(layer)) {
 					store.cesiumViewer.imageryLayers.remove(layer)
 				}
 			})

--- a/src/services/landcover.js
+++ b/src/services/landcover.js
@@ -21,7 +21,17 @@ import { useBackgroundMapStore } from '../stores/backgroundMapStore.js'
 import { useGlobalStore } from '../stores/globalStore.js'
 import { useURLStore } from '../stores/urlStore.js'
 import logger from '../utils/logger.js'
+import { getGlobalWMSRetryHandler } from '../utils/wmsRetryHandler.js'
 import { getCesium } from './cesiumProvider.js'
+import { isHostDegraded, recordFailure } from './hostCircuitBreaker.js'
+
+/**
+ * Imagery layer augmented with a stored error-listener remover so
+ * {@link removeLandcover} can detach the provider's error listener (preventing
+ * a listener leak across toggles).
+ * @typedef {Object} TrackedImageryLayer
+ * @property {() => void} [_removeErrorHandler]
+ */
 
 /**
  * Creates and adds HSY landcover WMS imagery layer to the Cesium viewer
@@ -73,10 +83,37 @@ export const createHSYImageryLayer = async (newLayers) => {
 		tilingScheme: new Cesium.GeographicTilingScheme(),
 	})
 
+	// HSY-outage resilience: bound and quiet the imagery layer's tile errors.
+	// When HSY's WMS gateway returns 504 (or is down), Cesium would otherwise
+	// error-storm with retries against a hung upstream — the layer renders
+	// nothing and the hung requests starve the connection pool. We:
+	//   1. feed each tile error to the shared WMS retry handler (bounded
+	//      exponential backoff, capped retry count), and
+	//   2. once the per-host circuit breaker has opened for the HSY proxy,
+	//      stop retrying entirely (error.retry stays false) so failed tiles
+	//      degrade quietly — the base map and the rest of the app keep working.
+	// Each tile error is also recorded into the breaker so it opens (and the
+	// user-facing "layers unavailable" notice fires) under a sustained outage.
+	const retryHandler = getGlobalWMSRetryHandler()
+	const proxyUrl = urlStore.wmsProxy
+	const errorHandler = (error) => {
+		recordFailure(proxyUrl)
+		if (isHostDegraded(proxyUrl)) {
+			// Breaker open — degrade quietly instead of retrying into the hang.
+			error.retry = false
+			return
+		}
+		retryHandler.handleTileError(error, 'HSY-landcover')
+	}
+	const removeErrorListener = provider.errorEvent.addEventListener(errorHandler)
+
 	// Cesium 1.104+ removed ImageryProvider.readyPromise/ready — WebMapServiceImageryProvider
 	// is usable immediately after construction, so no await is needed here.
 	// Add the new layer and update store
-	const addedLayer = store.cesiumViewer.imageryLayers.addImageryProvider(provider)
+	const addedLayer = /** @type {TrackedImageryLayer} */ (
+		store.cesiumViewer.imageryLayers.addImageryProvider(provider)
+	)
+	addedLayer._removeErrorHandler = removeErrorListener
 	backgroundMapStore.landcoverLayers.push(addedLayer)
 }
 
@@ -101,6 +138,12 @@ export const removeLandcover = () => {
 		) {
 			// Remove each layer from the viewer
 			backgroundMapStore.landcoverLayers.forEach((layer) => {
+				// Detach the WMS error listener first to avoid a listener leak
+				// across landcover toggles (see createHSYImageryLayer).
+				if (typeof layer?._removeErrorHandler === 'function') {
+					layer._removeErrorHandler()
+					layer._removeErrorHandler = undefined
+				}
 				if (store.cesiumViewer.imageryLayers.contains(layer)) {
 					store.cesiumViewer.imageryLayers.remove(layer)
 				}

--- a/src/services/unifiedLoader.js
+++ b/src/services/unifiedLoader.js
@@ -35,9 +35,15 @@
  * @see {@link module:stores/loadingStore}
  */
 
+import { TIMING } from '../constants/timing.js'
 import { useLoadingStore } from '../stores/loadingStore.js'
 import { requestIdle } from '../utils/idle.js'
 import cacheService from './cacheService.js'
+import {
+	canRequest as breakerCanRequest,
+	recordFailure as breakerRecordFailure,
+	recordSuccess as breakerRecordSuccess,
+} from './hostCircuitBreaker.js'
 import { acquireHostSlot } from './hostConcurrencyLimiter.js'
 import progressiveLoader from './progressiveLoader.js'
 
@@ -456,7 +462,7 @@ class UnifiedLoader {
 	}
 
 	/**
-	 * Fetch with automatic retry logic.
+	 * Fetch with automatic retry logic and outage resilience.
 	 *
 	 * Retry Strategy:
 	 * - Honors Retry-After header on 429/503 (seconds or HTTP-date)
@@ -465,6 +471,16 @@ class UnifiedLoader {
 	 *   doesn't pin a tab for minutes
 	 * - Skips retry entirely on non-retriable 4xx (anything except 408/429)
 	 * - Respects AbortController signal
+	 *
+	 * Outage resilience (HSY flakiness / down):
+	 * - Bounds each attempt with a {@link TIMING.FETCH_TIMEOUT_MS} timeout so a
+	 *   hung upstream (HSY's Azure App Gateway holds ~20s before a 504) cannot
+	 *   pin a hostConcurrencyLimiter slot for the full gateway timeout. On
+	 *   timeout the attempt aborts and is treated as a retriable failure.
+	 * - A per-host circuit breaker fast-fails when a host has had too many
+	 *   consecutive failures, so the app stops hammering a service that is
+	 *   clearly down and frees concurrency slots immediately. The breaker also
+	 *   drives the user-facing "layers unavailable" notice.
 	 *
 	 * @param {string} url - Request URL
 	 * @param {Object} [options={}] - Fetch options (including signal)
@@ -509,9 +525,50 @@ class UnifiedLoader {
 				)
 			)
 
+		// Run a single fetch bounded by FETCH_TIMEOUT_MS, while still honoring
+		// the caller's AbortSignal. Returns { response } on completion or
+		// { timedOut: true } when our own timeout fired (a retriable failure).
+		// A caller-driven abort propagates as a thrown AbortError.
+		/** @returns {Promise<{ response?: Response, timedOut?: boolean }>} */
+		const fetchWithTimeout = async () => {
+			const attemptController = new AbortController()
+			let timedOut = false
+			const onCallerAbort = () => attemptController.abort(options.signal?.reason)
+			if (options.signal) {
+				if (options.signal.aborted) {
+					throw options.signal.reason ?? new DOMException('Aborted', 'AbortError')
+				}
+				options.signal.addEventListener('abort', onCallerAbort, { once: true })
+			}
+			const timer = setTimeout(() => {
+				timedOut = true
+				attemptController.abort()
+			}, TIMING.FETCH_TIMEOUT_MS)
+			try {
+				const response = await fetch(url, { ...options, signal: attemptController.signal })
+				return { response }
+			} catch (error) {
+				if (timedOut) {
+					return { timedOut: true }
+				}
+				throw error
+			} finally {
+				clearTimeout(timer)
+				options.signal?.removeEventListener('abort', onCallerAbort)
+			}
+		}
+
 		let lastError
 
 		for (let attempt = 0; attempt <= retries; attempt++) {
+			// Circuit breaker: if this host is degraded, fast-fail without
+			// acquiring a slot or hitting the network. Frees concurrency
+			// immediately and stops hammering a down service.
+			if (!breakerCanRequest(url)) {
+				lastError = new Error(`Circuit open: host for ${url} is degraded`)
+				break
+			}
+
 			// Per-host concurrency gate. Throws AbortError if signal fires
 			// while we're queued.
 			let releaseSlot
@@ -525,13 +582,46 @@ class UnifiedLoader {
 			// Whatever happens in this attempt, release the slot before
 			// sleeping/returning/throwing so other waiters can proceed.
 			try {
-				const response = await fetch(url, options)
+				const { response, timedOut } = await fetchWithTimeout()
 
-				if (response.ok) return response
+				// `!response` is a defensive guard (and narrows `response` to
+				// defined for the rest of the block); `timedOut` is the real
+				// signal that our per-attempt timeout fired.
+				if (timedOut || !response) {
+					// Our own timeout fired — treat like a retriable failure.
+					breakerRecordFailure(url)
+					lastError = new Error(`Fetch timed out after ${TIMING.FETCH_TIMEOUT_MS}ms`)
+					if (attempt >= retries) break
+					const expBackoff = 2 ** attempt * 1000
+					const jitter = 0.5 + Math.random()
+					const delay = Math.min(MAX_RETRY_DELAY_MS, Math.round(expBackoff * jitter))
+					logger.warn(`Fetch attempt ${attempt + 1} timed out, retrying in ${delay}ms...`)
+					releaseSlot()
+					releaseSlot = null
+					await sleep(delay)
+					continue
+				}
+
+				if (response.ok) {
+					breakerRecordSuccess(url)
+					return response
+				}
 
 				const status = response.status
-				if (!isRetriableStatus(status) || attempt >= retries || options.signal?.aborted) {
-					throw new Error(`HTTP ${status}: ${response.statusText}`)
+				const retriable = isRetriableStatus(status)
+
+				// Record outage signal only for retriable (server/limit) failures;
+				// a non-retriable 4xx is a client error, not a host outage.
+				if (retriable) {
+					breakerRecordFailure(url)
+				}
+
+				// Terminal for this response — set lastError and break out rather
+				// than throwing into the local catch (which is for genuine
+				// network/timeout exceptions and would double-count the failure).
+				lastError = new Error(`HTTP ${status}: ${response.statusText}`)
+				if (!retriable || attempt >= retries || options.signal?.aborted) {
+					break
 				}
 
 				const retryAfterMs = parseRetryAfter(response.headers.get('Retry-After'))
@@ -544,12 +634,18 @@ class UnifiedLoader {
 					`Fetch attempt ${attempt + 1} got HTTP ${status}, retrying in ${delay}ms` +
 						(retryAfterMs != null ? ' (server Retry-After)' : '')
 				)
-				lastError = new Error(`HTTP ${status}: ${response.statusText}`)
+				// lastError already set above before the retriable break-check.
 				releaseSlot()
 				releaseSlot = null
 				await sleep(delay)
 			} catch (error) {
 				lastError = error
+
+				// A caller-driven cancel is not a host outage — don't penalize
+				// the breaker for it. A network/DNS error is.
+				if (!options.signal?.aborted) {
+					breakerRecordFailure(url)
+				}
 
 				if (attempt < retries && !options.signal?.aborted) {
 					const expBackoff = 2 ** attempt * 1000

--- a/src/stores/serviceHealthStore.js
+++ b/src/stores/serviceHealthStore.js
@@ -49,9 +49,15 @@ export const useServiceHealthStore = defineStore('serviceHealth', {
 		/** Specifically an HSY map-data host is degraded. */
 		isHsyDegraded: (state) => state.degradedHostKeys.some((key) => HSY_HOST_KEYS.has(key)),
 
-		/** User-facing notice text, or '' when healthy. */
+		/**
+		 * User-facing notice text, or '' when healthy. The message is
+		 * HSY-specific, so only emit it when an HSY map-data host is degraded —
+		 * a non-HSY host (digitransit, paavo, …) tripping its breaker must not
+		 * surface a misleading "HSY map layers unavailable" warning.
+		 */
 		degradedMessage: (state) => {
-			if (state.degradedHostKeys.length === 0) return ''
+			const isHsyDegraded = state.degradedHostKeys.some((key) => HSY_HOST_KEYS.has(key))
+			if (!isHsyDegraded) return ''
 			return 'HSY map layers are temporarily unavailable. The rest of the app keeps working; retrying automatically…'
 		},
 	},

--- a/src/stores/serviceHealthStore.js
+++ b/src/stores/serviceHealthStore.js
@@ -1,0 +1,91 @@
+/**
+ * @module stores/serviceHealthStore
+ *
+ * Surfaces upstream service degradation (driven by the per-host circuit
+ * breaker) to the UI as a non-blocking notice. When the breaker for an HSY
+ * map-data host opens, this store flips `isAnyServiceDegraded` true so a
+ * snackbar can tell the user "HSY map layers temporarily unavailable"; when the
+ * breaker recovers (half-open probe succeeds, or cooldown elapses) the notice
+ * clears automatically.
+ *
+ * Follows the store-init-gating pattern (see code-quality.md): components gate
+ * the notice on BOTH `initialized` AND the degraded flag so nothing flashes
+ * before `init()` has wired up the breaker subscription.
+ *
+ * @see {@link module:services/hostCircuitBreaker}
+ */
+
+import { defineStore } from 'pinia'
+import { getDegradedHostKeys, onBreakerChange } from '../services/hostCircuitBreaker.js'
+import logger from '../utils/logger.js'
+
+/**
+ * Host keys (as produced by extractHostKey) that map to HSY map data. The HSY
+ * landcover WMS proxies under `/wms/proxy` (key `wms`); HSY building tiles come
+ * from pygeoapi (`pygeoapi` / `pygeoapi.dataportal.fi`); legacy direct hosts.
+ */
+const HSY_HOST_KEYS = new Set([
+	'wms',
+	'pygeoapi',
+	'pygeoapi.dataportal.fi',
+	'hsy-action',
+	'kartta.hsy.fi',
+])
+
+export const useServiceHealthStore = defineStore('serviceHealth', {
+	state: () => ({
+		/** Flipped true once init() has subscribed to breaker events. */
+		initialized: false,
+		/** @type {string[]} Host keys whose circuit breaker is currently open. */
+		degradedHostKeys: [],
+		/** @type {(() => void)|null} Breaker unsubscribe handle. */
+		_unsubscribe: null,
+	}),
+
+	getters: {
+		/** Any upstream host is currently degraded. */
+		isAnyServiceDegraded: (state) => state.degradedHostKeys.length > 0,
+
+		/** Specifically an HSY map-data host is degraded. */
+		isHsyDegraded: (state) => state.degradedHostKeys.some((key) => HSY_HOST_KEYS.has(key)),
+
+		/** User-facing notice text, or '' when healthy. */
+		degradedMessage: (state) => {
+			if (state.degradedHostKeys.length === 0) return ''
+			return 'HSY map layers are temporarily unavailable. The rest of the app keeps working; retrying automatically…'
+		},
+	},
+
+	actions: {
+		/**
+		 * Wire up the breaker subscription. Idempotent — safe to call once on
+		 * app mount. Reads current degraded state immediately so a breaker that
+		 * opened before mount is reflected.
+		 */
+		init() {
+			if (this._unsubscribe) return
+			this.refresh()
+			this._unsubscribe = onBreakerChange(() => this.refresh())
+			this.initialized = true
+			logger.debug('[serviceHealthStore] initialized')
+		},
+
+		/** Recompute degraded host list from the breaker. */
+		refresh() {
+			this.degradedHostKeys = getDegradedHostKeys()
+		},
+
+		/**
+		 * Tear down the subscription. Call on app unmount / in test cleanup to
+		 * avoid leaking a listener into the module-level breaker registry.
+		 */
+		teardown() {
+			if (this._unsubscribe) {
+				this._unsubscribe()
+				this._unsubscribe = null
+			}
+			this.initialized = false
+			this.degradedHostKeys = []
+		},
+	},
+})

--- a/tests/unit/services/hostCircuitBreaker.test.js
+++ b/tests/unit/services/hostCircuitBreaker.test.js
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for hostCircuitBreaker.
+ *
+ * Tags: @unit
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+	__resetForTests,
+	canRequest,
+	getDegradedHostKeys,
+	inspectBreaker,
+	isHostDegraded,
+	onBreakerChange,
+	recordFailure,
+	recordSuccess,
+	setBreakerConfig,
+} from '../../../src/services/hostCircuitBreaker.js'
+
+const URL_A = 'https://kartta.hsy.fi/geoserver/wms'
+const URL_B = '/pygeoapi/collections/foo'
+
+describe('hostCircuitBreaker', () => {
+	beforeEach(() => {
+		__resetForTests()
+		// Small threshold + cooldown so tests are fast and explicit.
+		setBreakerConfig({ failureThreshold: 3, cooldownMs: 1000 })
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+		__resetForTests()
+	})
+
+	it('stays closed and permits requests below the failure threshold', () => {
+		recordFailure(URL_A)
+		recordFailure(URL_A)
+		expect(canRequest(URL_A)).toBe(true)
+		expect(isHostDegraded(URL_A)).toBe(false)
+		expect(inspectBreaker()['kartta.hsy.fi']).toEqual({ state: 'closed', failures: 2 })
+	})
+
+	it('opens after N consecutive failures and fast-fails subsequent requests', () => {
+		recordFailure(URL_A)
+		recordFailure(URL_A)
+		recordFailure(URL_A) // threshold reached
+
+		expect(isHostDegraded(URL_A)).toBe(true)
+		expect(canRequest(URL_A)).toBe(false)
+		expect(getDegradedHostKeys()).toEqual(['kartta.hsy.fi'])
+	})
+
+	it('isolates breakers per host', () => {
+		recordFailure(URL_A)
+		recordFailure(URL_A)
+		recordFailure(URL_A) // opens A only
+
+		expect(isHostDegraded(URL_A)).toBe(true)
+		expect(isHostDegraded(URL_B)).toBe(false)
+		expect(canRequest(URL_B)).toBe(true)
+	})
+
+	it('a success resets the consecutive-failure count (no premature open)', () => {
+		recordFailure(URL_A)
+		recordFailure(URL_A)
+		recordSuccess(URL_A) // resets to closed/0
+		recordFailure(URL_A)
+		recordFailure(URL_A)
+
+		expect(canRequest(URL_A)).toBe(true) // only 2 since reset
+		expect(isHostDegraded(URL_A)).toBe(false)
+	})
+
+	it('transitions to half-open after the cooldown and recovers on a successful probe', () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(0)
+
+		recordFailure(URL_A)
+		recordFailure(URL_A)
+		recordFailure(URL_A) // open at t=0
+
+		expect(canRequest(URL_A)).toBe(false)
+
+		// Still within cooldown.
+		vi.setSystemTime(500)
+		expect(canRequest(URL_A)).toBe(false)
+
+		// Past cooldown → half-open, one probe allowed.
+		vi.setSystemTime(1500)
+		expect(canRequest(URL_A)).toBe(true)
+		expect(getDegradedHostKeys()).toEqual([]) // half-open is not "degraded"
+
+		// Probe succeeds → fully closed.
+		recordSuccess(URL_A)
+		expect(inspectBreaker()['kartta.hsy.fi']).toEqual({ state: 'closed', failures: 0 })
+	})
+
+	it('re-opens immediately if the half-open probe fails', () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(0)
+
+		recordFailure(URL_A)
+		recordFailure(URL_A)
+		recordFailure(URL_A) // open
+
+		vi.setSystemTime(2000) // past cooldown
+		expect(canRequest(URL_A)).toBe(true) // half-open probe
+
+		recordFailure(URL_A) // probe fails
+		expect(isHostDegraded(URL_A)).toBe(true)
+		expect(canRequest(URL_A)).toBe(false) // back in cooldown
+	})
+
+	it('emits open and recovered (closed) transitions to subscribers', () => {
+		const events = []
+		const unsubscribe = onBreakerChange((e) => events.push(e))
+
+		recordFailure(URL_A)
+		recordFailure(URL_A)
+		recordFailure(URL_A) // open
+		recordSuccess(URL_A) // closed (recovered)
+
+		expect(events).toEqual([
+			{ hostKey: 'kartta.hsy.fi', state: 'open' },
+			{ hostKey: 'kartta.hsy.fi', state: 'closed' },
+		])
+
+		unsubscribe()
+		recordFailure(URL_A)
+		recordFailure(URL_A)
+		recordFailure(URL_A)
+		expect(events).toHaveLength(2) // no further events after unsubscribe
+	})
+
+	it('does not emit a duplicate open event while already open', () => {
+		const events = []
+		onBreakerChange((e) => events.push(e))
+
+		recordFailure(URL_A)
+		recordFailure(URL_A)
+		recordFailure(URL_A) // open (1 event)
+		recordFailure(URL_A) // still open, no new event
+
+		expect(events.filter((e) => e.state === 'open')).toHaveLength(1)
+	})
+})

--- a/tests/unit/services/landcover.test.js
+++ b/tests/unit/services/landcover.test.js
@@ -4,6 +4,9 @@ import { createHSYImageryLayer, removeLandcover } from '@/services/landcover.js'
 import { useBackgroundMapStore } from '@/stores/backgroundMapStore.js'
 import { useGlobalStore } from '@/stores/globalStore.js'
 
+// Shared spy for the error-listener remover returned by errorEvent.addEventListener.
+const removeErrorListenerSpy = vi.fn()
+
 // Create Cesium mock to be used by cesiumProvider
 const WebMapServiceImageryProviderMock = vi.fn(function (options) {
 	this.url = options.url
@@ -14,6 +17,11 @@ const WebMapServiceImageryProviderMock = vi.fn(function (options) {
 	this.maximumLevel = options.maximumLevel
 	this.tilingScheme = options.tilingScheme
 	this.readyPromise = Promise.resolve(true)
+	// Real WebMapServiceImageryProvider always exposes errorEvent; the HSY
+	// outage-resilience handler attaches to it.
+	this.errorEvent = {
+		addEventListener: vi.fn(() => removeErrorListenerSpy),
+	}
 })
 
 const GeographicTilingSchemeMock = vi.fn(function () {
@@ -144,6 +152,17 @@ describe('Landcover Service', () => {
 			)
 		})
 
+		it('attaches a tile error handler for HSY-outage resilience', async () => {
+			await createHSYImageryLayer()
+
+			const providerInstance = WebMapServiceImageryProviderMock.mock.instances[0]
+			expect(providerInstance.errorEvent.addEventListener).toHaveBeenCalledTimes(1)
+
+			// The added layer carries a remover so removeLandcover can detach it.
+			const addedLayer = mockBackgroundStore.landcoverLayers[0]
+			expect(typeof addedLayer._removeErrorHandler).toBe('function')
+		})
+
 		describe('performance configuration', () => {
 			it('should use 512x512 tiles to reduce request count', async () => {
 				await createHSYImageryLayer()
@@ -202,6 +221,16 @@ describe('Landcover Service', () => {
 			mockBackgroundStore.landcoverLayers = []
 
 			expect(() => removeLandcover()).not.toThrow()
+		})
+
+		it('detaches the tile error listener on removal (no listener leak)', async () => {
+			// Create a real layer so it carries the _removeErrorHandler remover.
+			await createHSYImageryLayer()
+			expect(removeErrorListenerSpy).not.toHaveBeenCalled()
+
+			removeLandcover()
+
+			expect(removeErrorListenerSpy).toHaveBeenCalledTimes(1)
 		})
 	})
 })

--- a/tests/unit/services/unifiedLoaderFetch.test.js
+++ b/tests/unit/services/unifiedLoaderFetch.test.js
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for unifiedLoader.fetchWithRetry — the HSY-outage-resilience
+ * behaviour: per-attempt timeout, circuit-breaker fast-fail, and which failure
+ * modes trip the breaker.
+ *
+ * Tags: @unit
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+	isHostDegraded,
+	__resetForTests as resetBreaker,
+	setBreakerConfig,
+} from '../../../src/services/hostCircuitBreaker.js'
+import { __resetForTests as resetLimiter } from '../../../src/services/hostConcurrencyLimiter.js'
+import unifiedLoader from '../../../src/services/unifiedLoader.js'
+
+const URL = 'https://kartta.hsy.fi/geoserver/wms?tile=1'
+
+/** A Response-like object for fetch mocks. */
+function makeResponse({ ok, status = 200, statusText = '', retryAfter = null }) {
+	return {
+		ok,
+		status,
+		statusText,
+		headers: { get: (name) => (name === 'Retry-After' ? retryAfter : null) },
+		json: async () => ({}),
+	}
+}
+
+describe('unifiedLoader.fetchWithRetry — outage resilience', () => {
+	beforeEach(() => {
+		resetBreaker()
+		resetLimiter()
+		// Threshold 1 so a single failed request opens the breaker, keeping the
+		// assertions about breaker integration direct.
+		setBreakerConfig({ failureThreshold: 1, cooldownMs: 1000 })
+		global.fetch = vi.fn()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+		resetBreaker()
+		resetLimiter()
+		vi.restoreAllMocks()
+	})
+
+	it('returns the response on success and keeps the breaker closed', async () => {
+		global.fetch.mockResolvedValue(makeResponse({ ok: true, status: 200 }))
+
+		const res = await unifiedLoader.fetchWithRetry(URL, {}, 0)
+
+		expect(res.ok).toBe(true)
+		expect(isHostDegraded(URL)).toBe(false)
+		expect(global.fetch).toHaveBeenCalledTimes(1)
+	})
+
+	it('records a failure and trips the breaker on a retriable 504', async () => {
+		global.fetch.mockResolvedValue(
+			makeResponse({ ok: false, status: 504, statusText: 'Gateway Timeout' })
+		)
+
+		await expect(unifiedLoader.fetchWithRetry(URL, {}, 0)).rejects.toThrow(/HTTP 504/)
+		expect(isHostDegraded(URL)).toBe(true) // threshold 1 → open
+	})
+
+	it('records a failure on a network error', async () => {
+		global.fetch.mockRejectedValue(new Error('Network error'))
+
+		await expect(unifiedLoader.fetchWithRetry(URL, {}, 0)).rejects.toThrow(/Network error/)
+		expect(isHostDegraded(URL)).toBe(true)
+	})
+
+	it('does NOT trip the breaker on a non-retriable 404', async () => {
+		global.fetch.mockResolvedValue(
+			makeResponse({ ok: false, status: 404, statusText: 'Not Found' })
+		)
+
+		await expect(unifiedLoader.fetchWithRetry(URL, {}, 0)).rejects.toThrow(/HTTP 404/)
+		expect(isHostDegraded(URL)).toBe(false) // client error, not an outage
+	})
+
+	it('fast-fails without calling fetch when the breaker is already open', async () => {
+		// Open the breaker via one 504.
+		global.fetch.mockResolvedValueOnce(makeResponse({ ok: false, status: 504 }))
+		await expect(unifiedLoader.fetchWithRetry(URL, {}, 0)).rejects.toThrow(/HTTP 504/)
+		expect(isHostDegraded(URL)).toBe(true)
+
+		global.fetch.mockClear()
+		await expect(unifiedLoader.fetchWithRetry(URL, {}, 0)).rejects.toThrow(/Circuit open/)
+		expect(global.fetch).not.toHaveBeenCalled() // never hit the network
+	})
+
+	it('aborts a hung request via the per-attempt timeout and trips the breaker', async () => {
+		vi.useFakeTimers()
+
+		// Hung upstream: never resolves; rejects (AbortError) only when its
+		// signal is aborted — mirrors real fetch + Azure gateway hang.
+		global.fetch.mockImplementation(
+			(_url, opts) =>
+				new Promise((_resolve, reject) => {
+					opts.signal?.addEventListener('abort', () =>
+						reject(new DOMException('Aborted', 'AbortError'))
+					)
+				})
+		)
+
+		const promise = unifiedLoader.fetchWithRetry(URL, {}, 0)
+		const assertion = expect(promise).rejects.toThrow(/timed out/i)
+
+		// Advance past FETCH_TIMEOUT_MS (12s) to fire the attempt timeout.
+		await vi.advanceTimersByTimeAsync(12_000)
+
+		await assertion
+		expect(isHostDegraded(URL)).toBe(true)
+	})
+
+	it('does not penalise the breaker when the caller aborts', async () => {
+		const controller = new AbortController()
+		global.fetch.mockImplementation(
+			(_url, opts) =>
+				new Promise((_resolve, reject) => {
+					opts.signal?.addEventListener('abort', () =>
+						reject(new DOMException('Aborted', 'AbortError'))
+					)
+				})
+		)
+
+		const promise = unifiedLoader.fetchWithRetry(URL, { signal: controller.signal }, 0)
+		controller.abort()
+
+		await expect(promise).rejects.toThrow()
+		expect(isHostDegraded(URL)).toBe(false) // user cancel ≠ host outage
+	})
+})

--- a/tests/unit/stores/serviceHealthStore.test.js
+++ b/tests/unit/stores/serviceHealthStore.test.js
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for serviceHealthStore — the bridge from the per-host circuit
+ * breaker to the user-facing degradation notice.
+ *
+ * Tags: @unit
+ */
+
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+	__resetForTests,
+	recordFailure,
+	recordSuccess,
+	setBreakerConfig,
+} from '../../../src/services/hostCircuitBreaker.js'
+import { useServiceHealthStore } from '../../../src/stores/serviceHealthStore.js'
+
+const HSY_WMS_URL = '/wms/proxy/landcover'
+const PYGEOAPI_URL = '/pygeoapi/collections/buildings'
+
+describe('serviceHealthStore', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia())
+		__resetForTests()
+		setBreakerConfig({ failureThreshold: 2, cooldownMs: 1000 })
+	})
+
+	afterEach(() => {
+		const store = useServiceHealthStore()
+		store.teardown()
+		__resetForTests()
+	})
+
+	it('starts uninitialized and healthy', () => {
+		const store = useServiceHealthStore()
+		expect(store.initialized).toBe(false)
+		expect(store.isAnyServiceDegraded).toBe(false)
+		expect(store.degradedMessage).toBe('')
+	})
+
+	it('init() wires the breaker subscription and flips initialized', () => {
+		const store = useServiceHealthStore()
+		store.init()
+		expect(store.initialized).toBe(true)
+	})
+
+	it('reflects a degraded HSY host once the breaker opens', () => {
+		const store = useServiceHealthStore()
+		store.init()
+
+		recordFailure(HSY_WMS_URL)
+		recordFailure(HSY_WMS_URL) // opens (threshold 2)
+
+		expect(store.isAnyServiceDegraded).toBe(true)
+		expect(store.isHsyDegraded).toBe(true)
+		expect(store.degradedMessage).toMatch(/HSY map layers/i)
+		expect(store.degradedHostKeys).toContain('wms')
+	})
+
+	it('clears the notice when the breaker recovers', () => {
+		const store = useServiceHealthStore()
+		store.init()
+
+		recordFailure(PYGEOAPI_URL)
+		recordFailure(PYGEOAPI_URL) // open
+		expect(store.isAnyServiceDegraded).toBe(true)
+
+		recordSuccess(PYGEOAPI_URL) // recovered → closed
+		expect(store.isAnyServiceDegraded).toBe(false)
+		expect(store.degradedMessage).toBe('')
+	})
+
+	it('picks up a breaker that opened before init()', () => {
+		recordFailure(HSY_WMS_URL)
+		recordFailure(HSY_WMS_URL) // open before the store subscribes
+
+		const store = useServiceHealthStore()
+		store.init() // refresh() reads current degraded state
+		expect(store.isAnyServiceDegraded).toBe(true)
+	})
+
+	it('teardown() unsubscribes and stops tracking further changes', () => {
+		const store = useServiceHealthStore()
+		store.init()
+		store.teardown()
+
+		recordFailure(HSY_WMS_URL)
+		recordFailure(HSY_WMS_URL) // would open, but we are unsubscribed
+
+		expect(store.initialized).toBe(false)
+		expect(store.isAnyServiceDegraded).toBe(false)
+	})
+})

--- a/tests/unit/stores/serviceHealthStore.test.js
+++ b/tests/unit/stores/serviceHealthStore.test.js
@@ -17,6 +17,7 @@ import { useServiceHealthStore } from '../../../src/stores/serviceHealthStore.js
 
 const HSY_WMS_URL = '/wms/proxy/landcover'
 const PYGEOAPI_URL = '/pygeoapi/collections/buildings'
+const NON_HSY_URL = '/digitransit/routing'
 
 describe('serviceHealthStore', () => {
 	beforeEach(() => {
@@ -55,6 +56,19 @@ describe('serviceHealthStore', () => {
 		expect(store.isHsyDegraded).toBe(true)
 		expect(store.degradedMessage).toMatch(/HSY map layers/i)
 		expect(store.degradedHostKeys).toContain('wms')
+	})
+
+	it('does not surface the HSY notice for a degraded non-HSY host', () => {
+		const store = useServiceHealthStore()
+		store.init()
+
+		recordFailure(NON_HSY_URL)
+		recordFailure(NON_HSY_URL) // opens (threshold 2)
+
+		// A non-HSY host is degraded, but the message is HSY-specific.
+		expect(store.isAnyServiceDegraded).toBe(true)
+		expect(store.isHsyDegraded).toBe(false)
+		expect(store.degradedMessage).toBe('')
 	})
 
 	it('clears the notice when the breaker recovers', () => {


### PR DESCRIPTION
## Problem

> The HSY API is flaky and returns 504 when making too many requests instead of throttling gracefully. Occasionally the HSY API is completely down, and that basically breaks the whole app. It messes up testing and stakeholder demos.

WO-4 observed the HSY landcover WMS returning **504 (Azure App Gateway, ~20s timeouts) for an entire session**. This PR makes the **client** resilient so an HSY outage degrades to "layer unavailable" instead of stalling the whole app. (nginx-side stale-on-error tile caching is owned by a separate change — this PR does not touch `nginx/` or the `Dockerfile`.)

## Diagnosis — why HSY-down "breaks the whole app"

HSY-sourced client requests:
- **HSY landcover WMS imagery** — `landcover.js::createHSYImageryLayer` → `urlStore.wmsProxy` (`/wms/proxy` → HSY GeoServer), a 13-layer composite GetMap.
- **HSY building tiles** — `viewportBuildingLoader` → `urlStore.hsyGridBuildings` (pygeoapi), fetched through `unifiedLoader.fetchWithRetry`.
- Heat data and other layer fetches sharing the same `fetchWithRetry` path.

Concrete failure chains under a 504 / 20s hang:

| Failure mode | Old behavior | New behavior |
|---|---|---|
| **HSY landcover WMS 504 / hang** | `createHSYImageryLayer` built a Cesium `WebMapServiceImageryProvider` with **no `errorEvent` listener** (unlike `wms.js`). Failed tiles error-stormed with default retries; each request hung ~20s on the gateway, dozens at once — log spam + hung requests starving the connection pool, layer rendered nothing. | Error handler attached: bounded retries via the shared WMS retry handler; once the HSY proxy circuit breaker opens it **stops retrying** (`error.retry = false`) so tiles degrade quietly. Listener detached on `removeLandcover` (no leak across toggles). |
| **Building/data fetch to a hung HSY upstream** | `fetchWithRetry` had **no per-request timeout**. Each hung request held a `hostConcurrencyLimiter` slot (cap 3) for the full ~20s, then retried (3× with backoff). With 3 slots, the viewport **never filled** — the app looked frozen. | Each attempt is bounded by a **12s timeout** (well under the 20s gateway hang); on timeout it aborts, frees the slot, and is treated as a retriable failure. |
| **Repeated requests to a down HSY service** | Every request independently paid the full timeout + retry penalty against an obviously-dead service; nothing stopped the hammering. | A **per-host circuit breaker** opens after N consecutive failures and **fast-fails** for a cooldown (no slot held, no network hit), then half-opens to probe recovery. Non-retriable 4xx and caller-cancels do **not** trip it. |
| **User has no idea what's happening** | App appeared frozen/broken with no signal. | Non-blocking warning **snackbar**: "HSY map layers are temporarily unavailable… retrying automatically", shown while a breaker is open and **auto-clearing on recovery**. |

Navigation/init were never hard-`await`-blocked on HSY (tile loads are fire-and-forget with `.catch`, `updateViewport` is debounced + try/caught) — the breakage was **slot starvation + error storm + no signal**, which this PR addresses.

## Changes

**Resilience mechanism** (`fix(wms)`):
- `src/services/hostCircuitBreaker.js` — new per-host breaker (sibling to `hostConcurrencyLimiter`), keyed identically; closed → open → half-open with broadcast events.
- `src/services/unifiedLoader.js` — `fetchWithRetry` gains a per-attempt `FETCH_TIMEOUT_MS` timeout (honoring the caller's `AbortSignal`) and breaker integration (fast-fail when open; record success/failure; honor `Retry-After`, already present).
- `src/services/landcover.js` — HSY WMS imagery error handler + listener cleanup.
- `src/constants/timing.js` — `FETCH_TIMEOUT_MS`, breaker threshold/cooldown.

**User signal** (`fix(ui)`):
- `src/stores/serviceHealthStore.js` — subscribes to the breaker; exposes `initialized` + `isAnyServiceDegraded` + `degradedMessage`.
- `src/pages/CesiumViewer.vue` — non-blocking snackbar, gated on `initialized` (store-init-gating).
- `src/App.vue` — `init()` on mount, `teardown()` on unmount (listener cleanup).

Behavior is unchanged when HSY is healthy: the timeout only fires on a >12s hang, the breaker only opens after sustained failures, and the snackbar only appears while degraded.

## Verification

- New unit tests (vitest, simulated 504 / timeout / network error / recovery):
  - `tests/unit/services/hostCircuitBreaker.test.js` — open/half-open/close, per-host isolation, recovery, event emission.
  - `tests/unit/services/unifiedLoaderFetch.test.js` — success keeps breaker closed; 504/network trip it; 404 does **not**; fast-fail when open; per-attempt timeout abort; caller-cancel not penalized.
  - `tests/unit/stores/serviceHealthStore.test.js` — degraded notice on open, clears on recovery, picks up pre-init breaker state, teardown.
  - Extended `tests/unit/services/landcover.test.js` — error handler attached + detached on removal.
- Full unit suite green (**836 passed, 4 skipped**), `biome check` clean, `vue-tsc --noEmit` 0 errors, production build succeeds. No Playwright/E2E runs (per scope).

## Review fixes (Gemini, 400f41e)
- Scope the degradation notice to HSY hosts: `degradedMessage` and the snackbar now gate on `isHsyDegraded`, so a non-HSY host (digitransit/paavo) tripping its breaker no longer shows a misleading "HSY map layers unavailable" warning.
- `removeLandcover()` uses optional chaining on `cesiumViewer?.imageryLayers` to avoid a `TypeError` during teardown/hot-reload.
- Added a unit test locking in the empty message for a degraded non-HSY host (**837 unit tests** green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

