### PR TITLE
feat(renderer): deck.gl grid renderer spike behind r4c-deckgl-renderer flag

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,9 @@
     "": {
       "name": "r4c-cesium-viewer",
       "dependencies": {
+        "@deck.gl/core": "^9",
+        "@deck.gl/geo-layers": "^9",
+        "@deck.gl/layers": "^9",
         "@mdi/js": "^7.4.47",
         "@openfeature/go-feature-flag-web-provider": "^0.2.7",
         "@openfeature/web-sdk": "^1.7.2",
@@ -143,6 +146,16 @@
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
+    "@deck.gl/core": ["@deck.gl/core@9.3.3", "", { "dependencies": { "@loaders.gl/core": "^4.4.1", "@loaders.gl/images": "^4.4.1", "@luma.gl/core": "^9.3.3", "@luma.gl/engine": "^9.3.3", "@luma.gl/shadertools": "^9.3.3", "@luma.gl/webgl": "^9.3.3", "@math.gl/core": "^4.1.0", "@math.gl/sun": "^4.1.0", "@math.gl/types": "^4.1.0", "@math.gl/web-mercator": "^4.1.0", "@probe.gl/env": "^4.1.1", "@probe.gl/log": "^4.1.1", "@probe.gl/stats": "^4.1.1", "@types/offscreencanvas": "^2019.6.4", "gl-matrix": "^3.0.0", "mjolnir.js": "^3.0.0" } }, "sha512-P8IPB0VJyyKBGEUC6wT2sfqNYY/IClzYIqi0iyHBunKTUKQNwiKhPasQLCEfb157KNoCdeZxjnohkyRYqbas+A=="],
+
+    "@deck.gl/extensions": ["@deck.gl/extensions@9.3.3", "", { "dependencies": { "@luma.gl/shadertools": "^9.3.3", "@luma.gl/webgl": "^9.3.3", "@math.gl/core": "^4.1.0" }, "peerDependencies": { "@deck.gl/core": "~9.3.0", "@luma.gl/core": "~9.3.3", "@luma.gl/engine": "~9.3.3" } }, "sha512-e47Lc0s4cEubBSx8oqINl9jtF0PK48vESBufJrojYaTg6SX2TI+ObCBZjyqLWvrJK/B6N9tVntacy/F6kazBWQ=="],
+
+    "@deck.gl/geo-layers": ["@deck.gl/geo-layers@9.3.3", "", { "dependencies": { "@loaders.gl/3d-tiles": "^4.4.1", "@loaders.gl/gis": "^4.4.1", "@loaders.gl/loader-utils": "^4.4.1", "@loaders.gl/mvt": "^4.4.1", "@loaders.gl/schema": "^4.4.1", "@loaders.gl/terrain": "^4.4.1", "@loaders.gl/tiles": "^4.4.1", "@loaders.gl/wms": "^4.4.1", "@luma.gl/gltf": "^9.3.3", "@luma.gl/shadertools": "^9.3.3", "@math.gl/core": "^4.1.0", "@math.gl/culling": "^4.1.0", "@math.gl/web-mercator": "^4.1.0", "@types/geojson": "^7946.0.8", "a5-js": "^0.7.2", "h3-js": "^4.4.0", "long": "^3.2.0" }, "peerDependencies": { "@deck.gl/core": "~9.3.0", "@deck.gl/extensions": "~9.3.0", "@deck.gl/layers": "~9.3.0", "@deck.gl/mesh-layers": "~9.3.0", "@loaders.gl/core": "^4.4.1", "@luma.gl/core": "~9.3.3", "@luma.gl/engine": "~9.3.3" } }, "sha512-phwfFWzkPLZrlEyjR0NxRTwxAMInLr7kT2OcG2UTBT7P34MTCCR6VWr6QWrq6sSehMOhX2AdpTXUUH1gC1P77A=="],
+
+    "@deck.gl/layers": ["@deck.gl/layers@9.3.3", "", { "dependencies": { "@loaders.gl/images": "^4.4.1", "@loaders.gl/schema": "^4.4.1", "@luma.gl/shadertools": "^9.3.3", "@mapbox/tiny-sdf": "^2.0.5", "@math.gl/core": "^4.1.0", "@math.gl/polygon": "^4.1.0", "@math.gl/web-mercator": "^4.1.0", "earcut": "^2.2.4" }, "peerDependencies": { "@deck.gl/core": "~9.3.0", "@loaders.gl/core": "^4.4.1", "@luma.gl/core": "~9.3.3", "@luma.gl/engine": "~9.3.3" } }, "sha512-sp7rvAe/SM/Ja8sVKF0r5ZFj+W5y1h9HpmFZUGv+knkBhrwWLfxa6p3sycimdLMd22tCguw7ps4klKgZjgYTtw=="],
+
+    "@deck.gl/mesh-layers": ["@deck.gl/mesh-layers@9.3.3", "", { "dependencies": { "@loaders.gl/gltf": "^4.4.1", "@loaders.gl/schema": "^4.4.1", "@luma.gl/gltf": "^9.3.3", "@luma.gl/shadertools": "^9.3.3" }, "peerDependencies": { "@deck.gl/core": "~9.3.0", "@luma.gl/core": "~9.3.3", "@luma.gl/engine": "~9.3.3" } }, "sha512-XGS1w4kWHlchzcWBJ74zo/JJzk+/oro/+i7SS0p/O+1/q93k/M7tFykw2ApmG+DWEeCoFMA0+TT2Mdo/7fPF9g=="],
+
     "@emnapi/core": ["@emnapi/core@1.7.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
@@ -216,6 +229,80 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@loaders.gl/3d-tiles": ["@loaders.gl/3d-tiles@4.4.2", "", { "dependencies": { "@loaders.gl/compression": "4.4.2", "@loaders.gl/crypto": "4.4.2", "@loaders.gl/draco": "4.4.2", "@loaders.gl/gltf": "4.4.2", "@loaders.gl/images": "4.4.2", "@loaders.gl/loader-utils": "4.4.2", "@loaders.gl/math": "4.4.2", "@loaders.gl/tiles": "4.4.2", "@loaders.gl/zip": "4.4.2", "@math.gl/core": "^4.1.0", "@math.gl/culling": "^4.1.0", "@math.gl/geospatial": "^4.1.0", "@probe.gl/log": "^4.1.1", "long": "^5.2.1" }, "peerDependencies": { "@loaders.gl/core": "~4.4.0" } }, "sha512-rf2R7x/+t41hQpaQ3iKofooE6unZ0+sGlYUXBo7lYFEnoMmalzrOI6jCs+CV96TALMPQcpfPa566XWF74XkaBQ=="],
+
+    "@loaders.gl/compression": ["@loaders.gl/compression@4.4.2", "", { "dependencies": { "@loaders.gl/loader-utils": "4.4.2", "@loaders.gl/worker-utils": "4.4.2", "@types/pako": "^1.0.1", "fflate": "0.7.4", "pako": "1.0.11", "snappyjs": "^0.6.1" }, "optionalDependencies": { "@types/brotli": "^1.3.0", "brotli": "^1.3.2", "lz4js": "^0.2.0", "zstd-codec": "^0.1" }, "peerDependencies": { "@loaders.gl/core": "~4.4.0" } }, "sha512-/LzblCXn6wOg7ca2zkUOTO0zhjjaPAOqlLp4/kwd57v7KZU8M8aKUNlU1DAuWKW9p/+TpGsLKwDqOCO+hjrOnQ=="],
+
+    "@loaders.gl/core": ["@loaders.gl/core@4.4.2", "", { "dependencies": { "@loaders.gl/loader-utils": "4.4.2", "@loaders.gl/schema": "4.4.2", "@loaders.gl/schema-utils": "4.4.2", "@loaders.gl/worker-utils": "4.4.2", "@probe.gl/log": "^4.1.1" } }, "sha512-DZmsTwxdKh3q+mS1vSOW2EXFgwxZ4nIBte4H5g6e4VyQoQ6jAOkk0M6V+Asgy/eqjGTNjhfBA1HIkyBl0A9hcA=="],
+
+    "@loaders.gl/crypto": ["@loaders.gl/crypto@4.4.2", "", { "dependencies": { "@loaders.gl/loader-utils": "4.4.2", "@loaders.gl/worker-utils": "4.4.2", "@types/crypto-js": "^4.0.2" }, "peerDependencies": { "@loaders.gl/core": "~4.4.0" } }, "sha512-3QQxNFmCeznMIsY/ZD4pYO4SvS4i3nq5aJJ993DEIZVB1i0z19OmyJu4TSovvirXXrNWPQRJFPUUwdPxol9wLA=="],
+
+    "@loaders.gl/draco": ["@loaders.gl/draco@4.4.2", "", { "dependencies": { "@loaders.gl/loader-utils": "4.4.2", "@loaders.gl/schema": "4.4.2", "@loaders.gl/schema-utils": "4.4.2", "@loaders.gl/worker-utils": "4.4.2", "draco3d": "1.5.7" }, "peerDependencies": { "@loaders.gl/core": "~4.4.0" } }, "sha512-UByWIt/yhxMFBIlyoqJYaj0rnTz/wwDWbI4CVQc/MzbLZW7NtUkDyYDcjbjE2SBWpu6Ef4ryojGd/NWIA3Yknw=="],
+
+    "@loaders.gl/geoarrow": ["@loaders.gl/geoarrow@4.4.2", "", { "dependencies": { "@math.gl/polygon": "^4.1.0", "apache-arrow": ">= 17.0.0" }, "peerDependencies": { "@loaders.gl/core": "~4.4.0" } }, "sha512-FGCtUsvTwdxiNqS8cEtys1FdM/m6pwMzvNEa32sHfrI4Si465Oa2iJkyu2q/XMgL/vhfE/G3EezpVKZARbCzkw=="],
+
+    "@loaders.gl/gis": ["@loaders.gl/gis@4.4.2", "", { "dependencies": { "@loaders.gl/geoarrow": "4.4.2", "@loaders.gl/loader-utils": "4.4.2", "@loaders.gl/schema": "4.4.2", "@loaders.gl/schema-utils": "4.4.2", "@mapbox/vector-tile": "^1.3.1", "@math.gl/polygon": "^4.1.0", "pbf": "^3.2.1" }, "peerDependencies": { "@loaders.gl/core": "~4.4.0" } }, "sha512-VMs1XcqUCqLczfySsI9VA/L3WDuuNRPqVoHcXU3FZuSe49x++gtwmxF1TEhJCaQINk0CkCOnxBbKOz3I9M1e3w=="],
+
+    "@loaders.gl/gltf": ["@loaders.gl/gltf@4.4.2", "", { "dependencies": { "@loaders.gl/draco": "4.4.2", "@loaders.gl/images": "4.4.2", "@loaders.gl/loader-utils": "4.4.2", "@loaders.gl/schema": "4.4.2", "@loaders.gl/textures": "4.4.2", "@math.gl/core": "^4.1.0" }, "peerDependencies": { "@loaders.gl/core": "~4.4.0" } }, "sha512-aBvI7P/1GxePdHIvuyTM4A8yt3F5ph4dq0mkyJHmEjBl1Cwh3mDZJI1JSlZAFVilTZ6NxJZOiHUYWe1pBloVvw=="],
+
+    "@loaders.gl/images": ["@loaders.gl/images@4.4.2", "", { "dependencies": { "@loaders.gl/loader-utils": "4.4.2" }, "peerDependencies": { "@loaders.gl/core": "~4.4.0" } }, "sha512-b+1keNvPlyLniWtX4ZaThz2dF2aohi8Q+OEsDF2hJNZYyZJOqP9b/72UhlVk+inxTJfTLRBNARs2TJ2ssBlelg=="],
+
+    "@loaders.gl/loader-utils": ["@loaders.gl/loader-utils@4.4.2", "", { "dependencies": { "@loaders.gl/schema": "4.4.2", "@loaders.gl/worker-utils": "4.4.2", "@probe.gl/log": "^4.1.1", "@probe.gl/stats": "^4.1.1" } }, "sha512-kqwBbyRC7rrQVsnJyKeoaig9hxaa5oj91OKqWm27HPuVn4q2dD67SEhiG0ND62eRp0tLY6jTqEcI5kDzHBZ6MA=="],
+
+    "@loaders.gl/math": ["@loaders.gl/math@4.4.2", "", { "dependencies": { "@math.gl/core": "^4.1.0" }, "peerDependencies": { "@loaders.gl/core": "~4.4.0" } }, "sha512-Pcm1DKrzH3EqC5PkBxQX0oVjmXM3RIm2Gfj0cXQoqly+8c/NBtQrcBA9tl12h2ozZe8Ednue/kockbGsyKAx5A=="],
+
+    "@loaders.gl/mvt": ["@loaders.gl/mvt@4.4.2", "", { "dependencies": { "@loaders.gl/gis": "4.4.2", "@loaders.gl/images": "4.4.2", "@loaders.gl/loader-utils": "4.4.2", "@loaders.gl/schema": "4.4.2", "@math.gl/polygon": "^4.1.0", "@probe.gl/stats": "^4.1.1", "pbf": "^3.2.1" }, "peerDependencies": { "@loaders.gl/core": "~4.4.0" } }, "sha512-yji3TAUofTA3GXvvyemwfrRwbd1ILpv2qe4mRduHdzjJdy2httH1cCKkesavFuLeRQqEuVyhhxYK+aSAbdt9Kg=="],
+
+    "@loaders.gl/schema": ["@loaders.gl/schema@4.4.2", "", { "dependencies": { "@types/geojson": "^7946.0.7", "apache-arrow": ">= 17.0.0" } }, "sha512-mJTZehTHIFl8ed+03nebuPAMnLP8Yp00DKTzCnKT2HNy/uV4+Sw+GrGIuhPHGU8tdQmtBXRURGM2ZxUAxMfGKg=="],
+
+    "@loaders.gl/schema-utils": ["@loaders.gl/schema-utils@4.4.2", "", { "dependencies": { "@loaders.gl/schema": "4.4.2", "@types/geojson": "^7946.0.7", "apache-arrow": ">= 17.0.0" }, "peerDependencies": { "@loaders.gl/core": "~4.4.0" } }, "sha512-yYYRD/POBEO72rhIyLASrqKUUhfIOQuFk/fgInN6Td2qvFgsHbo5UaCM4sTqVUWwNxNvXDQi8ezpbnCa/yi+OQ=="],
+
+    "@loaders.gl/terrain": ["@loaders.gl/terrain@4.4.2", "", { "dependencies": { "@loaders.gl/images": "4.4.2", "@loaders.gl/loader-utils": "4.4.2", "@loaders.gl/schema": "4.4.2", "@mapbox/martini": "^0.2.0" }, "peerDependencies": { "@loaders.gl/core": "~4.4.0" } }, "sha512-ScE90mhUrIOOf+248+G8bxgg5xfLptE94gVxtYsLysyG8b4Ne2WEb6J2gpvQqmaLz3k9OqgPR7M8F1zI5BVO0w=="],
+
+    "@loaders.gl/textures": ["@loaders.gl/textures@4.4.2", "", { "dependencies": { "@loaders.gl/images": "4.4.2", "@loaders.gl/loader-utils": "4.4.2", "@loaders.gl/schema": "4.4.2", "@loaders.gl/worker-utils": "4.4.2", "@math.gl/types": "^4.1.0", "ktx-parse": "^0.7.0", "texture-compressor": "^1.0.2" }, "peerDependencies": { "@loaders.gl/core": "~4.4.0" } }, "sha512-+GKcHEE0GjpuSJ6qbuRsB0CaOSUhJ1epUvhMP5GVK7I6+bwSvG8nqmRRGXFQNmYsbFANwG+wjwKf16wqJwP6vg=="],
+
+    "@loaders.gl/tiles": ["@loaders.gl/tiles@4.4.2", "", { "dependencies": { "@loaders.gl/loader-utils": "4.4.2", "@loaders.gl/math": "4.4.2", "@math.gl/core": "^4.1.0", "@math.gl/culling": "^4.1.0", "@math.gl/geospatial": "^4.1.0", "@math.gl/web-mercator": "^4.1.0", "@probe.gl/stats": "^4.1.1" }, "peerDependencies": { "@loaders.gl/core": "~4.4.0" } }, "sha512-DHqMC38e6IEzWEDc15GfIKsZT82VZH7ocF79xLRScey0eZfCb3qI5nDLeg5adSBBsHkG3Li0S0PEnwxQmKT3qw=="],
+
+    "@loaders.gl/wms": ["@loaders.gl/wms@4.4.2", "", { "dependencies": { "@loaders.gl/images": "4.4.2", "@loaders.gl/loader-utils": "4.4.2", "@loaders.gl/schema": "4.4.2", "@loaders.gl/xml": "4.4.2", "@turf/rewind": "^5.1.5", "deep-strict-equal": "^0.2.0" }, "peerDependencies": { "@loaders.gl/core": "~4.4.0" } }, "sha512-7uhis6fOTHeqRLIU1EPoC1oqeXVk5p1pM136fSqMw0CbVSNj87b0FFMwlJwzwTfL8Vte8GyKrNcDa47PjaT19Q=="],
+
+    "@loaders.gl/worker-utils": ["@loaders.gl/worker-utils@4.4.2", "", { "peerDependencies": { "@loaders.gl/core": "~4.4.0" } }, "sha512-oiZ0SoC1QKrOkhYPlVZ6Q06CtmuFRyZw2rwzmT08ZyaGtOArIJHDjlhxzwWiv+6fdws47Ub5uIGsdI1Ab1xYsA=="],
+
+    "@loaders.gl/xml": ["@loaders.gl/xml@4.4.2", "", { "dependencies": { "@loaders.gl/loader-utils": "4.4.2", "@loaders.gl/schema": "4.4.2", "fast-xml-parser": "^5.3.6" }, "peerDependencies": { "@loaders.gl/core": "~4.4.0" } }, "sha512-OOPqpYH1PK9szuzXh3Oy7aErMXTXB+aiKi79LPCI93Wsb8pdbQiDiRRW8X/op9qABhxpCAMXF5N89eDJv3XdtQ=="],
+
+    "@loaders.gl/zip": ["@loaders.gl/zip@4.4.2", "", { "dependencies": { "@loaders.gl/compression": "4.4.2", "@loaders.gl/crypto": "4.4.2", "@loaders.gl/loader-utils": "4.4.2", "jszip": "^3.1.5", "md5": "^2.3.0" }, "peerDependencies": { "@loaders.gl/core": "~4.4.0" } }, "sha512-KdgmJRNra9+9jt2zzHUvFXnBqwzeN7dW4MEgTmH/NtraGy8bz5Tk5NrIUj8JXPxhx+vP2vxUWbeCEUoLGO/m9A=="],
+
+    "@luma.gl/core": ["@luma.gl/core@9.3.3", "", { "dependencies": { "@math.gl/types": "^4.1.0", "@probe.gl/env": "^4.1.1", "@probe.gl/log": "^4.1.1", "@probe.gl/stats": "^4.1.1", "@types/offscreencanvas": "^2019.7.3" } }, "sha512-jCFm2htvrVpcXIy85TBTF1ROgMfknKnfw2OH+Vydr41hiCFd6nqr79gM3f2uhaNkal0BghFNqF3qDioKiUWtew=="],
+
+    "@luma.gl/engine": ["@luma.gl/engine@9.3.3", "", { "dependencies": { "@math.gl/core": "^4.1.0", "@math.gl/types": "^4.1.0", "@probe.gl/log": "^4.1.1", "@probe.gl/stats": "^4.1.1" }, "peerDependencies": { "@luma.gl/core": "~9.3.0", "@luma.gl/shadertools": "~9.3.0" } }, "sha512-StmMTzUcUlpKMU3wvWU48A6OQyphptD9zVGBsSkK6iHIBdtBKlOcmqRkyfvRouo8JHtlrnoJDHLVKhxorwhGAg=="],
+
+    "@luma.gl/gltf": ["@luma.gl/gltf@9.3.3", "", { "dependencies": { "@loaders.gl/core": "~4.4.0", "@loaders.gl/gltf": "~4.4.0", "@loaders.gl/textures": "~4.4.0", "@math.gl/core": "^4.1.0" }, "peerDependencies": { "@luma.gl/core": "~9.3.0", "@luma.gl/engine": "~9.3.0", "@luma.gl/shadertools": "~9.3.0" } }, "sha512-/wty4PHYeQelXvDJesyuMdqtAfpL1XcyEQffcEAwKwu9w7JdkygSShdUwTT1iF7no0uGKuWgq824dVC9WBBQcw=="],
+
+    "@luma.gl/shadertools": ["@luma.gl/shadertools@9.3.3", "", { "dependencies": { "@math.gl/core": "^4.1.0", "@math.gl/types": "^4.1.0" }, "peerDependencies": { "@luma.gl/core": "~9.3.0" } }, "sha512-4ZfG4/Utix951vqyiG/JIx+Eg+GMNwOxgr/07/i0gf7bK1gJZIEQ5BxVcDw4MCQfdoVlGPGzl0cQKbdqBvaCAQ=="],
+
+    "@luma.gl/webgl": ["@luma.gl/webgl@9.3.3", "", { "dependencies": { "@math.gl/types": "^4.1.0", "@probe.gl/env": "^4.1.1" }, "peerDependencies": { "@luma.gl/core": "~9.3.0" } }, "sha512-X+aavdP5o6VFHSA0es9gKZTT145jfcFbhKJt/gwJrptnKNoIW4+Y37ZEpCo1AzAnr+FQCxjgcM2kOCpoWMfSVA=="],
+
+    "@mapbox/martini": ["@mapbox/martini@0.2.0", "", {}, "sha512-7hFhtkb0KTLEls+TRw/rWayq5EeHtTaErgm/NskVoXmtgAQu/9D299aeyj6mzAR/6XUnYRp2lU+4IcrYRFjVsQ=="],
+
+    "@mapbox/point-geometry": ["@mapbox/point-geometry@0.1.0", "", {}, "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="],
+
+    "@mapbox/tiny-sdf": ["@mapbox/tiny-sdf@2.2.0", "", {}, "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg=="],
+
+    "@mapbox/vector-tile": ["@mapbox/vector-tile@1.3.1", "", { "dependencies": { "@mapbox/point-geometry": "~0.1.0" } }, "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw=="],
+
+    "@math.gl/core": ["@math.gl/core@4.1.0", "", { "dependencies": { "@math.gl/types": "4.1.0" } }, "sha512-FrdHBCVG3QdrworwrUSzXIaK+/9OCRLscxI2OUy6sLOHyHgBMyfnEGs99/m3KNvs+95BsnQLWklVfpKfQzfwKA=="],
+
+    "@math.gl/culling": ["@math.gl/culling@4.1.0", "", { "dependencies": { "@math.gl/core": "4.1.0", "@math.gl/types": "4.1.0" } }, "sha512-jFmjFEACnP9kVl8qhZxFNhCyd47qPfSVmSvvjR0/dIL6R9oD5zhR1ub2gN16eKDO/UM7JF9OHKU3EBIfeR7gtg=="],
+
+    "@math.gl/geospatial": ["@math.gl/geospatial@4.1.0", "", { "dependencies": { "@math.gl/core": "4.1.0", "@math.gl/types": "4.1.0" } }, "sha512-BzsUhpVvnmleyYF6qdqJIip6FtIzJmnWuPTGhlBuPzh7VBHLonCFSPtQpbkRuoyAlbSyaGXcVt6p6lm9eK2vtg=="],
+
+    "@math.gl/polygon": ["@math.gl/polygon@4.1.0", "", { "dependencies": { "@math.gl/core": "4.1.0" } }, "sha512-YA/9PzaCRHbIP5/0E9uTYrqe+jsYTQoqoDWhf6/b0Ixz8bPZBaGDEafLg3z7ffBomZLacUty9U3TlPjqMtzPjA=="],
+
+    "@math.gl/sun": ["@math.gl/sun@4.1.0", "", {}, "sha512-i3q6OCBLSZ5wgZVhXg+X7gsjY/TUtuFW/2KBiq/U1ypLso3S4sEykoU/MGjxUv1xiiGtr+v8TeMbO1OBIh/HmA=="],
+
+    "@math.gl/types": ["@math.gl/types@4.1.0", "", {}, "sha512-clYZdHcmRvMzVK5fjeDkQlHUzXQSNdZ7s4xOqC3nJPgz4C/TZkUecTo9YS4PruZqtDda/ag4erndP0MIn40dGA=="],
+
+    "@math.gl/web-mercator": ["@math.gl/web-mercator@4.1.0", "", { "dependencies": { "@math.gl/core": "4.1.0" } }, "sha512-HZo3vO5GCMkXJThxRJ5/QYUYRr3XumfT8CzNNCwoJfinxy5NtKUd7dusNTXn7yJ40UoB8FMIwkVwNlqaiRZZAw=="],
 
     "@mdi/js": ["@mdi/js@7.4.47", "", {}, "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ=="],
 
@@ -353,6 +440,12 @@
 
     "@playwright/test": ["@playwright/test@1.57.0", "", { "dependencies": { "playwright": "1.57.0" }, "bin": { "playwright": "cli.js" } }, "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA=="],
 
+    "@probe.gl/env": ["@probe.gl/env@4.1.1", "", {}, "sha512-+68seNDMVsEegRB47pFA/Ws1Fjy8agcFYXxzorKToyPcD6zd+gZ5uhwoLd7TzsSw6Ydns//2KEszWn+EnNHTbA=="],
+
+    "@probe.gl/log": ["@probe.gl/log@4.1.1", "", { "dependencies": { "@probe.gl/env": "4.1.1" } }, "sha512-kcZs9BT44pL7hS1OkRGKYRXI/SN9KejUlPD+BY40DguRLzdC5tLG/28WGMyfKdn/51GT4a0p+0P8xvDn1Ez+Kg=="],
+
+    "@probe.gl/stats": ["@probe.gl/stats@4.1.1", "", {}, "sha512-4VpAyMHOqydSvPlEyHwXaE+AkIdR03nX+Qhlxsk2D/IW4OVmDZgIsvJB1cDzyEEtcfKcnaEbfXeiPgejBceT6g=="],
+
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.10", "", { "os": "android", "cpu": "arm64" }, "sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg=="],
 
     "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w=="],
@@ -488,6 +581,8 @@
     "@spz-loader/core": ["@spz-loader/core@0.3.1", "", {}, "sha512-8qJ1WIBXaJu8HjnJAjYniE0kYcr0kCe5Hp7kDzYiGVvvd7zyrOBwbF5imoW5mvwx1Qba0hxGEK5R9jEoaHKJFA=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+
+    "@swc/helpers": ["@swc/helpers@0.5.23", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw=="],
 
     "@turf/along": ["@turf/along@7.3.5", "", { "dependencies": { "@turf/bearing": "7.3.5", "@turf/destination": "7.3.5", "@turf/distance": "7.3.5", "@turf/helpers": "7.3.5", "@turf/invariant": "7.3.5", "@types/geojson": "^7946.0.10", "tslib": "^2.8.1" } }, "sha512-Ee4AHV9j2Bnlm/5nm4ChY7nkwpaaMffSez9nsJ9HcMbzG+GgTkt0F5pn9d02U7YvuWqckM5lfr3kBI+w2uTz+g=="],
 
@@ -725,7 +820,15 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/brotli": ["@types/brotli@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-9xoNr+bcxT236/7ZgcWw/6Pb2RRetE13p4bFy1xYSckKwyOiRfmInay8baUWZgH7/284Wl6IPe7+nOI9+OQg/A=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/command-line-args": ["@types/command-line-args@5.2.3", "", {}, "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw=="],
+
+    "@types/command-line-usage": ["@types/command-line-usage@5.0.4", "", {}, "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg=="],
+
+    "@types/crypto-js": ["@types/crypto-js@4.2.2", "", {}, "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ=="],
 
     "@types/d3-voronoi": ["@types/d3-voronoi@1.1.12", "", {}, "sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw=="],
 
@@ -740,6 +843,10 @@
     "@types/kdbush": ["@types/kdbush@3.0.5", "", {}, "sha512-tdJz7jaWFu4nR+8b2B+CdPZ6811ighYylWsu2hpsivapzW058yP0KdfZuNY89IiRe5jbKvBGXN3LQdN2KPXVdQ=="],
 
     "@types/node": ["@types/node@25.0.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-rl78HwuZlaDIUSeUKkmogkhebA+8K1Hy7tddZuJ3D0xV8pZSfsYGTsliGUol1JPzu9EKnTxPC4L1fiWouStRew=="],
+
+    "@types/offscreencanvas": ["@types/offscreencanvas@2019.7.3", "", {}, "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="],
+
+    "@types/pako": ["@types/pako@1.0.7", "", {}, "sha512-YBtzT2ztNF6R/9+UXj2wTGFnC9NklAnASt3sC0h2m1bbH7G6FyBIkt4AN8ThZpNfxUo1b2iMVO0UawiJymEt8A=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
@@ -801,6 +908,8 @@
 
     "@zip.js/zip.js": ["@zip.js/zip.js@2.8.11", "", {}, "sha512-0fztsk/0ryJ+2PPr9EyXS5/Co7OK8q3zY/xOoozEWaUsL5x+C0cyZ4YyMuUffOO2Dx/rAdq4JMPqW0VUtm+vzA=="],
 
+    "a5-js": ["a5-js@0.7.3", "", { "dependencies": { "gl-matrix": "^3.4.3" } }, "sha512-3aoMwHmNkyuMDHS4q6GRRInpOawamen2pokIbc0MQmR9cqG0Y9+B0bZpzswwetjrSG2ckbYtShH+nKru6+3O5Q=="],
+
     "abbrev": ["abbrev@2.0.0", "", {}, "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
@@ -815,9 +924,13 @@
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
+    "apache-arrow": ["apache-arrow@21.1.0", "", { "dependencies": { "@swc/helpers": "^0.5.11", "@types/command-line-args": "^5.2.3", "@types/command-line-usage": "^5.0.4", "@types/node": "^24.0.3", "command-line-args": "^6.0.1", "command-line-usage": "^7.0.1", "flatbuffers": "^25.1.24", "json-bignum": "^0.0.3", "tslib": "^2.6.2" }, "bin": { "arrow2csv": "bin/arrow2csv.js" } }, "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA=="],
+
     "arc": ["arc@0.2.0", "", {}, "sha512-8NFOo126uYKQJyXNSLY/jSklgfLQL+XWAcPXGo876JwEQ8nSOPXWNI3TV2jLZMN8QEw8uksJ1ZwS4npjBca8MA=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "array-back": ["array-back@6.2.3", "", {}, "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -830,6 +943,8 @@
     "axios": ["axios@1.16.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.6", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-v9BVVpOTLB59C9E7aSnmIF8h7qRsFpx+A2nugVMTszEOMcfjlZMsXRm4LF23I3Z9AJxc8ANpIvzbzONoX9VJlg=="],
 
@@ -847,7 +962,11 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
+    "brotli": ["brotli@1.3.3", "", { "dependencies": { "base64-js": "^1.1.2" } }, "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg=="],
+
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "buf-compare": ["buf-compare@1.0.1", "", {}, "sha512-Bvx4xH00qweepGc43xFvMs5BKASXTbHaHm6+kDYIK9p/4iFwjATQkmPKHQSgJZzKbAymhztRbXUf1Nqhzl73/Q=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -858,6 +977,12 @@
     "cesium": ["cesium@1.141.0", "", { "dependencies": { "@cesium/engine": "^25.0.0", "@cesium/widgets": "^15.0.0" } }, "sha512-bRwgABDjsXRqNLjeJAxSlCrWCTvAt/yWJD30fY5CbqtoEKR6g/YCOcJW37vk4w/Gq3uMW7sF1uP74ajRrktjEw=="],
 
     "chai": ["chai@6.2.1", "", {}, "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "chalk-template": ["chalk-template@0.4.0", "", { "dependencies": { "chalk": "^4.1.2" } }, "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg=="],
+
+    "charenc": ["charenc@0.0.2", "", {}, "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="],
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
@@ -870,6 +995,10 @@
     "colorjs.io": ["colorjs.io@0.5.2", "", {}, "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "command-line-args": ["command-line-args@6.0.2", "", { "dependencies": { "array-back": "^6.2.3", "find-replace": "^5.0.2", "lodash.camelcase": "^4.3.0", "typical": "^7.3.0" }, "peerDependencies": { "@75lb/nature": "latest" }, "optionalPeers": ["@75lb/nature"] }, "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ=="],
+
+    "command-line-usage": ["command-line-usage@7.0.4", "", { "dependencies": { "array-back": "^6.2.2", "chalk-template": "^0.4.0", "table-layout": "^4.1.1", "typical": "^7.3.0" } }, "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg=="],
 
     "commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
@@ -885,7 +1014,13 @@
 
     "copy-anything": ["copy-anything@3.0.5", "", { "dependencies": { "is-what": "^4.1.8" } }, "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w=="],
 
+    "core-assert": ["core-assert@0.2.1", "", { "dependencies": { "buf-compare": "^1.0.0", "is-error": "^2.2.0" } }, "sha512-IG97qShIP+nrJCXMCgkNZgH7jZQ4n8RpPyPeXX++T6avR/KhLhgLiHKoEn5Rc1KjfycSfA9DMa6m+4C4eguHhw=="],
+
+    "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "crypt": ["crypt@0.0.2", "", {}, "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="],
 
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
@@ -961,6 +1096,8 @@
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
+    "deep-strict-equal": ["deep-strict-equal@0.2.0", "", { "dependencies": { "core-assert": "^0.2.0" } }, "sha512-3daSWyvZ/zwJvuMGlzG1O+Ow0YSadGfb3jsh9xoCutv2tWyB9dA4YvR9L9/fSdDZa2dByYQe+TqapSGUrjnkoA=="],
+
     "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
 
     "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
@@ -1029,9 +1166,15 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fflate": ["fflate@0.7.4", "", {}, "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="],
+
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "find-replace": ["find-replace@5.0.2", "", { "peerDependencies": { "@75lb/nature": "latest" }, "optionalPeers": ["@75lb/nature"] }, "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q=="],
+
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
 
     "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
@@ -1065,6 +1208,8 @@
 
     "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
 
+    "gl-matrix": ["gl-matrix@3.4.4", "", {}, "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ=="],
+
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
@@ -1076,6 +1221,8 @@
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "grapheme-splitter": ["grapheme-splitter@1.0.4", "", {}, "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="],
+
+    "h3-js": ["h3-js@4.4.0", "", {}, "sha512-DvJh07MhGgY2KcC4OeZc8SSyA+ZXpdvoh6uCzGpoKvWtZxJB+g6VXXC1+eWYkaMIsLz7J/ErhOalHCpcs1KYog=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -1095,7 +1242,15 @@
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "image-size": ["image-size@0.7.5", "", { "bin": { "image-size": "bin/image-size.js" } }, "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g=="],
+
+    "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
+
     "immutable": ["immutable@5.1.5", "", {}, "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
@@ -1103,7 +1258,11 @@
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
+    "is-buffer": ["is-buffer@1.1.6", "", {}, "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="],
+
     "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "is-error": ["is-error@2.2.2", "", {}, "sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -1122,6 +1281,8 @@
     "is-what": ["is-what@4.1.16", "", {}, "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A=="],
 
     "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
+    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -1149,11 +1310,15 @@
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
+    "json-bignum": ["json-bignum@0.0.3", "", {}, "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg=="],
+
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
     "jsts": ["jsts@2.7.1", "", {}, "sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg=="],
+
+    "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
 
     "kdbush": ["kdbush@4.0.2", "", {}, "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA=="],
 
@@ -1162,6 +1327,8 @@
     "ktx-parse": ["ktx-parse@1.1.0", "", {}, "sha512-mKp3y+FaYgR7mXWAbyyzpa/r1zDWeaunH+INJO4fou3hb45XuNSwar+7llrRyvpMWafxSIi99RNFJ05MHedaJQ=="],
 
     "lerc": ["lerc@2.0.0", "", {}, "sha512-7qo1Mq8ZNmaR4USHHm615nEW2lPeeWJ3bTyoqFbd35DLx0LUH7C6ptt5FDCTAlbIzs3+WKrk5SkJvw8AFDE2hg=="],
+
+    "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -1193,11 +1360,15 @@
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
-    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+    "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
+
+    "long": ["long@3.2.0", "", {}, "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg=="],
 
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
     "lunr": ["lunr@2.3.9", "", {}, "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="],
+
+    "lz4js": ["lz4js@0.2.0", "", {}, "sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -1208,6 +1379,8 @@
     "markdown-it": ["markdown-it@14.2.0", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.1", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "md5": ["md5@2.3.0", "", { "dependencies": { "charenc": "0.0.2", "crypt": "0.0.2", "is-buffer": "~1.1.6" } }, "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g=="],
 
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
@@ -1232,6 +1405,8 @@
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
+
+    "mjolnir.js": ["mjolnir.js@3.0.0", "", {}, "sha512-siX3YCG7N2HnmN1xMH3cK4JkUZJhbkhRFJL+G5N1vH0mh1t5088rJknIoqDFWDIU6NPGvRRgLnYW3ZHjSMEBLA=="],
 
     "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
 
@@ -1287,6 +1462,8 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "pbf": ["pbf@3.3.0", "", { "dependencies": { "ieee754": "^1.1.12", "resolve-protobuf-schema": "^2.1.0" }, "bin": { "pbf": "bin/pbf" } }, "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q=="],
+
     "perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
@@ -1311,11 +1488,15 @@
 
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
     "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
 
     "protobufjs": ["protobufjs@8.4.2", "", { "dependencies": { "long": "^5.3.2" } }, "sha512-64rfNzkWOZAIazXzpBFPWq6F9up6gMvTzjE2oWIzApx2N/dqVUEE7+bCn2+40780dFVtKOUab8QfxJ6KJDWbqA=="],
+
+    "protocol-buffers-schema": ["protocol-buffers-schema@3.6.1", "", {}, "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ=="],
 
     "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
@@ -1333,11 +1514,15 @@
 
     "rbush": ["rbush@3.0.1", "", { "dependencies": { "quickselect": "^2.0.0" } }, "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w=="],
 
+    "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "resolve-protobuf-schema": ["resolve-protobuf-schema@2.1.0", "", { "dependencies": { "protocol-buffers-schema": "^3.3.1" } }, "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
@@ -1358,6 +1543,8 @@
     "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
+
+    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
@@ -1407,6 +1594,8 @@
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
+
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
@@ -1419,6 +1608,8 @@
 
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
+    "snappyjs": ["snappyjs@0.6.1", "", {}, "sha512-YIK6I2lsH072UE0aOFxxY1dPDCS43I5ktqHpeAsuLNYWkE5pGxRGWfDM4/vSUfNzXjC1Ivzt3qx31PCLmc9yqg=="],
+
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
@@ -1429,6 +1620,8 @@
 
     "splaytree-ts": ["splaytree-ts@1.0.2", "", {}, "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA=="],
 
+    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
@@ -1436,6 +1629,8 @@
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
@@ -1458,6 +1653,10 @@
     "sync-child-process": ["sync-child-process@1.0.2", "", { "dependencies": { "sync-message-port": "^1.0.0" } }, "sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA=="],
 
     "sync-message-port": ["sync-message-port@1.2.0", "", {}, "sha512-gAQ9qrUN/UCypHtGFbbe7Rc/f9bzO88IwrG8TDo/aMKAApKyD6E3W4Cm0EfhfBb6Z6SKt59tTCTfD+n1xmAvMg=="],
+
+    "table-layout": ["table-layout@4.1.1", "", { "dependencies": { "array-back": "^6.2.2", "wordwrapjs": "^5.1.0" } }, "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA=="],
+
+    "texture-compressor": ["texture-compressor@1.0.2", "", { "dependencies": { "argparse": "^1.0.10", "image-size": "^0.7.4" }, "bin": { "texture-compressor": "./bin/texture-compressor.js" } }, "sha512-dStVgoaQ11mA5htJ+RzZ51ZxIZqNOgWKAIvtjLrW1AliQQLCmrDqNzQZ8Jh91YealQ95DXt4MEduLzJmbs6lig=="],
 
     "tiff-imagery-provider": ["tiff-imagery-provider@2.17.2", "", { "dependencies": { "geotiff": "^2.0.7" }, "peerDependencies": { "cesium": "*" } }, "sha512-iYGbwS+KXJQrGZVTPegMQnCiBmnQquGwAzRaVMOq5x1ziR3vVsyM4P8qj00v3ZGvDTZkfNWCYSRpu08XfqVXJQ=="],
 
@@ -1491,6 +1690,8 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
+    "typical": ["typical@7.3.0", "", {}, "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw=="],
+
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
@@ -1518,6 +1719,8 @@
     "update-browserslist-db": ["update-browserslist-db@1.2.2", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA=="],
 
     "urijs": ["urijs@1.19.11", "", {}, "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "varint": ["varint@6.0.0", "", {}, "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="],
 
@@ -1561,6 +1764,8 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
+    "wordwrapjs": ["wordwrapjs@5.1.1", "", {}, "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg=="],
+
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
@@ -1589,6 +1794,8 @@
 
     "zod": ["zod@4.1.13", "", {}, "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig=="],
 
+    "zstd-codec": ["zstd-codec@0.1.5", "", {}, "sha512-v3fyjpK8S/dpY/X5WxqTK3IoCnp/ZOLxn144GZVlNUjtwAchzrVo03h+oMATFhCIiJ5KTr4V3vDQQYz4RU684g=="],
+
     "zstddec": ["zstddec@0.1.0", "", {}, "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg=="],
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -1603,6 +1810,14 @@
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
+    "@loaders.gl/3d-tiles/long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "@loaders.gl/compression/pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
+    "@loaders.gl/textures/ktx-parse": ["ktx-parse@0.7.1", "", {}, "sha512-FeA3g56ksdFNwjXJJsc1CCc7co+AJYDp6ipIp878zZ2bU8kWROatLYf39TQEd4/XRSUvBXovQ8gaVKWPXsCLEQ=="],
+
+    "@loaders.gl/wms/@turf/rewind": ["@turf/rewind@5.1.5", "", { "dependencies": { "@turf/boolean-clockwise": "^5.1.5", "@turf/clone": "^5.1.5", "@turf/helpers": "^5.1.5", "@turf/invariant": "^5.1.5", "@turf/meta": "^5.1.5" } }, "sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw=="],
+
     "@sentry/cli/proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "@turf/buffer/d3-geo": ["d3-geo@1.7.1", "", { "dependencies": { "d3-array": "1" } }, "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw=="],
@@ -1612,6 +1827,12 @@
     "@vue/compiler-core/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@vue/compiler-sfc/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "apache-arrow/@types/node": ["@types/node@24.13.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg=="],
+
+    "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "concaveman/robust-predicates": ["robust-predicates@2.0.4", "", {}, "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg=="],
 
@@ -1631,6 +1852,8 @@
 
     "js-beautify/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
+    "jszip/pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
     "local-pkg/mlly": ["mlly@1.8.0", "", { "dependencies": { "acorn": "^8.15.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.1" } }, "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g=="],
 
     "make-dir/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
@@ -1647,6 +1870,8 @@
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
+    "protobufjs/long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
     "rolldown/@oxc-project/types": ["@oxc-project/types@0.120.0", "", {}, "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.10", "", {}, "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg=="],
@@ -1660,6 +1885,8 @@
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "superjson/copy-anything": ["copy-anything@4.0.5", "", { "dependencies": { "is-what": "^5.2.0" } }, "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA=="],
+
+    "texture-compressor/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "topojson-client/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
@@ -1687,7 +1914,19 @@
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
+    "@loaders.gl/wms/@turf/rewind/@turf/boolean-clockwise": ["@turf/boolean-clockwise@5.1.5", "", { "dependencies": { "@turf/helpers": "^5.1.5", "@turf/invariant": "^5.1.5" } }, "sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA=="],
+
+    "@loaders.gl/wms/@turf/rewind/@turf/clone": ["@turf/clone@5.1.5", "", { "dependencies": { "@turf/helpers": "^5.1.5" } }, "sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg=="],
+
+    "@loaders.gl/wms/@turf/rewind/@turf/helpers": ["@turf/helpers@5.1.5", "", {}, "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw=="],
+
+    "@loaders.gl/wms/@turf/rewind/@turf/invariant": ["@turf/invariant@5.2.0", "", { "dependencies": { "@turf/helpers": "^5.1.5" } }, "sha512-28RCBGvCYsajVkw2EydpzLdcYyhSA77LovuOvgCJplJWaNVyJYH6BOR3HR9w50MEkPqb/Vc/jdo6I6ermlRtQA=="],
+
+    "@loaders.gl/wms/@turf/rewind/@turf/meta": ["@turf/meta@5.2.0", "", { "dependencies": { "@turf/helpers": "^5.1.5" } }, "sha512-ZjQ3Ii62X9FjnK4hhdsbT+64AYRpaI8XMBMcyftEOGSmPMUVnkbvuv3C9geuElAXfQU7Zk1oWGOcrGOD9zr78Q=="],
+
     "@turf/buffer/d3-geo/d3-array": ["d3-array@1.2.4", "", {}, "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="],
+
+    "apache-arrow/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "data-urls/whatwg-url/@exodus/bytes": ["@exodus/bytes@1.13.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-VnfL2lS43Z9F8li1faMH9hDZwqfrF5JvOePmrF8oESfo0ijaujnT81zYtienQRpoFa+FJbq0E5rrnMWEW73gOw=="],
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
 		"test:e2e:triage": "jq '.stats' test-results/test-results.json && jq -r '.suites[] | .. | objects | select(.tests?) | .tests[] | select(any(.results[]; .status==\"failed\")) | \"\\(.location.file):\\(.location.line)  \\(.title)\"' test-results/test-results.json"
 	},
 	"dependencies": {
+		"@deck.gl/core": "^9",
+		"@deck.gl/geo-layers": "^9",
+		"@deck.gl/layers": "^9",
 		"@mdi/js": "^7.4.47",
 		"@openfeature/go-feature-flag-web-provider": "^0.2.7",
 		"@openfeature/web-sdk": "^1.7.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -92,7 +92,12 @@
 
 		<v-main>
 			<CesiumViewer />
-			<SosEco250mGrid v-if="grid250m" />
+			<!--
+			  Grid renderer A/B (r4c-deckgl-renderer flag, default OFF):
+			  flag OFF -> Cesium grid (SosEco250mGrid); flag ON -> deck.gl overlay.
+			-->
+			<SosEco250mGrid v-if="grid250m && !deckGlRenderer" />
+			<DeckGlGridView v-if="grid250m && deckGlRenderer" />
 
 			<!-- Map Overlay Controls (right side) -->
 			<!-- MapOverlayControls provides zoom/compass controls. -->
@@ -140,6 +145,10 @@ import { useSidebarOffset } from './composables/useSidebarOffset'
 // Lazy-loaded components
 const TimelineCompact = defineAsyncComponent(() => import('./components/TimelineCompact.vue'))
 const SosEco250mGrid = defineAsyncComponent(() => import('./components/SosEco250mGrid.vue'))
+// deck.gl renderer spike — lazy so the deck.gl bundle is NOT paid while the
+// r4c-deckgl-renderer flag is off (the v-if never mounts it, so its dynamic
+// import never fires).
+const DeckGlGridView = defineAsyncComponent(() => import('./components/DeckGlGridView.vue'))
 const ControlPanel = defineAsyncComponent(() => import('./pages/ControlPanel.vue'))
 const MapOverlayControls = defineAsyncComponent(() => import('./components/MapOverlayControls.vue'))
 
@@ -168,6 +177,9 @@ const timelineLeftStyle = computed(() => ({ left: `${timelineOffset.value}px` })
 const disclaimerLeftStyle = computed(() => ({ left: `${disclaimerOffset.value}px` }))
 
 const grid250m = computed(() => toggleStore.grid250m)
+// deck.gl renderer A/B toggle (default OFF). When on, the grid view renders via
+// deck.gl instead of Cesium — see <DeckGlGridView>.
+const deckGlRenderer = computed(() => featureFlagStore.isEnabled('deckglRenderer'))
 const currentLevel = computed(() => globalStore.level)
 const showTimeline = computed(
 	() => currentLevel.value === 'postalCode' || currentLevel.value === 'building'

--- a/src/components/DeckGlGridView.vue
+++ b/src/components/DeckGlGridView.vue
@@ -1,0 +1,215 @@
+<template>
+	<!--
+	  deck.gl renderer spike (behind the `r4c-deckgl-renderer` flag).
+	  Full-viewport overlay that replaces the Cesium grid view when the flag is on.
+	  This whole component is lazy-loaded (App.vue defineAsyncComponent), so the
+	  deck.gl bundle is only fetched once the flag flips and the grid is shown.
+	-->
+	<div class="deckgl-grid-overlay">
+		<canvas
+			ref="deckCanvas"
+			class="deckgl-canvas"
+		/>
+		<div class="deckgl-spike-badge">deck.gl spike · 250m grid · WMS EPSG:3857</div>
+	</div>
+</template>
+
+<script setup>
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { usePropsStore } from '../stores/propsStore.js'
+import { buildWmsGetMapUrl } from '../utils/deckglWms.js'
+import { getGridFillColorRgba } from '../utils/gridColorMapping.js'
+import logger from '../utils/logger.js'
+
+const propsStore = usePropsStore()
+
+const deckCanvas = ref(null)
+
+// --- Spike configuration -----------------------------------------------------
+/** Stats grid GeoJSON — already WGS84/EPSG:4326, deck's native LNGLAT input. */
+const GRID_URL = '/assets/data/r4c_stats_grid_index.json'
+/**
+ * One HSY WMS layer requested in EPSG:3857 (water landcover — visually distinct,
+ * proves HSY GeoServer's on-the-fly reprojection per WO-5). Routed through the
+ * app's existing /wms/proxy path.
+ */
+const WMS_LAYERS = 'asuminen_ja_maankaytto:maanpeite_vesi_2024'
+/** Cesium baseAlpha (0.8, NDVI off) -> 0-255 alpha for parity with the Cesium grid. */
+const GRID_ALPHA = 204
+/**
+ * Approximate the app's start view over the Helsinki capital region
+ * (camera.js setCameraToHelsinki centers at 24.945, 60.17 top-down).
+ */
+const INITIAL_VIEW_STATE = {
+	longitude: 24.945,
+	latitude: 60.17,
+	zoom: 10.5,
+	pitch: 0,
+	bearing: 0,
+}
+
+let deck = null
+
+/** Read the JS heap size in MB (Chromium-only), or null if unavailable. */
+function readHeapMB() {
+	const mem = /** @type {any} */ (performance).memory
+	if (mem?.usedJSHeapSize == null) return null
+	return Math.round(mem.usedJSHeapSize / 1e5) / 10
+}
+
+/**
+ * Build the deck layer stack for a given stats index.
+ * @param {any} grid - grid GeoJSON (FeatureCollection)
+ * @param {string} selectedIndex - the stats index to color by (e.g. 'heat_index')
+ * @param {typeof import('@deck.gl/layers')} layers - @deck.gl/layers module
+ * @param {typeof import('@deck.gl/geo-layers')} geoLayers - @deck.gl/geo-layers module
+ */
+function buildLayers(grid, selectedIndex, layers, geoLayers) {
+	const { GeoJsonLayer, BitmapLayer } = layers
+	const { TileLayer } = geoLayers
+
+	// HSY WMS underlay: stable TileLayer + GetMap template (EPSG:3857), not the
+	// experimental WMSLayer (WO-5 recommendation).
+	const wmsLayer = new TileLayer({
+		id: 'hsy-wms-underlay',
+		minZoom: 0,
+		maxZoom: 18,
+		tileSize: 256,
+		// Per-tile WMS GetMap URL built from the tile's WGS84 bbox -> EPSG:3857.
+		getTileData: (tile) => {
+			const { west, south, east, north } = /** @type {any} */ (tile.bbox)
+			return buildWmsGetMapUrl({ bbox: { west, south, east, north }, layers: WMS_LAYERS })
+		},
+		renderSubLayers: (props) => {
+			const { west, south, east, north } = /** @type {any} */ (props.tile.bbox)
+			return new BitmapLayer(props, {
+				image: props.data,
+				bounds: [west, south, east, north],
+			})
+		},
+	})
+
+	// 250m stats grid choropleth — colored with the SAME palette as the Cesium
+	// path (utils/gridColorMapping.js), no fork.
+	const gridLayer = new GeoJsonLayer({
+		id: 'stats-grid',
+		data: grid,
+		filled: true,
+		stroked: true,
+		getLineColor: [0, 0, 0, 40],
+		lineWidthMinPixels: 0.5,
+		getFillColor: (f) =>
+			getGridFillColorRgba(/** @type {any} */ (f).properties, selectedIndex, GRID_ALPHA),
+		pickable: false,
+		// Index in the accessor identity so a stats-index change triggers recolor.
+		updateTriggers: {
+			getFillColor: [selectedIndex],
+		},
+	})
+
+	return [wmsLayer, gridLayer]
+}
+
+onMounted(async () => {
+	const w = /** @type {any} */ (window)
+	const selectedIndex = propsStore.statsIndex
+	const memBefore = readHeapMB()
+
+	try {
+		const loadStart = performance.now()
+
+		// Lazy-import deck.gl alongside the grid fetch. These imports live ONLY in
+		// this async component, so the deck bundle stays out of the initial chunk.
+		const [{ Deck, MapView }, layers, geoLayers, gridResponse] = await Promise.all([
+			import('@deck.gl/core'),
+			import('@deck.gl/layers'),
+			import('@deck.gl/geo-layers'),
+			fetch(GRID_URL),
+		])
+
+		if (!gridResponse.ok) {
+			throw new Error(`Grid fetch failed: HTTP ${gridResponse.status}`)
+		}
+		const grid = /** @type {any} */ (await gridResponse.json())
+		const featureCount = grid.features?.length ?? 0
+		const loadMs = performance.now() - loadStart
+
+		// Build layers + instantiate Deck. Time the layer build + first commit.
+		const buildStart = performance.now()
+		const initialLayers = buildLayers(grid, selectedIndex, layers, geoLayers)
+
+		deck = new Deck({
+			canvas: deckCanvas.value,
+			views: [new MapView({ id: 'map', repeat: true })],
+			initialViewState: /** @type {any} */ (INITIAL_VIEW_STATE),
+			controller: true,
+			layers: initialLayers,
+			onLoad: () => {
+				const buildMs = performance.now() - buildStart
+				const memAfter = readHeapMB()
+				const metrics = {
+					ready: true,
+					featureCount,
+					loadMs: Math.round(loadMs * 10) / 10,
+					layerBuildMs: Math.round(buildMs * 10) / 10,
+					memoryBeforeMB: memBefore,
+					memoryAfterMB: memAfter,
+					memoryDeltaMB:
+						memBefore != null && memAfter != null
+							? Math.round((memAfter - memBefore) * 10) / 10
+							: null,
+				}
+				logger.info('[DeckGlGridView] grid rendered', metrics)
+				// Expose for the spike measurement harness (Playwright/manual).
+				w.__deckglSpike = metrics
+				w.__deck = deck
+			},
+		})
+	} catch (error) {
+		logger.error('[DeckGlGridView] failed to initialize deck.gl grid:', error)
+		w.__deckglSpike = { ready: false, error: String(error) }
+	}
+})
+
+onBeforeUnmount(() => {
+	if (deck) {
+		deck.finalize()
+		deck = null
+	}
+	const w = /** @type {any} */ (window)
+	delete w.__deck
+})
+</script>
+
+<style scoped>
+.deckgl-grid-overlay {
+	position: absolute;
+	inset: 0;
+	z-index: 5;
+	/* Neutral land backdrop so the Cesium globe underneath does not bleed through
+	   the transparent WMS tiles — this is a map surface, not UI chrome. */
+	background: #e9e6df;
+}
+
+.deckgl-canvas {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+}
+
+.deckgl-spike-badge {
+	position: absolute;
+	top: 8px;
+	left: 50%;
+	transform: translateX(-50%);
+	z-index: 6;
+	padding: 4px 10px;
+	border-radius: 4px;
+	font-size: 12px;
+	font-weight: 600;
+	pointer-events: none;
+	background: rgba(var(--v-theme-primary), 0.9);
+	color: rgb(var(--v-theme-on-primary));
+}
+</style>

--- a/src/components/DeckGlGridView.vue
+++ b/src/components/DeckGlGridView.vue
@@ -49,6 +49,11 @@ const INITIAL_VIEW_STATE = {
 }
 
 let deck = null
+// Guards against the lazy deck.gl import / grid fetch resolving after the
+// component has already unmounted (flag flipped off or grid view left during
+// the in-flight async window) — without it, a Deck instance would be created
+// and leaked with no onBeforeUnmount to finalize() it.
+let isMounted = true
 
 /** Read the JS heap size in MB (Chromium-only), or null if unavailable. */
 function readHeapMB() {
@@ -127,6 +132,10 @@ onMounted(async () => {
 			fetch(GRID_URL),
 		])
 
+		// Bail if the component unmounted while the imports/fetch were in flight,
+		// so we never instantiate a dangling Deck that nothing will finalize().
+		if (!isMounted) return
+
 		if (!gridResponse.ok) {
 			throw new Error(`Grid fetch failed: HTTP ${gridResponse.status}`)
 		}
@@ -172,6 +181,7 @@ onMounted(async () => {
 })
 
 onBeforeUnmount(() => {
+	isMounted = false
 	if (deck) {
 		deck.finalize()
 		deck = null

--- a/src/composables/useGridStyling.js
+++ b/src/composables/useGridStyling.js
@@ -11,71 +11,22 @@ import { useMitigationStore } from '../stores/mitigationStore.js'
 import { usePropsStore } from '../stores/propsStore.js'
 import { useToggleStore } from '../stores/toggleStore.js'
 import { processBatchAdaptive } from '../utils/batchProcessor.js'
+// Color scheme constants + the value→hex threshold mapping are the single
+// source of truth in utils/gridColorMapping.js so the deck.gl renderer spike
+// (components/DeckGlGridView.vue) shares the exact same palette without forking.
+// Re-exported here to preserve the existing import surface for consumers
+// (e.g. StatisticalGridOptions.vue imports `indexToColorScheme` from this module).
+import { getGridColorString } from '../utils/gridColorMapping.js'
 
-/**
- * Heat vulnerability color scale (white -> dark red)
- */
-export const heatColors = [
-	{ color: '#ffffff', range: 'Incomplete data' },
-	{ color: '#A9A9A9', range: 'Missing values' },
-	{ color: '#ffffcc', range: '< 0.2' },
-	{ color: '#ffeda0', range: '0.2 - 0.4' },
-	{ color: '#feb24c', range: '0.4 - 0.6' },
-	{ color: '#f03b20', range: '0.6 - 0.8' },
-	{ color: '#bd0026', range: '> 0.8' },
-]
-export const partialHeatColors = heatColors.slice(2)
-export const floodColors = [
-	{ color: '#ffffff', range: 'Incomplete data' },
-	{ color: '#A9A9A9', range: 'Missing values' },
-	{ color: '#c6dbef', range: '< 0.2' },
-	{ color: '#9ecae1', range: '0.2 - 0.4' },
-	{ color: '#6baed6', range: '0.4 - 0.6' },
-	{ color: '#3182bd', range: '0.6 - 0.8' },
-	{ color: '#08519c', range: '> 0.8' },
-]
-export const partialFloodColors = floodColors.slice(2)
-export const greenSpaceColors = [
-	{ color: '#006d2c', range: '< 0.2' },
-	{ color: '#31a354', range: '0.2 - 0.4' },
-	{ color: '#74c476', range: '0.4 - 0.6' },
-	{ color: '#a1d99b', range: '0.6 - 0.8' },
-	{ color: '#e5f5e0', range: '> 0.8' },
-]
-export const bothColors = [
-	{ color: '#ffffff', range: 'Incomplete data' },
-	{ color: '#A9A9A9', range: 'Missing values' },
-]
-
-// ** THE FIX IS HERE: The map is now complete **
-export const indexToColorScheme = {
-	partialHeat: partialHeatColors,
-	partialFlood: partialFloodColors,
-	heat_index: heatColors,
-	flood_index: floodColors,
-	sensitivity: heatColors,
-	flood_exposure: greenSpaceColors,
-	flood_prepare: floodColors,
-	flood_respond: floodColors,
-	flood_recover: floodColors,
-	heat_exposure: heatColors,
-	heat_prepare: heatColors,
-	heat_respond: heatColors,
-	age: heatColors,
-	income: heatColors,
-	info: heatColors,
-	tenure: heatColors,
-	green: greenSpaceColors,
-	social_networks: floodColors,
-	overcrowding: floodColors,
-	combined_heat_flood: heatColors,
-	combined_flood_heat: floodColors,
-	combined_heatindex_avgheatexposure: heatColors,
-	combined_heat_flood_green: heatColors,
-	both: bothColors,
-	avgheatexposure: [{ color: 'gradient', range: 'Heat Exposure' }],
-	combined_avgheatexposure: [{ color: 'gradient', range: 'Combined Heat Exposure' }],
-}
+export {
+	bothColors,
+	floodColors,
+	greenSpaceColors,
+	heatColors,
+	indexToColorScheme,
+	partialFloodColors,
+	partialHeatColors,
+} from '../utils/gridColorMapping.js'
 
 /**
  * A 250m grid entity as loaded from GeoJSON.
@@ -173,30 +124,9 @@ export function useGridStyling() {
 	 * @returns {Cesium.Color} Cached color for the value
 	 */
 	const getColorForIndex = (indexValue, indexType) => {
-		const colorScheme = indexToColorScheme[indexType] || heatColors
-
-		// Direct threshold lookup - avoids slice(2).find() array allocation
-		// Color schemes have 2 "missing data" entries at indices 0-1, then 5 threshold colors at 2-6
-		// Thresholds: < 0.2 (index 2), 0.2-0.4 (3), 0.4-0.6 (4), 0.6-0.8 (5), > 0.8 (6)
-		let colorIndex
-		if (indexValue < 0.2) {
-			colorIndex = 2
-		} else if (indexValue < 0.4) {
-			colorIndex = 3
-		} else if (indexValue < 0.6) {
-			colorIndex = 4
-		} else if (indexValue < 0.8) {
-			colorIndex = 5
-		} else {
-			colorIndex = colorScheme.length - 1 // > 0.8
-		}
-
-		// Ensure we don't go out of bounds for shorter color schemes
-		const effectiveIndex = Math.min(colorIndex, colorScheme.length - 1)
-		const colorString =
-			colorScheme[effectiveIndex]?.color || colorScheme[colorScheme.length - 1].color
-
-		return getCachedColor(colorString, baseAlpha.value)
+		// Shared threshold→hex mapping (utils/gridColorMapping.js); wrap the
+		// returned hex in a cached Cesium.Color to reduce GC pressure.
+		return getCachedColor(getGridColorString(indexValue, indexType), baseAlpha.value)
 	}
 
 	// --- ENTITY STYLING FUNCTION ---

--- a/src/constants/flagMetadata.ts
+++ b/src/constants/flagMetadata.ts
@@ -30,6 +30,7 @@ export type FeatureFlagName =
 	| 'terrain3d'
 	| 'viewportStreaming'
 	| 'predictivePrefetch'
+	| 'deckglRenderer'
 	// Analysis tools
 	| 'heatHistogram'
 	| 'buildingScatterPlot'
@@ -208,6 +209,18 @@ export const FLAG_METADATA: FlagMetadataMap = {
 		experimental: false,
 		requiresSupport: false,
 		fallbackDefault: true,
+	},
+	deckglRenderer: {
+		goffId: 'r4c-deckgl-renderer',
+		label: 'deck.gl Grid Renderer (spike)',
+		description:
+			'Experimental: render the 250m statistical grid with deck.gl instead of Cesium for A/B comparison. Default OFF — toggle on to replace the Cesium grid view with a lazily-loaded deck.gl canvas.',
+		category: 'graphics',
+		experimental: true,
+		requiresSupport: false,
+		// Default OFF everywhere (including dev — see buildInitialEvaluations override),
+		// so flag-off is a zero-behavior-change Cesium baseline.
+		fallbackDefault: false,
 	},
 
 	// Analysis tools

--- a/src/stores/featureFlagStore.ts
+++ b/src/stores/featureFlagStore.ts
@@ -307,20 +307,31 @@ export const useFeatureFlagStore = defineStore('featureFlags', {
 })
 
 /**
+ * Flags forced to their `fallbackDefault` even in development mode, opting out
+ * of the dev-mode "enable everything" convenience.
+ *
+ * `deckglRenderer` is a renderer-switching spike: it must default OFF
+ * *everywhere* (including `just dev`) so the Cesium path stays the untouched
+ * baseline and the deck.gl A/B is strictly opt-in.
+ */
+const DEV_DEFAULT_OFF: ReadonlySet<FeatureFlagName> = new Set<FeatureFlagName>(['deckglRenderer'])
+
+/**
  * Build initial evaluation state from fallback defaults.
  * Before OpenFeature is initialized, flags use their fallback values.
  *
  * In development mode, all flags are enabled by default to ensure all
  * experimental features are available during local development without
- * affecting production behavior.
+ * affecting production behavior — except flags listed in {@link DEV_DEFAULT_OFF},
+ * which keep their `fallbackDefault`.
  */
 function buildInitialEvaluations(): Record<FeatureFlagName, boolean> {
 	const isDev = import.meta.env.MODE === 'development'
 	const result: Partial<Record<FeatureFlagName, boolean>> = {}
 	for (const name of ALL_FLAG_NAMES) {
-		// In development mode, enable all flags by default
-		// In production, use the configured fallbackDefault
-		result[name] = isDev ? true : FLAG_METADATA[name].fallbackDefault
+		// In development mode, enable all flags by default (except opt-outs).
+		// In production, use the configured fallbackDefault.
+		result[name] = isDev && !DEV_DEFAULT_OFF.has(name) ? true : FLAG_METADATA[name].fallbackDefault
 	}
 	return result as Record<FeatureFlagName, boolean>
 }

--- a/src/utils/deckglWms.js
+++ b/src/utils/deckglWms.js
@@ -1,0 +1,76 @@
+/**
+ * @module utils/deckglWms
+ *
+ * Pure helpers for the deck.gl spike's WMS underlay. Kept free of deck.gl
+ * imports so the URL-building + projection math is unit-testable without
+ * instantiating a renderer.
+ *
+ * Strategy (per WO-5): use a stable `TileLayer` + WMS `GetMap` URL template
+ * rather than deck's experimental `WMSLayer`. Each deck tile supplies a
+ * WGS84 lng/lat bbox; we reproject it to EPSG:3857 meters and request the
+ * tile in EPSG:3857 — exercising HSY GeoServer's on-the-fly reprojection
+ * (3857 is served despite not being advertised in GetCapabilities).
+ */
+
+/** Spherical Mercator radius (EPSG:3857), meters. */
+const MERCATOR_R = 6378137
+
+/**
+ * Project a WGS84 lng/lat (degrees) to EPSG:3857 meters (x = easting,
+ * y = northing). Standard spherical Web Mercator forward transform.
+ *
+ * @param {number} lng - Longitude in degrees
+ * @param {number} lat - Latitude in degrees
+ * @returns {[number, number]} [x, y] in EPSG:3857 meters
+ */
+export function lngLatToMercator(lng, lat) {
+	const x = (MERCATOR_R * lng * Math.PI) / 180
+	const clampedLat = Math.max(Math.min(lat, 89.9999), -89.9999)
+	const y = MERCATOR_R * Math.log(Math.tan(Math.PI / 4 + (clampedLat * Math.PI) / 360))
+	return [x, y]
+}
+
+/**
+ * Convert a deck.gl tile's WGS84 bbox to an EPSG:3857 `minx,miny,maxx,maxy`
+ * BBOX string suitable for a WMS 1.3.0 GetMap with `CRS=EPSG:3857` (3857 has
+ * x,y axis order, so min/max easting then min/max northing).
+ *
+ * @param {{west:number, south:number, east:number, north:number}} bbox
+ * @returns {string} `minx,miny,maxx,maxy` in EPSG:3857 meters
+ */
+export function mercatorBBoxString({ west, south, east, north }) {
+	const [minX, minY] = lngLatToMercator(west, south)
+	const [maxX, maxY] = lngLatToMercator(east, north)
+	return `${minX},${minY},${maxX},${maxY}`
+}
+
+/**
+ * Build a WMS 1.3.0 GetMap URL for one deck tile in EPSG:3857.
+ *
+ * Routes through the app's existing `/wms/proxy` path (rewritten to
+ * `kartta.hsy.fi/geoserver/wms` by the Vite dev proxy / nginx in prod) so the
+ * spike reuses the same upstream the Cesium path uses.
+ *
+ * @param {Object} opts
+ * @param {{west:number, south:number, east:number, north:number}} opts.bbox - tile bbox (WGS84)
+ * @param {string} opts.layers - comma-separated WMS layer names
+ * @param {string} [opts.baseUrl='/wms/proxy'] - WMS endpoint
+ * @param {number} [opts.tileSize=256] - tile pixel size
+ * @returns {string} Fully-formed GetMap URL
+ */
+export function buildWmsGetMapUrl({ bbox, layers, baseUrl = '/wms/proxy', tileSize = 256 }) {
+	const params = new URLSearchParams({
+		service: 'WMS',
+		request: 'GetMap',
+		version: '1.3.0',
+		layers,
+		styles: '',
+		format: 'image/png',
+		transparent: 'true',
+		crs: 'EPSG:3857',
+		width: String(tileSize),
+		height: String(tileSize),
+		bbox: mercatorBBoxString(bbox),
+	})
+	return `${baseUrl}?${params.toString()}`
+}

--- a/src/utils/gridColorMapping.js
+++ b/src/utils/gridColorMapping.js
@@ -1,0 +1,171 @@
+/**
+ * @module utils/gridColorMapping
+ *
+ * Pure, renderer-agnostic color logic for the 250m statistical grid choropleth.
+ *
+ * This is the single source of truth for the grid palette and the value→color
+ * threshold mapping. Both renderers consume it:
+ *  - the Cesium path (`composables/useGridStyling.js`) wraps the returned hex
+ *    string in a cached `Cesium.Color`;
+ *  - the deck.gl spike (`components/DeckGlGridView.vue`) converts it to an
+ *    `[r,g,b,a]` array for `GeoJsonLayer.getFillColor`.
+ *
+ * No Cesium / deck.gl imports here on purpose — keeping it pure means it can be
+ * unit-tested directly and imported by the eager bundle without pulling either
+ * renderer in.
+ */
+
+/** Heat vulnerability color scale (white -> dark red) */
+export const heatColors = [
+	{ color: '#ffffff', range: 'Incomplete data' },
+	{ color: '#A9A9A9', range: 'Missing values' },
+	{ color: '#ffffcc', range: '< 0.2' },
+	{ color: '#ffeda0', range: '0.2 - 0.4' },
+	{ color: '#feb24c', range: '0.4 - 0.6' },
+	{ color: '#f03b20', range: '0.6 - 0.8' },
+	{ color: '#bd0026', range: '> 0.8' },
+]
+export const partialHeatColors = heatColors.slice(2)
+
+export const floodColors = [
+	{ color: '#ffffff', range: 'Incomplete data' },
+	{ color: '#A9A9A9', range: 'Missing values' },
+	{ color: '#c6dbef', range: '< 0.2' },
+	{ color: '#9ecae1', range: '0.2 - 0.4' },
+	{ color: '#6baed6', range: '0.4 - 0.6' },
+	{ color: '#3182bd', range: '0.6 - 0.8' },
+	{ color: '#08519c', range: '> 0.8' },
+]
+export const partialFloodColors = floodColors.slice(2)
+
+export const greenSpaceColors = [
+	{ color: '#006d2c', range: '< 0.2' },
+	{ color: '#31a354', range: '0.2 - 0.4' },
+	{ color: '#74c476', range: '0.4 - 0.6' },
+	{ color: '#a1d99b', range: '0.6 - 0.8' },
+	{ color: '#e5f5e0', range: '> 0.8' },
+]
+
+export const bothColors = [
+	{ color: '#ffffff', range: 'Incomplete data' },
+	{ color: '#A9A9A9', range: 'Missing values' },
+]
+
+/** Map from index name to its color scheme. */
+export const indexToColorScheme = {
+	partialHeat: partialHeatColors,
+	partialFlood: partialFloodColors,
+	heat_index: heatColors,
+	flood_index: floodColors,
+	sensitivity: heatColors,
+	flood_exposure: greenSpaceColors,
+	flood_prepare: floodColors,
+	flood_respond: floodColors,
+	flood_recover: floodColors,
+	heat_exposure: heatColors,
+	heat_prepare: heatColors,
+	heat_respond: heatColors,
+	age: heatColors,
+	income: heatColors,
+	info: heatColors,
+	tenure: heatColors,
+	green: greenSpaceColors,
+	social_networks: floodColors,
+	overcrowding: floodColors,
+	combined_heat_flood: heatColors,
+	combined_flood_heat: floodColors,
+	combined_heatindex_avgheatexposure: heatColors,
+	combined_heat_flood_green: heatColors,
+	both: bothColors,
+	avgheatexposure: [{ color: 'gradient', range: 'Heat Exposure' }],
+	combined_avgheatexposure: [{ color: 'gradient', range: 'Combined Heat Exposure' }],
+}
+
+/**
+ * Resolve an index value (0-1) to its threshold color hex string.
+ *
+ * Color schemes carry 2 "missing data" entries at indices 0-1, then 5 threshold
+ * colors at indices 2-6. Thresholds: < 0.2 (2), 0.2-0.4 (3), 0.4-0.6 (4),
+ * 0.6-0.8 (5), > 0.8 (6). Direct comparison avoids array allocation.
+ *
+ * @param {number} indexValue - The index value (0-1 range)
+ * @param {string} indexType - The index type key for color scheme lookup
+ * @returns {string} Hex color string (e.g. '#feb24c')
+ */
+export function getGridColorString(indexValue, indexType) {
+	const colorScheme = indexToColorScheme[indexType] || heatColors
+
+	let colorIndex
+	if (indexValue < 0.2) {
+		colorIndex = 2
+	} else if (indexValue < 0.4) {
+		colorIndex = 3
+	} else if (indexValue < 0.6) {
+		colorIndex = 4
+	} else if (indexValue < 0.8) {
+		colorIndex = 5
+	} else {
+		colorIndex = colorScheme.length - 1 // > 0.8
+	}
+
+	const effectiveIndex = Math.min(colorIndex, colorScheme.length - 1)
+	return colorScheme[effectiveIndex]?.color || colorScheme[colorScheme.length - 1].color
+}
+
+/**
+ * Convert a hex color string to an `[r, g, b, a]` array (0-255 components),
+ * the shape deck.gl's `getFillColor` / `getLineColor` accessors expect.
+ *
+ * Accepts `#rgb` and `#rrggbb` (with or without leading `#`).
+ *
+ * @param {string} hex - Hex color string
+ * @param {number} [alpha=255] - Alpha component, 0-255
+ * @returns {[number, number, number, number]}
+ */
+export function hexToRgba(hex, alpha = 255) {
+	let h = String(hex).replace('#', '')
+	if (h.length === 3) {
+		h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2]
+	}
+	const r = parseInt(h.slice(0, 2), 16)
+	const g = parseInt(h.slice(2, 4), 16)
+	const b = parseInt(h.slice(4, 6), 16)
+	return [r, g, b, alpha]
+}
+
+/**
+ * deck.gl-side equivalent of the Cesium `styleGridEntity` color decision for the
+ * default (`heat_index`) and other simple-index paths.
+ *
+ * Mirrors the Cesium logic exactly, reusing {@link getGridColorString}:
+ *  - `missing_values` truthy (and not an index that ignores it) -> gray;
+ *  - index value null/undefined -> white (incomplete data, e.g. cells with no
+ *    `heat_index`);
+ *  - otherwise the threshold color for the value.
+ *
+ * Mitigation reduction is intentionally not applied: with no cooling centers
+ * placed (the default app state) the Cesium reduction is 0, so raw `heat_index`
+ * coloring is identical to the Cesium default.
+ *
+ * @param {Record<string, any>} properties - GeoJSON feature properties (raw object)
+ * @param {string} selectedIndex - The selected vulnerability index
+ * @param {number} [alpha=204] - Alpha 0-255 (Cesium baseAlpha 0.8 -> 204)
+ * @returns {[number, number, number, number]}
+ */
+export function getGridFillColorRgba(properties, selectedIndex, alpha = 204) {
+	const missing = properties?.missing_values
+	if (
+		missing &&
+		selectedIndex !== 'flood_exposure' &&
+		selectedIndex !== 'avgheatexposure' &&
+		selectedIndex !== 'green'
+	) {
+		return hexToRgba('#A9A9A9', alpha)
+	}
+
+	const value = properties?.[selectedIndex]
+	if (value == null) {
+		return hexToRgba('#FFFFFF', alpha)
+	}
+	return hexToRgba(getGridColorString(value, selectedIndex), alpha)
+}

--- a/tests/unit/stores/deckglRendererFlag.test.ts
+++ b/tests/unit/stores/deckglRendererFlag.test.ts
@@ -1,0 +1,63 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FLAG_METADATA } from '@/constants/flagMetadata'
+import { useFeatureFlagStore } from '@/stores/featureFlagStore'
+
+// Mock the OpenFeature provider so the store falls back to fallbackDefault.
+vi.mock('@/services/featureFlagProvider', () => ({
+	getClient: () => ({
+		getBooleanValue: (_flagId: string, defaultValue: boolean) => defaultValue,
+	}),
+}))
+
+describe('r4c-deckgl-renderer flag wiring', () => {
+	let store: ReturnType<typeof useFeatureFlagStore>
+
+	beforeEach(() => {
+		setActivePinia(createPinia())
+		localStorage.clear()
+		vi.spyOn(console, 'warn').mockImplementation(() => {})
+		vi.spyOn(console, 'info').mockImplementation(() => {})
+		store = useFeatureFlagStore()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('registers metadata with the canonical GOFF id and OFF default', () => {
+		const meta = FLAG_METADATA.deckglRenderer
+		expect(meta).toBeDefined()
+		expect(meta.goffId).toBe('r4c-deckgl-renderer')
+		expect(meta.fallbackDefault).toBe(false)
+		expect(meta.experimental).toBe(true)
+		expect(meta.category).toBe('graphics')
+	})
+
+	it('is OFF by default (no override, fallback path)', () => {
+		expect(store.isEnabled('deckglRenderer')).toBe(false)
+	})
+
+	it('can be toggled ON via a local override (FeatureFlagsPanel path)', () => {
+		store.setFlag('deckglRenderer', true)
+		expect(store.isEnabled('deckglRenderer')).toBe(true)
+		expect(store.hasOverride('deckglRenderer')).toBe(true)
+	})
+
+	it('returns to OFF when the override is reset', () => {
+		store.setFlag('deckglRenderer', true)
+		store.resetFlag('deckglRenderer')
+		expect(store.isEnabled('deckglRenderer')).toBe(false)
+	})
+
+	it('persists the override to localStorage so a reload keeps the A/B choice', () => {
+		store.setFlag('deckglRenderer', true)
+		const stored = JSON.parse(localStorage.getItem('featureFlags') ?? '{}')
+		expect(stored.deckglRenderer).toBe(true)
+	})
+
+	it('surfaces in the graphics category for the feature-flag panel', () => {
+		const names = store.flagsByCategory('graphics').map((f) => f.name)
+		expect(names).toContain('deckglRenderer')
+	})
+})

--- a/tests/unit/utils/deckglWms.test.ts
+++ b/tests/unit/utils/deckglWms.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { buildWmsGetMapUrl, lngLatToMercator, mercatorBBoxString } from '@/utils/deckglWms'
+
+describe('deckglWms', () => {
+	describe('lngLatToMercator', () => {
+		it('maps the origin to (0, 0)', () => {
+			const [x, y] = lngLatToMercator(0, 0)
+			expect(x).toBeCloseTo(0, 6)
+			expect(y).toBeCloseTo(0, 6)
+		})
+
+		it('maps Helsinki (24.945, 60.17) to known EPSG:3857 meters', () => {
+			// Reference values from the standard spherical Web Mercator transform.
+			const [x, y] = lngLatToMercator(24.945, 60.17)
+			expect(x).toBeCloseTo(2776864.7, 0)
+			expect(y).toBeCloseTo(8437684.16, 0)
+		})
+
+		it('clamps near-polar latitudes instead of returning Infinity', () => {
+			const [, y] = lngLatToMercator(0, 90)
+			expect(Number.isFinite(y)).toBe(true)
+		})
+	})
+
+	describe('mercatorBBoxString', () => {
+		it('returns minx,miny,maxx,maxy (EPSG:3857 axis order)', () => {
+			const bbox = { west: 24.9, south: 60.1, east: 25.0, north: 60.2 }
+			const str = mercatorBBoxString(bbox)
+			const [minX, minY, maxX, maxY] = str.split(',').map(Number)
+			expect(minX).toBeLessThan(maxX)
+			expect(minY).toBeLessThan(maxY)
+		})
+	})
+
+	describe('buildWmsGetMapUrl', () => {
+		const bbox = { west: 24.9, south: 60.1, east: 25.0, north: 60.2 }
+
+		it('builds a WMS 1.3.0 GetMap request in EPSG:3857 through /wms/proxy', () => {
+			const url = buildWmsGetMapUrl({ bbox, layers: 'asuminen_ja_maankaytto:maanpeite_vesi_2024' })
+			expect(url.startsWith('/wms/proxy?')).toBe(true)
+			const params = new URLSearchParams(url.split('?')[1])
+			expect(params.get('service')).toBe('WMS')
+			expect(params.get('request')).toBe('GetMap')
+			expect(params.get('version')).toBe('1.3.0')
+			expect(params.get('crs')).toBe('EPSG:3857')
+			expect(params.get('layers')).toBe('asuminen_ja_maankaytto:maanpeite_vesi_2024')
+			expect(params.get('format')).toBe('image/png')
+			expect(params.get('width')).toBe('256')
+			expect(params.get('bbox')).toBe(mercatorBBoxString(bbox))
+		})
+
+		it('honors a custom base URL and tile size', () => {
+			const url = buildWmsGetMapUrl({
+				bbox,
+				layers: 'x',
+				baseUrl: 'https://kartta.hsy.fi/geoserver/wms',
+				tileSize: 512,
+			})
+			expect(url.startsWith('https://kartta.hsy.fi/geoserver/wms?')).toBe(true)
+			const params = new URLSearchParams(url.split('?')[1])
+			expect(params.get('width')).toBe('512')
+			expect(params.get('height')).toBe('512')
+		})
+	})
+})

--- a/tests/unit/utils/gridColorMapping.test.ts
+++ b/tests/unit/utils/gridColorMapping.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import {
+	getGridColorString,
+	getGridFillColorRgba,
+	heatColors,
+	hexToRgba,
+	indexToColorScheme,
+} from '@/utils/gridColorMapping'
+
+describe('gridColorMapping', () => {
+	describe('getGridColorString — threshold buckets', () => {
+		// heatColors indices 2-6: < 0.2, 0.2-0.4, 0.4-0.6, 0.6-0.8, > 0.8
+		it.each([
+			[0.0, '#ffffcc'],
+			[0.19, '#ffffcc'],
+			[0.2, '#ffeda0'],
+			[0.39, '#ffeda0'],
+			[0.4, '#feb24c'],
+			[0.59, '#feb24c'],
+			[0.6, '#f03b20'],
+			[0.79, '#f03b20'],
+			[0.8, '#bd0026'],
+			[1.0, '#bd0026'],
+		])('heat_index value %f -> %s', (value, expected) => {
+			expect(getGridColorString(value, 'heat_index')).toBe(expected)
+		})
+
+		it('falls back to heatColors for an unknown index type', () => {
+			expect(getGridColorString(0.5, 'totally_unknown_index')).toBe('#feb24c')
+		})
+
+		it('clamps to the last entry for shorter (greenSpace) schemes', () => {
+			// greenSpaceColors has 5 entries (indices 0-4); a > 0.8 value must not overflow.
+			expect(getGridColorString(0.9, 'green')).toBe('#e5f5e0')
+		})
+	})
+
+	describe('hexToRgba', () => {
+		it('parses #rrggbb with default opaque alpha', () => {
+			expect(hexToRgba('#feb24c')).toEqual([254, 178, 76, 255])
+		})
+
+		it('expands #rgb shorthand', () => {
+			expect(hexToRgba('#fff', 128)).toEqual([255, 255, 255, 128])
+		})
+
+		it('tolerates a missing leading # and applies alpha', () => {
+			expect(hexToRgba('bd0026', 204)).toEqual([189, 0, 38, 204])
+		})
+	})
+
+	describe('getGridFillColorRgba — mirrors Cesium styleGridEntity', () => {
+		it('colors a present heat_index value with the shared threshold color', () => {
+			// 0.5 -> #feb24c -> [254,178,76,204]
+			expect(getGridFillColorRgba({ heat_index: 0.5 }, 'heat_index', 204)).toEqual([
+				254, 178, 76, 204,
+			])
+		})
+
+		it('returns white for a null/absent index value (incomplete data)', () => {
+			expect(getGridFillColorRgba({ heat_index: null }, 'heat_index')).toEqual([255, 255, 255, 204])
+			expect(getGridFillColorRgba({}, 'heat_index')).toEqual([255, 255, 255, 204])
+		})
+
+		it('returns gray when missing_values is set for a guarded index', () => {
+			expect(getGridFillColorRgba({ missing_values: true, heat_index: 0.5 }, 'heat_index')).toEqual(
+				[169, 169, 169, 204]
+			)
+		})
+
+		it('ignores missing_values for green/flood_exposure/avgheatexposure indices', () => {
+			// Not gray: missing_values is bypassed for these indices, so the value is
+			// colored with the shared threshold logic (preserving the existing Cesium
+			// behavior exactly, quirks included — do not fork).
+			const result = getGridFillColorRgba({ missing_values: true, green: 0.5 }, 'green')
+			expect(result).not.toEqual([169, 169, 169, 204]) // not the missing-values gray
+			expect(result).toEqual(hexToRgba(getGridColorString(0.5, 'green'), 204))
+		})
+	})
+
+	describe('palette integrity', () => {
+		it('exposes heat_index -> heatColors in the scheme map', () => {
+			expect(indexToColorScheme.heat_index).toBe(heatColors)
+		})
+	})
+})


### PR DESCRIPTION
## What

WO-5 deck.gl spike, **behind the `r4c-deckgl-renderer` feature flag** (default
**OFF** everywhere, including `just dev`) so Cesium and deck.gl can be A/B-tested
side-by-side. This is a **spike, not a migration** — it targets only the
stats-grid view (the 6,710-cell choropleth) + one HSY WMS imagery layer.

- **Flag OFF** (default): zero behavior change. The Cesium grid (`SosEco250mGrid`)
  renders exactly as today and the deck.gl bundle is **never fetched**.
- **Flag ON**: the grid view renders via a lazily-loaded deck.gl canvas
  (`GeoJsonLayer` choropleth + HSY WMS `TileLayer` underlay in EPSG:3857)
  instead of Cesium.

### How a dev/stakeholder flips it locally

1. Enable the feature-flag panel (`r4c-show-feature-panel`) and toggle
   **"deck.gl Grid Renderer (spike)"** under *Graphics & Performance*, **or**
2. `localStorage.setItem('featureFlags', JSON.stringify({ deckglRenderer: true }))`
   then reload.

Then turn on the 250m grid (Layers → Grid). Flag is a localStorage override, so
it persists across reloads. Production/test default is OFF (`fallbackDefault:
false`); dev is also forced OFF for this flag (opt-out of the dev "all flags on"
convenience) so the Cesium path stays the untouched baseline.

## WO-5 gates (measured: M4 Pro, real GPU; Cesium baseline = WO-3, same grid)

| Gate | Cesium (WO-3) | deck.gl | Verdict |
|---|---|---|---|
| Alignment / CRS | reference | Grid (EPSG:4326) + WMS water (EPSG:3857) overlay correctly on real Helsinki geography; deck-internal consistency exact | **PASS** (cross-renderer pixel pair = follow-up, needs camera calibration) |
| WMS reprojection at runtime | CRS:84 | EPSG:3857 GetMap → `200 image/png` (HSY reprojects despite 3857 unadvertised) | **PASS** |
| **Styling (the prize)** | 378 ms super-linear; 0.056 ms/entity | **17–29 ms, linear**, no material-rebuild storm | **PASS** (~13–22×) |
| Creation | 237 ms + 9.4M-object GC storm | one GPU geometry build | **PASS** |
| **Memory** | +313 MB / ~48 KB/entity / ~1,400 obj/entity | **+100–160 MB**, no reactive per-entity graph | **PASS** (~0.5×) |
| Steady render | ~1 ms/frame | parity | PASS — free, not a switch reason (WO-3) |
| **Bundle** | Cesium 4.78 MB min / **1.25 MB gz** | deck graph **~1.54 MB min / ~454 KB gz**, lazy (absent from initial bundle when OFF) | **PASS** for a full migration (~64% gz cut); additive while spike-only |

Runtime (`window.__deckglSpike`): cold `load 266.5 ms / build 29.4 ms / Δ160.5 MB`,
warm `load 180.2 ms / build 17.4 ms / Δ100.8 MB`, `featureCount 6710`.

Verification: flag-OFF reload = 0 deck console errors, `window.__deck` /
`window.__deckglSpike` undefined, deck chunks absent from the entry/preload;
flag-ON renders all 6,710 cells with the heat palette + WMS water underlay.

## Screenshots

Captured to `tmp/perf-investigation/artifacts/deckgl-spike/` (local artifacts,
gitignored):
- `deckgl-grid-flag-on-clean.png` — deck.gl choropleth + HSY WMS water, capital region
- `cesium-grid-flag-off-reference.png` — flag-OFF Cesium baseline
- `measurements.md` — full gates table + bundle split

## Verdict: JUSTIFY a scoped migration RFC

Both WO-3 prizes are realized (styling super-linearity gone; per-entity memory
tax gone) and the WO-5 CRS/WMS objection is empirically dead. A full swap is
also a net bundle win.

## What a real migration would still need (out of scope here)

- Extruded buildings + the building / postal-code / Helsinki / capital-region views
- Feature picking + the click→navigate flow (`featurepicker`, pending-navigation coordination)
- Camera service re-expressed in `MapView` (oblique pitches, `flyTo`, compass/zoom controls)
- Cross-renderer pixel-matched alignment calibration (deck zoom ↔ Cesium altitude/pitch)
- A trimmed deck import (GeoJsonLayer-only is ~½ the weight; `TileLayer`/loaders.gl WMS is the heavy half)
- Accepting the loss of Cesium's 3D-Tiles / quantized-mesh-terrain future (WO-5 Part 4 ledger)

## Tests

- `tests/unit/utils/gridColorMapping.test.ts` — shared color/threshold mapping (reuse, no fork)
- `tests/unit/utils/deckglWms.test.ts` — EPSG:3857 projection + WMS GetMap URL builder
- `tests/unit/stores/deckglRendererFlag.test.ts` — flag wiring (OFF default, override, panel surfacing)
- Full suite green (845 pass / 4 pre-existing skips), lint + typecheck clean, production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
