### PR TITLE
perf(grid): batch entity styling to eliminate super-linear material rebuilds

### DIFF
--- a/src/composables/useGridStyling.js
+++ b/src/composables/useGridStyling.js
@@ -10,7 +10,6 @@ import { useGlobalStore } from '../stores/globalStore.js'
 import { useMitigationStore } from '../stores/mitigationStore.js'
 import { usePropsStore } from '../stores/propsStore.js'
 import { useToggleStore } from '../stores/toggleStore.js'
-import { processBatchAdaptive } from '../utils/batchProcessor.js'
 
 /**
  * Heat vulnerability color scale (white -> dark red)
@@ -292,8 +291,12 @@ export function useGridStyling() {
 	/**
 	 * Updates grid entity colors based on the selected vulnerability index.
 	 *
-	 * Styling runs as a SINGLE non-yielding pass (`yieldToMain: false`) wrapped
-	 * in `entities.suspendEvents()` / `resumeEvents()`.
+	 * Styling runs as a SINGLE non-yielding pass — a plain synchronous `for`
+	 * loop wrapped in `entities.suspendEvents()` / `resumeEvents()`. A bare loop
+	 * is used deliberately instead of `processBatchAdaptive`: with yielding
+	 * disabled the batcher adds only overhead (per-batch array slicing, promise
+	 * wrapping, timing, and calibration) without changing behaviour, and the
+	 * loop makes the "no intermediate frames" guarantee explicit.
 	 *
 	 * WO-3 measured this pass as super-linear (3,291→6,710 entities = 2.04×
 	 * entities but ~7× time; ~412 ms at 6,710 on an M4 Pro). The cause was the
@@ -333,10 +336,9 @@ export function useGridStyling() {
 
 		collection.suspendEvents()
 		try {
-			await processBatchAdaptive(entities, (entity) => styleGridEntity(entity, selectedIndex), {
-				processorName: 'gridStyling',
-				yieldToMain: false,
-			})
+			for (let i = 0; i < entities.length; i++) {
+				styleGridEntity(entities[i], selectedIndex)
+			}
 		} finally {
 			collection.resumeEvents()
 		}

--- a/src/composables/useGridStyling.js
+++ b/src/composables/useGridStyling.js
@@ -291,7 +291,34 @@ export function useGridStyling() {
 	// --- MAIN EXPOSED FUNCTION ---
 	/**
 	 * Updates grid entity colors based on the selected vulnerability index.
-	 * Uses adaptive batch processing to maintain UI responsiveness.
+	 *
+	 * Styling runs as a SINGLE non-yielding pass (`yieldToMain: false`) wrapped
+	 * in `entities.suspendEvents()` / `resumeEvents()`.
+	 *
+	 * WO-3 measured this pass as super-linear (3,291→6,710 entities = 2.04×
+	 * entities but ~7× time; ~412 ms at 6,710 on an M4 Pro). The cause was the
+	 * `scheduler.yield()` between adaptive batches: each yield released an
+	 * animation frame, and under requestRenderMode that frame REBUILT the
+	 * polygon-material primitives dirtied by the previous batch. Across the pass
+	 * that is O(N) interleaved render/rebuilds whose per-frame cost grows with
+	 * the accumulated dirty set — the cliff. Dropping the per-batch yield removes
+	 * every intermediate frame, so no material rebuild happens until the whole
+	 * pass is done; benchmarking shows 6,710-entity styling fall from ~412 ms to
+	 * ~127 ms and the 3,291→6,710 scaling fall from ~6.8× to ~2.6×.
+	 *
+	 * `suspendEvents()`/`resumeEvents()` additionally collapses the per-entity
+	 * `collectionChanged` notifications into one on resume, and the final
+	 * `requestRender()` flushes the single batched material rebuild. The
+	 * end-state visual output is unchanged — only the transition stops animating
+	 * colour-by-colour and snaps once at the end (a one-off ~127 ms main-thread
+	 * pass for the full 6,710-cell grid, versus ~412 ms of interleaved jank).
+	 *
+	 * NOTE: keep the per-entity `polygon.material = <Color>` assignment as a
+	 * REPLACEMENT. Reusing the existing `ColorMaterialProperty` and `setValue()`-
+	 * ing its colour in place (the obvious "avoid the allocation" idea) is a
+	 * Cesium antipattern here — it pegs the `StaticGeometryColorBatch` and is
+	 * dramatically slower (measured: tens of seconds at 6,710) than letting
+	 * Cesium swap the material property.
 	 *
 	 * @param {string} selectedIndex - The selected vulnerability index
 	 * @returns {Promise<void>}
@@ -301,11 +328,21 @@ export function useGridStyling() {
 		const dataSource = viewer.value.dataSources.getByName('250m_grid')[0]
 		if (!dataSource) return
 
-		const entities = dataSource.entities.values
+		const collection = dataSource.entities
+		const entities = collection.values
 
-		await processBatchAdaptive(entities, (entity) => styleGridEntity(entity, selectedIndex), {
-			processorName: 'gridStyling',
-		})
+		collection.suspendEvents()
+		try {
+			await processBatchAdaptive(entities, (entity) => styleGridEntity(entity, selectedIndex), {
+				processorName: 'gridStyling',
+				yieldToMain: false,
+			})
+		} finally {
+			collection.resumeEvents()
+		}
+
+		// Flush the single batched material rebuild now that events have resumed.
+		viewer.value.scene?.requestRender?.()
 	}
 
 	return {


### PR DESCRIPTION
## Problem (WO-3)

WO-3 of the performance investigation measured the 6,710-entity stats-grid
styling pass (`useGridStyling().updateGridColors`) as **super-linear**:
3,291→6,710 entities is **2.04× entities but ~7× time** — ~412 ms at 6,710
on an M4 Pro (Metal GPU). The DevTools trace decomposed the cliff as
**~50% styling-callback CPU + ~50% interleaved material-rebuild render frames**:
"Cesium re-renders WHILE materials mutate."

## Root cause

The `scheduler.yield()` between adaptive batches released an animation frame,
and under `requestRenderMode` that frame **rebuilt the polygon-material
primitives dirtied by the previous batch**. Across the pass that is O(N)
interleaved render/rebuilds whose per-frame cost grows with the accumulated
dirty set — exactly the cliff WO-3 saw.

## Fix

Run the styling pass as a **single non-yielding pass** (`yieldToMain: false`)
wrapped in `entities.suspendEvents()` / `resumeEvents()`, then one
`scene.requestRender()` to flush the single batched material rebuild. No
animation frame fires mid-pass, so materials are rebuilt **once at the end**
instead of O(N) times. The diff is ~40 lines in one file.

## Before / after (real `updateGridColors` path, M4 Pro Metal, median of 5, anti-throttle headed Chromium)

| N (entities) | before | after | speedup |
|---|---|---|---|
| 1,000 | 15.1 ms | 10.3 ms | 1.5× |
| 3,291 | 60.8 ms | 48.2 ms | 1.26× |
| **6,710** | **412.3 ms** | **127.5 ms** | **3.2×** |
| **3291→6710 scaling** | **6.78×** | **2.64×** | **cliff removed** |

The 6,710 styling time drops 69%, and the scaling curve collapses from ~7×
to ~2.6× per 2.04× entities — clearly sub-linear vs WO-3's curve.

## Technique chosen and why

Of WO-3's three candidates I benchmarked each in isolation (real Metal GPU,
in-page A/B harness):

1. **`suspendEvents()` alone (keeping yields)** — no win: still **451 ms** at
   6,710. Each entity's `GeometryUpdater` subscribes directly to the entity's
   `definitionChanged`, *not* to the collection's `collectionChanged`, so
   suspending the collection does not stop the per-frame rebuilds while yields
   keep firing animation frames. Kept anyway as cheap hygiene (collapses N
   `collectionChanged` emissions to 1 on resume).
2. **In-place colour mutation** (reuse the `ColorMaterialProperty`,
   `setValue()` its `ConstantProperty` instead of replacing) — **counter-
   productive**: it pegs Cesium's `StaticGeometryColorBatch` and blew the pass
   up to **tens of seconds** at 3,291+. Cesium's color batch is optimised for
   material-property *replacement*, so the per-entity `polygon.material = <Color>`
   assignment is intentionally kept (and a code comment warns against the
   "obvious" allocation-avoidance refactor).
3. **Drop the per-batch yield** (this PR) — the real lever. Removing the
   interleaved frames is what eliminates the super-linearity.

Trade-off: the transition is now a single ~127 ms main-thread pass for the
full 6,710-cell grid rather than ~412 ms of interleaved jank. Not migrating to
Primitives/deck.gl — that remains a separate spike.

## Visual parity

Same view, before vs after: **0.32% pixel difference** (5,127 / 1.6 M px),
entirely incidental background (map-tile streaming + a "Loading layers"
indicator differing between runs). The grid coloring is pixel-identical — the
end-state output is unchanged; only the transition snaps once at the end
instead of animating colour-by-colour.

## Verification

- Unit suite: **813 passed, 4 skipped** (`bun run test:unit`)
- Lint: clean (`bun run lint` / biome)
- Build: green (`bun run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Review follow-up (2026-06-10)

Addressed Gemini review feedback (`refactor(grid): replace adaptive batcher with synchronous loop`): with yielding disabled, `processBatchAdaptive` only added overhead (per-batch slicing, promise wrapping, timing, calibration) without changing behaviour, so the styling pass now uses a plain synchronous `for` loop inside the existing `suspendEvents()/resumeEvents()` + final `requestRender()`. Behaviour and visual output are unchanged; the loop performs strictly fewer operations than the batcher it replaced, so the measured ~127 ms / 6,710-cell result is an upper bound.

The reviewer's second point (resetting `mitigationStore` impact/affected before the heat_index pass) is a **pre-existing, out-of-scope** concern — this PR does not touch the `addImpact`/`addCell` accumulation logic — and the literal `resetMitigationState()` fix has side effects (it also clears `optimised`, consumed by `EstimatedImpacts.vue`, and double-interacts with `recalculateCoolingCenterImpacts()`). Tracking it separately rather than bundling it into this perf change.
