### PR TITLE
fix(nginx): re-declare security headers in location blocks (+ session-learning rules)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -80,6 +80,35 @@ Material Design Icons render as **inline SVG paths** via a custom Vuetify iconse
 
 When RRM is on, Cesium only re-renders when something changes (camera move, entity update, imagery load); when off, the scene re-renders every animation frame at ~60 FPS. On a 3D globe with terrain + buildings + WMS imagery the difference is roughly one CPU core and a hot dGPU — keep RRM on unless a specific feature genuinely needs continuous rendering, and explicitly call `viewer.scene.requestRender()` at any mutation site that would otherwise be visually invisible under RRM (existing camera/entity/imagery hooks already do this).
 
+## Bulk Entity Styling (grids, building sets)
+
+Measured on the 6,710-entity stats grid (Wave-0 perf investigation, PR #880;
+WO-3 report). Three findings that contradict the "obvious" optimizations:
+
+1. **Mid-pass yields are the cliff, not the styling work.** Any
+   `await`/`scheduler.yield()`/`requestIdleCallback` inside a styling loop
+   releases an animation frame, and Cesium rebuilds entity materials on every
+   frame while they mutate — O(N) rebuilds instead of one. Removing the
+   per-batch yield took the 6,710-cell pass from 412 ms to 127 ms and removed
+   the super-linear scaling. The same mechanism made the Helsinki heat merge
+   take 11.7–137 s (PR #874): the cost was tens of thousands of untimed
+   `requestIdleCallback` round-trips, not the merge CPU (single-digit ms).
+2. **`entityCollection.suspendEvents()` alone does NOT stop the rebuilds** —
+   each entity's `GeometryUpdater` subscribes to the entity's own
+   `definitionChanged`, not the collection's `collectionChanged`. Suspend is
+   still correct (batches collection events), but only helps once the pass is
+   yield-free.
+3. **Never mutate a shared color property in place** (`color.setValue()` /
+   mutating a cached `Cesium.Color`): it pegs Cesium's
+   `StaticGeometryColorBatch` and was measured to blow the pass to tens of
+   seconds. Assign cached immutable `Color` instances per palette bucket
+   instead (see the warning comment in `useGridStyling.js`).
+
+Canonical pattern: single synchronous loop wrapped in
+`suspendEvents()`/`resumeEvents()`, one `scene.requestRender()` at the end.
+For yield-needing huge passes, yield coarsely (hundreds of items) with a
+timeout-bounded idle callback — never per-N-features untimed.
+
 ## Reading Cesium Entity Properties
 
 Read GeoJSON entity properties through the **public** API:
@@ -130,7 +159,43 @@ The "HSY buildings" tiles (`viewport_buildings_hsy_*`) are served by `pygeoapi.d
 2. **Inspect the BackendTrafficPolicy** for the affected route — `kubectl get backendtrafficpolicy -n <ns> <name> -o yaml`. The `spec.rateLimit.local.rules` describe the per-IP budget.
 3. **Distinguish "service overloaded" from "gateway rejecting"**: per-IP buckets mean one dev workstation can produce 940 429s in a session while the service itself is idle. In production each user has their own IP, so the effective limit is per-user, but bursts can still exceed a tight cap on initial viewport load (~30-50 tiles in 1-3 seconds).
 
-The client-side per-host concurrency limiter (`src/services/hostConcurrencyLimiter.js`) caps in-flight count but does not throttle the request rate — a circuit breaker or `Retry-After`-honoring backoff is the right next lever if cap relaxation alone isn't enough.
+The client-side per-host concurrency limiter (`src/services/hostConcurrencyLimiter.js`) caps in-flight count but does not throttle the request rate.
+
+### HSY Outage Resilience Stack (PRs #877, #878)
+
+HSY (`kartta.hsy.fi` behind an Azure App Gateway) returns 504s under load
+instead of throttling, with ~20 s hangs, and is occasionally fully down. The
+app survives this with two layers — keep both in mind when touching HSY paths:
+
+- **nginx (`/wms/proxy`)**: `proxy_cache` with
+  `proxy_cache_use_stale error timeout updating http_5xx` + `proxy_cache_lock`
+  - short 3 s/10 s timeouts — a flaky/down HSY serves stale tiles instead of
+    failing; `X-Cache-Status` header exposes HIT/MISS/STALE.
+- **Client**: `src/services/hostCircuitBreaker.js` (sibling of the
+  concurrency limiter — opens after consecutive failures, fast-fails during
+  cooldown, half-opens to probe recovery), 12 s per-attempt fetch timeouts in
+  `unifiedLoader.js` (must stay below the 20 s gateway hang so a hung request
+  frees its 3-per-host slot), quiet-degrade `errorEvent` handling on HSY
+  imagery layers (`landcover.js`), and a `serviceHealthStore`-driven snackbar
+  gated on HSY host keys only.
+
+Behavior is unchanged when HSY is healthy; never let an HSY request block app
+init or navigation.
+
+## deck.gl Renderer (experimental, behind flag)
+
+The `r4c-deckgl-renderer` feature flag (default OFF everywhere; local
+override via FeatureFlagsPanel) swaps the stats-grid view to a deck.gl 9.x
+renderer (`src/components/DeckGlGridView.vue`, GeoJsonLayer choropleth + HSY
+WMS via TileLayer in EPSG:3857). Spike verdict (PR #879): styling 17–29 ms vs
+Cesium's 127 ms, ~half the memory, ~454 KB gz lazy chunk vs Cesium's 1.25 MB.
+
+- **Lazy-load invariant**: deck.gl chunks must never appear in the entry
+  bundle — `DeckGlGridView` is dynamically imported; check the build output
+  if you touch its imports.
+- **Shared palette**: both renderers consume `src/utils/gridColorMapping.js`
+  (extracted from `useGridStyling.js`, which re-exports it for existing
+  consumers). Never fork the color mapping — fix it in one place.
 
 ## Component Organization
 

--- a/.claude/rules/development.md
+++ b/.claude/rules/development.md
@@ -70,11 +70,30 @@ ast-grep -p 'await $PROMISE.catch($$$)'               # Find error handling
 ## Building
 
 ```bash
-bun run build    # Production build
+bun run build    # Production build (runs scripts/precompress.mjs after vite build)
 bun run dev      # Development server with hot reload
 bun run lint     # Biome check
 bun run lint:fix # Biome auto-fix
 ```
+
+`bun run build` ends with a precompression step (`scripts/precompress.mjs`,
+gzip-9 over `dist/` — ~−77% on compressible assets); nginx serves the `.gz`
+siblings via `gzip_static`. If a build artifact seems stale or doubled, check
+for orphaned `.gz` files. Brotli precompression is blocked on a
+brotli-capable nginx image — tracked in issue #876.
+
+## Merge Commits Must Be Conventional
+
+The `conventional-pre-commit` hook validates **merge commits too** — git's
+default `Merge remote-tracking branch '...'` subject is rejected. When
+committing a conflict resolution, supply a conventional subject:
+
+```bash
+git commit -m "chore(merge): merge main into <branch>"
+```
+
+(The subject disappears on squash-merge anyway; it only needs to satisfy the
+hook.)
 
 ## CI/CD
 

--- a/.claude/rules/development.md
+++ b/.claude/rules/development.md
@@ -85,8 +85,15 @@ brotli-capable nginx image — tracked in issue #876.
 ## Merge Commits Must Be Conventional
 
 The `conventional-pre-commit` hook validates **merge commits too** — git's
-default `Merge remote-tracking branch '...'` subject is rejected. When
-committing a conflict resolution, supply a conventional subject:
+default `Merge remote-tracking branch '...'` subject is rejected. A
+conflict-free `git merge main` auto-commits the default subject and fails
+the hook immediately, so pass the message on the merge itself:
+
+```bash
+git merge main -m "chore(merge): merge main into <branch>"
+```
+
+When committing a conflict resolution, the same subject goes on the commit:
 
 ```bash
 git commit -m "chore(merge): merge main into <branch>"

--- a/.claude/rules/nginx.md
+++ b/.claude/rules/nginx.md
@@ -21,7 +21,9 @@ to a `location` silently drops every server-level header (the security set:
 `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, …). Any
 location that sets its own `Cache-Control` must re-declare the security
 headers. Verify with `curl -sI` against the container — we shipped this bug
-in the first cut of `/assets/data/`.
+in the first cut of `/assets/data/`, and the #885 review found four more
+locations (`/index.html`, `/assets/`, `/`, `/feature-flags/`) plus the
+unhashed-static regex location with the same violation, all fixed since.
 
 ## Outbound TLS proxying needs explicit SNI
 
@@ -53,6 +55,11 @@ on;` serves `.gz` siblings; dynamic/proxied responses (pygeoapi JSON arrives
 uncompressed from origin) use `gzip_comp_level 6` + `application/geo+json`
 in `gzip_types`. The stock `nginx:1.31` image (Renovate-managed) has **no
 brotli module** — `.br` serving requires an image change, tracked in #876.
+
+Never add image formats (JPEG/PNG/GIF/WebP) to `gzip_types` — they are
+already compressed; gzipping them burns CPU per response and can grow the
+payload. The `/helsinki-wms` tile proxy shipped this anti-pattern until the
+#885 review caught it.
 
 ## Verifying changes
 

--- a/.claude/rules/nginx.md
+++ b/.claude/rules/nginx.md
@@ -1,0 +1,62 @@
+---
+paths:
+  - 'nginx/**'
+  - 'Dockerfile'
+  - 'docker-compose*.yml'
+---
+
+# nginx Configuration (`nginx/default.conf.template`)
+
+Hard-won facts from PR #877 (delivery caching + HSY stale-on-error), each
+verified against nginx docs and empirically in the container. The config is
+an envsubst template — keep `${VAR}` placeholders intact, and remember the
+Kyverno read-only-rootfs constraint: anything nginx writes (proxy cache,
+temp paths) must live on the writable tmp emptyDir mount.
+
+## `add_header` in a location block suppresses ALL inherited headers
+
+nginx's headers module inherits `add_header` directives from outer scopes
+**only if the current level defines none**. Adding a single `add_header`
+to a `location` silently drops every server-level header (the security set:
+`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, …). Any
+location that sets its own `Cache-Control` must re-declare the security
+headers. Verify with `curl -sI` against the container — we shipped this bug
+in the first cut of `/assets/data/`.
+
+## Outbound TLS proxying needs explicit SNI
+
+`proxy_ssl_server_name` defaults to **off**; Azure App Gateway fronted
+upstreams (HSY `kartta.hsy.fi`) and api.digitransit.fi (#870) 502 the
+handshake without SNI. Every `proxy_pass https://...` location needs
+`proxy_ssl_server_name on;` (`proxy_ssl_name` defaults to `$proxy_host`,
+which is correct here). Symptom: works with `curl` direct, 502 via nginx.
+
+## Cache policy by path class
+
+| Path                      | Policy                                                                                                          | Why                                                                                                                   |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `/assets/data/*.json`     | `max-age=3600, must-revalidate` + ETag                                                                          | **Unhashed filenames** (grid index etc.) — `immutable` here served year-stale data after redeploys (the original bug) |
+| `/assets/` hashed bundles | `max-age=31536000, immutable`                                                                                   | Content-hashed names, safe forever                                                                                    |
+| `/wms/proxy` (HSY tiles)  | `proxy_cache` + `proxy_cache_use_stale error timeout updating http_5xx` + `proxy_cache_lock`, 3 s/10 s timeouts | HSY 504s under load and goes down; stale tiles beat broken demos. `X-Cache-Status` exposes HIT/MISS/STALE             |
+
+Do not "simplify" the `/assets/data/` block to `expires 1h` — `expires`
+emits only `max-age`, dropping the deliberate `public`/`must-revalidate`.
+
+Known pre-existing quirk (untouched, do not cargo-cult): the `/assets/`
+block emits a duplicate `Cache-Control` (one from `expires 1y`, one from
+`add_header`).
+
+## Compression
+
+Build-time precompression (`scripts/precompress.mjs`, gzip-9) + `gzip_static
+on;` serves `.gz` siblings; dynamic/proxied responses (pygeoapi JSON arrives
+uncompressed from origin) use `gzip_comp_level 6` + `application/geo+json`
+in `gzip_types`. The stock `nginx:1.31` image (Renovate-managed) has **no
+brotli module** — `.br` serving requires an image change, tracked in #876.
+
+## Verifying changes
+
+`docker compose build && docker compose up -d`, then `nginx -t` inside the
+container and `curl -sI` the three path classes (data JSON, hashed bundle,
+GetMap twice for MISS→HIT). `docker compose down -v` after. Local compose
+needs `VITE_DIGITRANSIT_KEY` in the environment.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -83,12 +83,13 @@ EventBus emits 'showBuilding'
 
 The app exposes Cesium and Pinia state on `window` in E2E mode (`VITE_E2E_TEST=true`):
 
-| Variable             | Set by                       | Contains                         |
-| -------------------- | ---------------------------- | -------------------------------- |
-| `window.__cesium`    | `useViewerInitialization.js` | Cesium module                    |
-| `window.__viewer`    | `useViewerInitialization.js` | Cesium.Viewer instance           |
-| `window.Cesium`      | NOT set by app               | Only set by CI mock fixture      |
-| `window.globalStore` | `src/main.js`                | Live Pinia globalStore reference |
+| Variable             | Set by                       | Contains                                                                                                       |
+| -------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `window.__cesium`    | `useViewerInitialization.js` | Cesium module                                                                                                  |
+| `window.__viewer`    | `useViewerInitialization.js` | Cesium.Viewer instance                                                                                         |
+| `window.Cesium`      | NOT set by app               | Only set by CI mock fixture                                                                                    |
+| `window.globalStore` | `src/main.js`                | Live Pinia globalStore reference                                                                               |
+| `window.__perfStats` | `src/utils/perfStats.js`     | Perf counters (limiter queue-wait, cache hit/miss/bytes, requestRender count); `reset()` zeroes between trials |
 
 Test helpers must check `window.__cesium || window.Cesium` — never just `window.Cesium`.
 
@@ -300,6 +301,18 @@ it('…fps…', async (ctx) => {
 ```
 
 The viewer is exposed as `window.__viewer` (double underscore, gated on `VITE_E2E_TEST`) — never `window.cesiumViewer`. The Performance Tests CI job runs **only on push-to-`main`, not on PRs**, and is not a merge gate, so a PR check won't catch breakage here — verify locally with `just test-performance`.
+
+## No Wall-Clock Comparison Assertions in Unit Tests
+
+Never assert that one implementation is faster than another by comparing
+measured durations (`expect(newMs).toBeLessThan(oldMs)`). At small absolute
+magnitudes (sub-15 ms), JIT warmup and GC noise on shared CI runners can make
+the "slow" implementation win any single run — PR #874's benchmark failed CI
+at 14.56 ms vs 14.07 ms exactly this way, despite a real 14× speedup on other
+runs. Keep benchmark timings as informational `console.log` output and assert
+correctness via behavior-equivalence checks instead. If a perf property must
+be enforced, enforce it via the dedicated performance suite with baselines
+(`tests/performance-baselines.json`), not inline unit assertions.
 
 ## Feature Flag Defaults Affect Test Assertions
 

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -230,6 +230,11 @@ server {
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header Pragma "no-cache" always;
         add_header Expires "0" always;
+        # Re-declare security headers: location-level add_header suppresses
+        # ALL inherited server-level add_header directives (see /assets/data/).
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         try_files $uri =404;
     }
 
@@ -262,6 +267,10 @@ server {
     # Rule 2: Aggressively cache hashed assets (they're immutable)
     location /assets/ {
         add_header Cache-Control "public, max-age=31536000, immutable" always;
+        # Re-declare security headers (suppressed by the add_header above).
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         expires 1y;
         access_log off;
         try_files $uri =404;
@@ -270,6 +279,10 @@ server {
     # Rule 3: Don't cache unhashed static assets
     location ~* \.(svg|png|jpg|jpeg|gif|ico|webp)$ {
         add_header Cache-Control "no-cache" always;
+        # Re-declare security headers (suppressed by the add_header above).
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         try_files $uri =404;
     }
 
@@ -278,6 +291,10 @@ server {
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header Pragma "no-cache" always;
         add_header Expires "0" always;
+        # Re-declare security headers (suppressed by the add_header above).
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         try_files $uri $uri/ /index.html;
     }
 
@@ -290,6 +307,10 @@ server {
         proxy_read_timeout 5s;
         proxy_cache off;
         add_header Cache-Control "no-cache, no-store" always;
+        # Re-declare security headers (suppressed by the add_header above).
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     }
 
     # FIXED: Updated to match Vite configuration (removed _2024 suffix)
@@ -410,9 +431,9 @@ server {
         proxy_send_timeout 60s;
         proxy_read_timeout 60s;
 
-        # Enable compression
-        gzip on;
-        gzip_types image/jpeg image/png image/gif;
+        # No gzip override here: JPEG/PNG/GIF tiles are already compressed —
+        # gzipping them wastes CPU and can grow the payload. Text responses
+        # (GetCapabilities XML etc.) inherit the server-level gzip settings.
         rewrite ^/helsinki-wms(.*)$ /ws/geoserver/avoindata/ows$1 break;
     }
 


### PR DESCRIPTION
## Summary

Codifies the durable learnings from the 2026-06-10 Wave-0 performance investigation and optimization wave (PRs #873–#880) into `.claude/rules/` so future sessions inherit them — and fixes the nginx header/compression issues the review surfaced in the process.

- **testing.md** — `window.__perfStats` added to the E2E globals table (#873); new rule banning wall-clock comparison assertions in unit tests (the #874 CI flake: 14.56 ms vs 14.07 ms JIT noise)
- **architecture.md** — measured bulk-entity-styling facts (#880/WO-3: mid-pass yields cause O(N) material rebuilds; `suspendEvents` alone doesn't stop them; in-place `setValue()` pegs `StaticGeometryColorBatch`); HSY outage resilience stack (#877/#878) replacing the stale "circuit breaker is the next lever" note; deck.gl flag-renderer invariants (#879: lazy-chunk, shared palette)
- **development.md** — build precompression step (#877); conventional merge-commit subjects (the `conventional-pre-commit` hook rejects git's default merge message; per review, pass `-m` on the merge itself so conflict-free merges don't auto-commit a failing subject)
- **nginx.md** (new, path-scoped to `nginx/**`/`Dockerfile`/`docker-compose*`) — the three verified traps from #877: `add_header` location-level inheritance suppression, outbound SNI (`proxy_ssl_server_name`), cache policy by path class; plus compression setup and the container verification loop

## nginx fix (from review feedback)

The gemini-code-assist review pointed out that `nginx/default.conf.template` itself violated the new `add_header` inheritance rule. Verified and fixed:

- **Re-declared the security headers** (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`) in every location that sets its own `add_header`: `/index.html`, `/assets/`, the unhashed-static regex location (missed by the review, same violation), `/`, and `/feature-flags/` — previously these silently dropped all server-level headers. `/assets/data/` already did this correctly and served as the pattern.
- **Removed the `gzip_types image/jpeg image/png image/gif` override** in `/helsinki-wms` — gzipping already-compressed tile formats wastes CPU per response; text responses (GetCapabilities XML) now inherit the server-level gzip settings.

## Verification

- Rules claims cite the PR and measurement they came from; the nginx facts were verified against nginx.org docs and empirically in the container during #877.
- nginx changes verified in `nginx:1.31-alpine`: template rendered via envsubst, `nginx -t` passes, and `curl -sI` against `/index.html` and `/` (SPA fallback) now returns all three security headers alongside the Cache-Control set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
