### PR TITLE
fix(nginx): repair GOFF relay proxying — path rewrite, websocket, API key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,13 @@ ENV VITE_VTT_API_HOST=130.188.4.230
 # DNS resolver: "auto" means detect from /etc/resolv.conf at startup
 # This works in both Docker (127.0.0.11) and Kubernetes (kube-dns ClusterIP)
 ENV NGINX_DNS_RESOLVER=auto
+# GOFF relay evaluation key, injected into proxied /feature-flags/ requests by
+# nginx (see default.conf.template). MUST stay defined (even empty): the nginx
+# image's envsubst-on-templates only substitutes variables present in the
+# environment — an undefined var leaves a literal ${GOFF_API_KEY} that nginx
+# parses as an unknown nginx variable and refuses to start. Production
+# overrides this via a Secret-backed env var on the Deployment.
+ENV GOFF_API_KEY=""
 
 # Install dbmate and postgresql-client for migrations
 RUN apt-get update && apt-get install -y \

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -298,11 +298,43 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # GO Feature Flag relay proxy — websocket (flag-change push channel).
+    # The GOFF web provider's initialize() requires this socket; without it the
+    # app silently falls back to local flag defaults. The relay authenticates
+    # the websocket via the `apiKey` query parameter ONLY (the Authorization
+    # header is rejected on this endpoint — verified against relay v1.50.1),
+    # so the rewrite injects the key server-side; it never ships in the JS
+    # bundle. Empty ${GOFF_API_KEY} yields a 401 and the app degrades to
+    # fallback defaults, same as an unreachable relay.
+    location /feature-flags/ws/ {
+        set $goff_host "gofeatureflag-relay-proxy.feature-flags.svc.cluster.local";
+        rewrite ^/feature-flags/(.*)$ /$1?apiKey=${GOFF_API_KEY} break;
+        proxy_pass http://$goff_host:1031;
+        proxy_set_header Host $goff_host;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_connect_timeout 3s;
+        # Long-lived socket: GOFF pushes flag-change events over it. The 5s
+        # read timeout of the HTTP block below would sever it immediately.
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+    }
+
     # GO Feature Flag relay proxy (OFREP endpoint)
     location /feature-flags/ {
         set $goff_host "gofeatureflag-relay-proxy.feature-flags.svc.cluster.local";
-        proxy_pass http://$goff_host:1031/;
+        # proxy_pass with a variable host passes its URI part LITERALLY — the
+        # previous `proxy_pass http://$goff_host:1031/;` sent every request to
+        # the relay as `GET /`, so /feature-flags/health hit a 404 and the app
+        # always fell back to local defaults. Rewrite first, then pass without
+        # a URI part (same pattern as the pygeoapi block below).
+        rewrite ^/feature-flags/(.*)$ /$1 break;
+        proxy_pass http://$goff_host:1031;
         proxy_set_header Host $goff_host;
+        # Relay evaluation endpoints require an API key (Bearer works for
+        # HTTP). Injected server-side so the key stays out of the bundle.
+        proxy_set_header Authorization "Bearer ${GOFF_API_KEY}";
         proxy_connect_timeout 3s;
         proxy_read_timeout 5s;
         proxy_cache off;

--- a/vite.config.js
+++ b/vite.config.js
@@ -318,6 +318,11 @@ export default defineConfig(({ mode }) => {
 				'/feature-flags': {
 					target: 'http://localhost:1031',
 					changeOrigin: true,
+					// The GOFF web provider's initialize() requires the
+					// /feature-flags/ws/* websocket — without ws proxying it
+					// always falls back to local defaults (masked in dev by
+					// the enable-all-flags dev fallback).
+					ws: true,
 					rewrite: (path) => path.replace(/^\/feature-flags/, ''),
 				},
 				'/hsy-action': {
@@ -361,6 +366,7 @@ export default defineConfig(({ mode }) => {
 				'/feature-flags': {
 					target: 'http://localhost:1031',
 					changeOrigin: true,
+					ws: true,
 					rewrite: (path) => path.replace(/^\/feature-flags/, ''),
 				},
 			},


### PR DESCRIPTION
## What

Fixes the client-side half of "feature flags don't work on r4c-beta / prod": the in-container nginx `/feature-flags/` proxy was broken in three independent ways, so the GOFF provider could never initialize and the app always degraded to local fallback flag defaults.

## Root causes & fixes

1. **Path mangling (the smoking gun).** `proxy_pass http://$goff_host:1031/;` uses a variable host **and** a URI part — nginx then passes the URI part *literally*, so every request reached the relay as `GET /` (404). The app's health check (`/feature-flags/health`) therefore failed instantly on every page load → immediate fallback. Fixed with rewrite-then-pass (same pattern the pygeoapi block in this file already uses). Verified empirically with an A/B nginx test.
2. **No websocket support.** `GoFeatureFlagWebProvider.initialize()` is `Promise.all([fetchAll, connectWebsocket])` — the `wss://…/feature-flags/ws/v1/flag/change` socket is a hard requirement. The location had no `proxy_http_version 1.1` / `Upgrade` headers (handshake can never succeed) and a 5 s read timeout (would sever the socket anyway). Added a dedicated `/feature-flags/ws/` location with upgrade headers and long timeouts. This is also the likely real cause of the recurring Sentry websocket-timeout noise (#735) — not "slow handshakes".
3. **No API key.** The deployed relay (v1.50.1) requires an evaluation key on all evaluation endpoints; the app sends none. nginx now injects it server-side — `Authorization: Bearer` for HTTP, `apiKey` query param for the websocket (the relay rejects header auth on the ws endpoint; verified against a local relay v1.50.1). The key never ships in the JS bundle. **No r4c key is provisioned yet** — see follow-up below; with an empty key the app degrades exactly as today.

Also: `ws: true` on the Vite dev/preview `/feature-flags` proxies (the same websocket failure existed locally, masked by the dev enable-all-flags fallback).

## Verification

Full matrix through the **rendered production template** (stock `nginx:1.31` envsubst) against a local `gofeatureflag/go-feature-flag:v1.50.1` with an authorized test key:

| Request | Before | After |
|---|---|---|
| `GET /feature-flags/health` | 404 (relay saw `GET /`) | **200** |
| `POST /feature-flags/v1/allflags` | 404/401 | **200** (real evaluation payload) |
| WS `/feature-flags/ws/v1/flag/change` | no upgrade possible | **101** |
| Empty `GOFF_API_KEY` | — | health 200, evaluation 401 → graceful fallback (status quo) |

`nginx -t` passes on the rendered template. `GOFF_API_KEY` is defined (empty) in the Dockerfile so envsubst always substitutes it — an undefined var would leave a literal `${GOFF_API_KEY}` that nginx parses as an unknown variable and refuses to start.

## Follow-ups (required for end-to-end flags)

- ForumViriumHelsinki/infrastructure#2019 — provision the r4c GOFF evaluation key + wire `GOFF_API_KEY` into deploy values (until then the app keeps using fallback defaults, same as today)
- ForumViriumHelsinki/infrastructure#2018 — `/oauth2/userinfo` gone after Envoy OIDC migration → app identity always anonymous, so email-targeted flags can't match (the "auth isn't working" half of the report)
- ForumViriumHelsinki/infrastructure#2020 — `r4c-deckgl-renderer` missing from the relay flag config

🤖 Generated with [Claude Code](https://claude.com/claude-code)
