### PR TITLE
ci: migrate release-please to org reusable workflow with CI App token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,24 +1,24 @@
+name: release-please
+
 on:
   push:
     branches:
       - main
-      # Support backport release branches (e.g., release-1.22.x)
-      # Pattern must NOT match release-please PR branches (release-please--branches--*)
-      - 'release-[0-9]+.[0-9]+.x'
+  # Manual re-run escape hatch (e.g. to cut a release missed by a failed run)
+  workflow_dispatch: {}
 
-permissions:
-  contents: write
-  pull-requests: write
-
-name: release-please
-
+# Authenticates via the org CI GitHub App (short-lived installation tokens,
+# no PAT rotation) — see infrastructure/docs/CI_GITHUB_APP_SETUP.md.
+# CI_APP_PRIVATE_KEY availability is gated on the repo's release-please
+# topic in infrastructure/github/repos.json.
+#
+# The release-1.22.x branch trigger was removed with ADR-008: the branch is
+# frozen (no more backport releases); the legacy v1.22.6 deployment is pinned
+# in the infrastructure repo.
 jobs:
   release-please:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: googleapis/release-please-action@v5
-        with:
-          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
-          target-branch: ${{ github.ref_name }}
+    uses: ForumViriumHelsinki/.github/.github/workflows/reusable-release-please.yml@main
+    with:
+      app-id: ${{ vars.CI_APP_ID }}
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.CI_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## What

Migrates release-please from an inline `googleapis/release-please-action@v5` + `MY_RELEASE_PLEASE_TOKEN` PAT to the org reusable workflow authenticating via the **CI GitHub App** (`app-id: vars.CI_APP_ID` + `secrets.CI_APP_PRIVATE_KEY`) — the same pattern the infrastructure repo already uses. Adds `workflow_dispatch` for manual re-runs.

## Why

The org PAT went bad between 2026-06-09 and 2026-06-11: release-please runs on `main` now fail with `Bad credentials`, and the **v1.53.0 release PR (#883) merged but was never tagged** — no release, no 1.53.0 image. App installation tokens are short-lived and auto-generated per run, so this expiry class disappears. This also brings the repo into compliance with the org rule that application repos call the reusable workflows.

Also drops the `release-[0-9]+.[0-9]+.x` branch trigger (and its `target-branch` passthrough, which the reusable workflow doesn't expose): `release-1.22.x` is frozen per [ADR-008](docs/adr/ADR-008-legacy-version-gateway-routing.md) — no more backport releases.

## ⚠️ Merge ordering

**Merge only after [infrastructure#2021](https://github.com/ForumViriumHelsinki/infrastructure/pull/2021) is merged and the `infrastructure-github` Terraform Cloud workspace has applied** — `CI_APP_PRIVATE_KEY` only becomes visible to this repo once the `release-please` topic lands via Terraform.

## Post-merge

- [ ] Dispatch the workflow (or push to main) and confirm the "Generate GitHub App token" step succeeds
- [ ] Confirm v1.53.0 gets tagged + released, and `container-release` promotes the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)
