### PR TITLE
fix(grid): map short color schemes proportionally in getGridColorString

### DIFF
--- a/src/utils/gridColorMapping.js
+++ b/src/utils/gridColorMapping.js
@@ -84,9 +84,13 @@ export const indexToColorScheme = {
 /**
  * Resolve an index value (0-1) to its threshold color hex string.
  *
- * Color schemes carry 2 "missing data" entries at indices 0-1, then 5 threshold
- * colors at indices 2-6. Thresholds: < 0.2 (2), 0.2-0.4 (3), 0.4-0.6 (4),
- * 0.6-0.8 (5), > 0.8 (6). Direct comparison avoids array allocation.
+ * Full-length schemes (`heatColors`, `floodColors`) carry 2 "missing data"
+ * entries at indices 0-1, then 5 threshold colors at indices 2-6. Shorter
+ * schemes (`greenSpaceColors`, `partialHeatColors`, `partialFloodColors`)
+ * have no placeholders — their 5 threshold colors start at index 0. A
+ * length-based offset selects the right starting index so both shapes map
+ * the thresholds < 0.2, 0.2-0.4, 0.4-0.6, 0.6-0.8, > 0.8 to consecutive
+ * entries (#882). Direct comparison avoids array allocation.
  *
  * @param {number} indexValue - The index value (0-1 range)
  * @param {string} indexType - The index type key for color scheme lookup
@@ -95,15 +99,19 @@ export const indexToColorScheme = {
 export function getGridColorString(indexValue, indexType) {
 	const colorScheme = indexToColorScheme[indexType] || heatColors
 
+	// 2 placeholder entries ("Incomplete data" / "Missing values") only exist
+	// on the full 7-entry schemes; shorter schemes index thresholds from 0.
+	const offset = colorScheme.length > 5 ? 2 : 0
+
 	let colorIndex
 	if (indexValue < 0.2) {
-		colorIndex = 2
+		colorIndex = offset
 	} else if (indexValue < 0.4) {
-		colorIndex = 3
+		colorIndex = offset + 1
 	} else if (indexValue < 0.6) {
-		colorIndex = 4
+		colorIndex = offset + 2
 	} else if (indexValue < 0.8) {
-		colorIndex = 5
+		colorIndex = offset + 3
 	} else {
 		colorIndex = colorScheme.length - 1 // > 0.8
 	}

--- a/tests/unit/utils/gridColorMapping.test.ts
+++ b/tests/unit/utils/gridColorMapping.test.ts
@@ -25,6 +25,81 @@ describe('gridColorMapping', () => {
 			expect(getGridColorString(value, 'heat_index')).toBe(expected)
 		})
 
+		// Regression net for #882: the other full 7-entry scheme must keep mapping
+		// from index 2 (placeholders at 0-1), byte-identical to pre-fix behavior.
+		it.each([
+			[0.0, '#c6dbef'],
+			[0.19, '#c6dbef'],
+			[0.2, '#9ecae1'],
+			[0.39, '#9ecae1'],
+			[0.4, '#6baed6'],
+			[0.59, '#6baed6'],
+			[0.6, '#3182bd'],
+			[0.79, '#3182bd'],
+			[0.8, '#08519c'],
+			[1.0, '#08519c'],
+		])('flood_index value %f -> %s', (value, expected) => {
+			expect(getGridColorString(value, 'flood_index')).toBe(expected)
+		})
+
+		// #882: greenSpaceColors has no placeholder entries — its 5 threshold
+		// colors start at index 0, so values < 0.6 must hit the darker greens
+		// instead of overshooting by the placeholder offset.
+		it.each([
+			[0.0, '#006d2c'],
+			[0.19, '#006d2c'],
+			[0.2, '#31a354'],
+			[0.39, '#31a354'],
+			[0.4, '#74c476'],
+			[0.59, '#74c476'],
+			[0.6, '#a1d99b'],
+			[0.79, '#a1d99b'],
+			[0.8, '#e5f5e0'],
+			[1.0, '#e5f5e0'],
+		])('green value %f -> %s', (value, expected) => {
+			expect(getGridColorString(value, 'green')).toBe(expected)
+		})
+
+		// #882: partialHeatColors = heatColors.slice(2) — same threshold colors,
+		// indexed from 0.
+		it.each([
+			[0.0, '#ffffcc'],
+			[0.19, '#ffffcc'],
+			[0.2, '#ffeda0'],
+			[0.39, '#ffeda0'],
+			[0.4, '#feb24c'],
+			[0.59, '#feb24c'],
+			[0.6, '#f03b20'],
+			[0.79, '#f03b20'],
+			[0.8, '#bd0026'],
+			[1.0, '#bd0026'],
+		])('partialHeat value %f -> %s', (value, expected) => {
+			expect(getGridColorString(value, 'partialHeat')).toBe(expected)
+		})
+
+		// #882: partialFloodColors = floodColors.slice(2) — same threshold colors,
+		// indexed from 0.
+		it.each([
+			[0.0, '#c6dbef'],
+			[0.19, '#c6dbef'],
+			[0.2, '#9ecae1'],
+			[0.39, '#9ecae1'],
+			[0.4, '#6baed6'],
+			[0.59, '#6baed6'],
+			[0.6, '#3182bd'],
+			[0.79, '#3182bd'],
+			[0.8, '#08519c'],
+			[1.0, '#08519c'],
+		])('partialFlood value %f -> %s', (value, expected) => {
+			expect(getGridColorString(value, 'partialFlood')).toBe(expected)
+		})
+
+		// #882: flood_exposure shares greenSpaceColors — spot-check lower bands.
+		it('maps flood_exposure lower bands through greenSpaceColors from index 0', () => {
+			expect(getGridColorString(0.1, 'flood_exposure')).toBe('#006d2c')
+			expect(getGridColorString(0.5, 'flood_exposure')).toBe('#74c476')
+		})
+
 		it('falls back to heatColors for an unknown index type', () => {
 			expect(getGridColorString(0.5, 'totally_unknown_index')).toBe('#feb24c')
 		})


### PR DESCRIPTION
Fixes #882

## What

`getGridColorString` hardcoded color indices 2–5 for values < 0.8, assuming every scheme carries the two "Incomplete data"/"Missing values" placeholder entries at indices 0–1. The 5-entry schemes — `greenSpaceColors` (used by `green`/`flood_exposure`), `partialHeatColors`, `partialFloodColors` — have no placeholders, so every value < 0.6 mapped one-to-two bands too high (e.g. `green` `0.1` → `#74c476` instead of `#006d2c`). Only the > 0.8 bucket was accidentally correct via the `Math.min` clamp.

## Fix

A length-based offset (`colorScheme.length > 5 ? 2 : 0`), exactly as prescribed in #882:

- **7-entry schemes** (`heatColors`, `floodColors`): offset 2 → indices 2/3/4/5/6 — byte-identical to previous behavior.
- **5-entry schemes**: offset 0 → indices 0/1/2/3/4 — all bands now correct.

The palette is **shared by both the Cesium renderer** (`composables/useGridStyling.js`, always on — so this fixes live Cesium output) **and the deck.gl renderer** (`components/DeckGlGridView.vue`); the fix lands in `src/utils/gridColorMapping.js` only, never forked.

## Tests (the regression net)

`tests/unit/utils/gridColorMapping.test.ts` adds full 10-point band tables for `green`, `partialHeat`, and `partialFlood` (the fixed schemes), plus a `flood_index` band table alongside the existing `heat_index` one proving the 7-entry mapping is unchanged.

Note: this change was authored via the GitHub API from a sandbox without local test execution — the unit-test CI gate on this PR is the verification run. The 4 a11y/E2E checks are known-red on all PRs (broken `main`, #897).

## Follow-up

- [ ] Visual re-verification of the Cesium grid for green-space / partial indices (issue #882 acceptance item)

🤖 Generated with [Claude Code](https://claude.com/claude-code)