### PR TITLE
fix(urbanheat): gate locationUnder40 on locationunder40 field

### DIFF
--- a/src/services/urbanheat.js
+++ b/src/services/urbanheat.js
@@ -251,10 +251,11 @@ export const HEAT_MERGE_YIELD_INTERVAL = 500
  * Copies the heat-exposure attributes from a matched heat feature onto the
  * building's properties and decodes the building's own coded fields.
  *
- * Behaviour is identical to the per-match block of the previous linear scan:
- * each field is copied only when present on the heat feature, and the building's
+ * Behaviour matches the per-match block of the previous linear scan — each
+ * field is copied only when present on the heat feature, and the building's
  * coded fields (`c_julkisivu`, `c_rakeaine`, …) are decoded only for matched
- * buildings.
+ * buildings — except that `locationUnder40` is now gated on `locationunder40`
+ * (the old scan gated it on `distancetounder40` by mistake; see #881).
  *
  * @param {Object} properties - Properties of the building to enrich (mutated in place).
  * @param {Object} heatProps - Properties of the matched heat feature.
@@ -269,7 +270,7 @@ const applyHeatAttributes = (properties, heatProps, decodingService) => {
 		properties.distanceToUnder40 = heatProps.distancetounder40
 	}
 
-	if (heatProps.distancetounder40) {
+	if (heatProps.locationunder40) {
 		properties.locationUnder40 = heatProps.locationunder40
 	}
 

--- a/tests/unit/services/urbanheat.test.js
+++ b/tests/unit/services/urbanheat.test.js
@@ -38,6 +38,10 @@ vi.mock('@/services/unifiedLoader.js', () => ({
  * Faithful re-implementation of the previous merge algorithm (without the
  * per-25-feature idle yields, which never affected the *output*). Used as the
  * equivalence oracle and the benchmark baseline.
+ *
+ * One deliberate divergence from the historical scan: `locationUnder40` is
+ * gated on `locationunder40` rather than `distancetounder40`, matching the
+ * #881 fix, so the equivalence assertions verify the *corrected* behaviour.
  */
 function oldMergeReference(buildingFeatures, heatFeatures) {
 	const decodingService = new Decoding()
@@ -53,7 +57,7 @@ function oldMergeReference(buildingFeatures, heatFeatures) {
 				if (hp.distancetounder40) {
 					properties.distanceToUnder40 = hp.distancetounder40
 				}
-				if (hp.distancetounder40) {
+				if (hp.locationunder40) {
 					properties.locationUnder40 = hp.locationunder40
 				}
 				if (hp.year_of_construction) {
@@ -141,6 +145,32 @@ describe('mergeHeatFeaturesIntoBuildings', () => {
 		expect(props.kayttotarkoitus).toBe('Yhden asunnon talot')
 	})
 
+	it('sets locationUnder40 when locationunder40 is present but distancetounder40 is absent (#881)', async () => {
+		const buildings = [building('A')]
+		const heatFeatures = [heat('A', { distancetounder40: undefined })]
+
+		await mergeHeatFeaturesIntoBuildings(buildings, heatFeatures)
+
+		const props = buildings[0].properties
+		// Pre-#881 the locationUnder40 copy was gated on distancetounder40,
+		// silently dropping the cold point for exactly this shape of feature.
+		expect(props.locationUnder40).toBe('north')
+		expect(props.distanceToUnder40).toBeUndefined()
+	})
+
+	it('does not set locationUnder40 when locationunder40 is absent even if distancetounder40 is present (#881)', async () => {
+		const buildings = [building('A')]
+		const heatFeatures = [heat('A', { locationunder40: undefined })]
+
+		await mergeHeatFeaturesIntoBuildings(buildings, heatFeatures)
+
+		const props = buildings[0].properties
+		expect(props.distanceToUnder40).toBe(10)
+		// Pre-#881 this assigned `undefined` to locationUnder40; the key must
+		// now be absent entirely, not present-with-undefined.
+		expect('locationUnder40' in props).toBe(false)
+	})
+
 	it('leaves an unmatched building untouched', async () => {
 		const buildings = [building('A'), building('NO_MATCH')]
 		const heatFeatures = [heat('A')]
@@ -219,9 +249,21 @@ describe('mergeHeatFeaturesIntoBuildings', () => {
 			building('id_5'), // duplicate of an existing id
 		]
 		// Heat: matches for most ids (shuffled), a couple of orphans, one no-key,
-		// and a second feature for the duplicated id.
+		// and a second feature for the duplicated id. Mix in #881-relevant shapes:
+		// some features missing distancetounder40, some missing locationunder40.
 		const heatSpecs = [
-			...ids.filter((_, i) => i % 7 !== 0).map((id) => heat(id)),
+			...ids
+				.filter((_, i) => i % 7 !== 0)
+				.map((id, i) =>
+					heat(
+						id,
+						i % 5 === 1
+							? { distancetounder40: undefined }
+							: i % 5 === 3
+								? { locationunder40: undefined }
+								: {}
+					)
+				),
 			heat('ORPHAN_A'),
 			heat('ORPHAN_B'),
 			heat(undefined),


### PR DESCRIPTION
## What

Fixes the `locationUnder40` copy in `applyHeatAttributes` (`src/services/urbanheat.js`): the value is copied from `heatProps.locationunder40`, but the guarding condition read `heatProps.distancetounder40`. The gate now checks the field actually being copied.

## Why

`locationUnder40` is consumed downstream by `featurepicker/buildingHandler.js` (`coldAreaService.addColdPoint`). With the wrong guard:

- `distancetounder40` falsy but `locationunder40` present → `locationUnder40` was **not** copied (cold point silently dropped).
- `distancetounder40` truthy but `locationunder40` missing → `locationUnder40` was set to `undefined`.

This is a pre-existing latent bug deliberately preserved by the behavior-equivalent hash-join refactor in #874 (flagged by Gemini there); split out as its own `fix:` per the issue.

## How

- `src/services/urbanheat.js`: gate changed to `if (heatProps.locationunder40)`; `applyHeatAttributes` JSDoc notes the intentional divergence from the old scan.
- `tests/unit/services/urbanheat.test.js`:
  - Two regression tests: `locationUnder40` is set when `locationunder40` is present but `distancetounder40` is absent; and the key is absent entirely (not present-with-`undefined`) when `locationunder40` is missing even if `distancetounder40` is present.
  - The equivalence oracle (`oldMergeReference`) is updated to the corrected gate — per the issue, the bug is **not** carried into the oracle — and the randomized fixture now mixes in features missing one of the two fields so the equivalence assertion exercises the divergent shapes.

Fixes #881

> Note: the 4 a11y/E2E checks are known-red on all PRs (broken `main`, #897); unit/lint/typecheck/build are the meaningful gates here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)