### PR TITLE
fix(tests): align ConstantProperty stubs with setup.js getValue convention

### DIFF
--- a/tests/fixtures/cesium-fixture.ts
+++ b/tests/fixtures/cesium-fixture.ts
@@ -483,7 +483,12 @@ export const cesiumTest = base.extend<CesiumFixtures>({
 							}
 						},
 						CallbackProperty: class {},
-						ConstantProperty: class {},
+						ConstantProperty: class {
+							constructor(value) {
+								this._value = value
+								this.getValue = () => value
+							}
+						},
 						SampledProperty: class {
 							addSample(_time, _value) {}
 						},

--- a/tests/mocks/cesium-mock.ts
+++ b/tests/mocks/cesium-mock.ts
@@ -416,7 +416,15 @@ export function createCesiumMock() {
 			}
 		},
 		CallbackProperty: class {},
-		ConstantProperty: class {},
+		ConstantProperty: class {
+			_value: any
+			constructor(value?: any) {
+				this._value = value
+			}
+			getValue() {
+				return this._value
+			}
+		},
 		SampledProperty: class {
 			addSample(_time: any, _value: any) {}
 		},


### PR DESCRIPTION
## What

Replace the two bare `ConstantProperty: class {}` stubs with the `tests/setup.js` convention — a constructor that captures the value and a `getValue()` that returns it:

- `tests/mocks/cesium-mock.ts` (unit-test mock, TypeScript form)
- `tests/fixtures/cesium-fixture.ts` (browser-injected E2E mock, plain-JS form matching the sibling anonymous classes)

## Why

Production reads entity properties via the public `ConstantProperty.getValue()` (see `.claude/rules/architecture.md` "Reading Cesium Entity Properties"). The empty-class stubs construct fine but throw `entity.properties?.x?.getValue is not a function` the moment a code path calls `.getValue()` — the same latent drift that broke the Integration Tests check fixed in #856.

Fixes #869

## Verification

- Unit suite (`bunx vitest run`): 54/54 files, 986 passed, 4 skipped, 0 failed
- E2E smoke comparison (`tests/e2e/accessibility/expansion-panels.spec.ts`, accessibility-desktop, no database): identical results with and without the change — 8 failed / 4 passed, same 8 environmental failures (seeded-data dependent) in both runs. No new failure class.
- Diff verified via branch compare: only the two stub bodies change (+15/−2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)