### PR TITLE
fix(tests): wait out grid-view main-thread wedge in a11y view navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"test:integration": "vitest run tests/integration",
 		"test:e2e": "playwright test tests/e2e",
 		"test:e2e:mock": "playwright test tests/e2e --grep-invert @requires-database",
+		"test:e2e:ci": "bun scripts/test-e2e-ci.mjs",
 		"test:performance": "vitest run --config vitest.performance.config.js",
 		"test:watch": "vitest",
 		"test:coverage": "vitest run --coverage",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -105,8 +105,9 @@ export default defineConfig({
      - View navigation with retries: 5-10s
      - Element interactions: 5-10s
      Total: ~25-35s needed for complex tests
-     CI gets extra buffer for slower/variable environments */
-	timeout: process.env.CI ? 50000 : 40000,
+     CI gets extra buffer for slower/variable environments, including the
+     grid-view data-load quiescence wait on 2-vCPU SwiftShader runners (#897) */
+	timeout: process.env.CI ? 90000 : 40000,
 	/* Bound the entire test run so a runaway process doesn't hold the CI
 	 * runner indefinitely. 30 minutes covers the slowest current full-suite. */
 	globalTimeout: 30 * 60 * 1000,

--- a/scripts/ci-parity.just
+++ b/scripts/ci-parity.just
@@ -1,0 +1,10 @@
+# CI-parity playwright wrapper (#897) — see scripts/test-e2e-ci.mjs.
+#
+# Usage (from the repo root):
+#   just -f scripts/ci-parity.just test-e2e-ci [--skip-build] [playwright args...]
+
+# Run playwright against a production build on :4173 with CI=true,
+# mirroring the GitHub Actions a11y/E2E jobs.
+[no-cd]
+test-e2e-ci *args:
+    bun scripts/test-e2e-ci.mjs {{ args }}

--- a/scripts/test-e2e-ci.mjs
+++ b/scripts/test-e2e-ci.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env bun
+/**
+ * CI-parity E2E/a11y runner (#897).
+ *
+ * The GitHub Actions a11y/E2E jobs (.github/workflows/test.yml) test a
+ * PRODUCTION build served by `bun run preview` on :4173 with CI=true and
+ * SKIP_REQUIRES_DATABASE=true. The default local Playwright setup instead
+ * auto-starts the DEV server on :5173, where MODE === 'development' flips
+ * every feature flag on and the dev server proxies the data endpoints —
+ * so dev-mode runs cannot reproduce CI-only failures.
+ *
+ * This script mirrors the CI environment:
+ *   1. production build with VITE_E2E_TEST=true (skip with --skip-build)
+ *   2. `bun run preview` serving dist/ on :4173
+ *   3. `bunx playwright test` with CI=true + SKIP_REQUIRES_DATABASE=true
+ *
+ * Usage:
+ *   bun run test:e2e:ci -- [--skip-build] [playwright args...]
+ *
+ * Example (reproduce #897):
+ *   bun run test:e2e:ci -- tests/e2e/accessibility/building-filters.spec.ts \
+ *     --project=accessibility-tablet -g "non-grid views only" --repeat-each=5
+ *
+ * Note: :4173 must be free — `vite preview` falls back to another port when
+ * the port is taken, and the CI baseURL is hard-wired to :4173.
+ */
+import { spawn } from 'node:child_process'
+
+const argv = process.argv.slice(2)
+const skipBuild = argv.includes('--skip-build')
+const playwrightArgs = argv.filter((a) => a !== '--skip-build')
+
+const PREVIEW_URL = 'http://localhost:4173/'
+
+function run(cmd, args, env = {}) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(cmd, args, {
+			stdio: 'inherit',
+			env: { ...process.env, ...env },
+		})
+		child.on('exit', (code) => resolve(code ?? 1))
+		child.on('error', reject)
+	})
+}
+
+async function waitForServer(url, timeoutMs = 30000) {
+	const deadline = Date.now() + timeoutMs
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetch(url)
+			if (res.ok) return
+		} catch {
+			// not up yet
+		}
+		await new Promise((r) => setTimeout(r, 500))
+	}
+	throw new Error(`Preview server did not respond at ${url} within ${timeoutMs}ms`)
+}
+
+// 1. Production build with the E2E hook (same artifact as the CI build job)
+if (!skipBuild) {
+	const code = await run('bun', ['run', 'build'], { VITE_E2E_TEST: 'true' })
+	if (code !== 0) process.exit(code)
+}
+
+// 2. Serve dist/ on :4173
+const preview = spawn('bun', ['run', 'preview'], {
+	stdio: ['ignore', 'inherit', 'inherit'],
+	env: { ...process.env },
+})
+const killPreview = () => {
+	if (!preview.killed) preview.kill('SIGTERM')
+}
+process.on('exit', killPreview)
+process.on('SIGINT', () => {
+	killPreview()
+	process.exit(130)
+})
+
+let exitCode = 1
+try {
+	await waitForServer(PREVIEW_URL)
+
+	// 3. CI-parity Playwright run
+	exitCode = await run('bunx', ['playwright', 'test', ...playwrightArgs], {
+		CI: 'true',
+		SKIP_REQUIRES_DATABASE: 'true',
+	})
+} finally {
+	killPreview()
+}
+process.exit(exitCode)

--- a/tests/e2e/accessibility/building-filters.spec.ts
+++ b/tests/e2e/accessibility/building-filters.spec.ts
@@ -19,21 +19,15 @@
  * - Filter functionality is maintained when navigating between non-grid views
  *
  * Ensures all building filter controls remain accessible during interface overhaul.
- *
- * SKIPPED: These tests are currently skipped due to a Vuetify v-navigation-drawer
- * rendering issue in the Playwright test environment. The drawer component does not
- * render its DOM element even when the model value is true, preventing tests from
- * accessing the .map-controls content.
- * See: https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/issues/470
  */
 
 import { expect } from '@playwright/test'
 import { cesiumDescribe, cesiumTest } from '../../fixtures/cesium-fixture'
-import AccessibilityTestHelpers, { TEST_TIMEOUTS } from '../helpers/test-helpers'
+import GridAwareTestHelpers, { TEST_TIMEOUTS } from '../helpers/grid-aware-helpers'
 
 cesiumDescribe('Building Filters Accessibility', () => {
 	cesiumTest.use({ tag: ['@accessibility', '@e2e'] })
-	let helpers: AccessibilityTestHelpers
+	let helpers: GridAwareTestHelpers
 
 	cesiumTest.beforeEach(async ({ cesiumPage }, testInfo) => {
 		// The entire Building Filters section is unmounted (not just CSS-hidden) on
@@ -51,7 +45,7 @@ cesiumDescribe('Building Filters Accessibility', () => {
 			return
 		}
 
-		helpers = new AccessibilityTestHelpers(cesiumPage)
+		helpers = new GridAwareTestHelpers(cesiumPage)
 		// Cesium is already initialized by the fixture
 
 		// Ensure control panel is open (needed for mobile viewports where drawer is closed by default)

--- a/tests/e2e/accessibility/building-filters.spec.ts
+++ b/tests/e2e/accessibility/building-filters.spec.ts
@@ -385,89 +385,97 @@ cesiumDescribe('Building Filters Accessibility', () => {
 			await expect(tallBuildingsToggle).not.toBeChecked()
 		})
 
-		cesiumTest('should handle filter state during navigation levels', async ({ cesiumPage }) => {
-			// Enable filters at start level
-			const publicBuildingsToggle = cesiumPage
-				.getByText('Public Buildings', { exact: true })
-				.locator('..')
-				.locator('input[type="checkbox"]')
-			const tallBuildingsToggle = cesiumPage
-				.getByText('Tall Buildings', { exact: true })
-				.locator('..')
-				.locator('input[type="checkbox"]')
+		cesiumTest(
+			'should handle filter state during navigation levels',
+			{ tag: ['@requires-database'] },
+			async ({ cesiumPage }) => {
+				// Enable filters at start level
+				const publicBuildingsToggle = cesiumPage
+					.getByText('Public Buildings', { exact: true })
+					.locator('..')
+					.locator('input[type="checkbox"]')
+				const tallBuildingsToggle = cesiumPage
+					.getByText('Tall Buildings', { exact: true })
+					.locator('..')
+					.locator('input[type="checkbox"]')
 
-			await helpers.checkWithRetry(publicBuildingsToggle, {
-				elementName: 'Public Buildings filter',
-				force: true,
-			})
-			await helpers.checkWithRetry(tallBuildingsToggle, {
-				elementName: 'Tall Buildings filter',
-				force: true,
-			})
-
-			// Navigate to postal code level
-			await helpers.drillToLevel('postalCode')
-			// Wait for postal code UI instead of fixed timeout
-			await cesiumPage
-				.waitForSelector('text="Building Analysis"', {
-					timeout: TEST_TIMEOUTS.ELEMENT_STANDARD,
+				await helpers.checkWithRetry(publicBuildingsToggle, {
+					elementName: 'Public Buildings filter',
+					force: true,
 				})
-				.catch(() => {})
-
-			// Filters should remain functional
-			await expect(publicBuildingsToggle).toBeVisible()
-			await expect(tallBuildingsToggle).toBeVisible()
-
-			// State may be maintained or reset depending on implementation
-			// Test that they can be toggled
-			await helpers.uncheckWithRetry(publicBuildingsToggle, {
-				elementName: 'Public Buildings filter',
-				force: true,
-			})
-			await helpers.checkWithRetry(publicBuildingsToggle, {
-				elementName: 'Public Buildings filter',
-				force: true,
-			})
-			await expect(publicBuildingsToggle).toBeChecked()
-		})
-
-		cesiumTest('should apply filters to building visualization', async ({ cesiumPage }) => {
-			// Navigate to postal code level where buildings are visible
-			await helpers.drillToLevel('postalCode')
-			// Wait for postal code UI instead of fixed timeout
-			await cesiumPage
-				.waitForSelector('text="Building Analysis"', {
-					timeout: TEST_TIMEOUTS.ELEMENT_STANDARD,
+				await helpers.checkWithRetry(tallBuildingsToggle, {
+					elementName: 'Tall Buildings filter',
+					force: true,
 				})
-				.catch(() => {})
 
-			const tallBuildingsToggle = cesiumPage
-				.getByText('Tall Buildings', { exact: true })
-				.locator('..')
-				.locator('input[type="checkbox"]')
+				// Navigate to postal code level
+				await helpers.drillToLevel('postalCode')
+				// Wait for postal code UI instead of fixed timeout
+				await cesiumPage
+					.waitForSelector('text="Building Analysis"', {
+						timeout: TEST_TIMEOUTS.ELEMENT_STANDARD,
+					})
+					.catch(() => {})
 
-			// Apply filter
-			await helpers.checkWithRetry(tallBuildingsToggle, {
-				elementName: 'Tall Buildings filter',
-				force: true,
-			})
-			// Brief wait for filter to apply
-			await cesiumPage.waitForTimeout(TEST_TIMEOUTS.WAIT_TOOLTIP)
+				// Filters should remain functional
+				await expect(publicBuildingsToggle).toBeVisible()
+				await expect(tallBuildingsToggle).toBeVisible()
 
-			// Filter should be applied (visual changes would occur in Cesium)
-			// We verify the toggle state is consistent
-			await expect(tallBuildingsToggle).toBeChecked()
+				// State may be maintained or reset depending on implementation
+				// Test that they can be toggled
+				await helpers.uncheckWithRetry(publicBuildingsToggle, {
+					elementName: 'Public Buildings filter',
+					force: true,
+				})
+				await helpers.checkWithRetry(publicBuildingsToggle, {
+					elementName: 'Public Buildings filter',
+					force: true,
+				})
+				await expect(publicBuildingsToggle).toBeChecked()
+			}
+		)
 
-			// Remove filter
-			await helpers.uncheckWithRetry(tallBuildingsToggle, {
-				elementName: 'Tall Buildings filter',
-				force: true,
-			})
-			// Brief wait for filter to remove
-			await cesiumPage.waitForTimeout(TEST_TIMEOUTS.WAIT_TOOLTIP)
+		cesiumTest(
+			'should apply filters to building visualization',
+			{ tag: ['@requires-database'] },
+			async ({ cesiumPage }) => {
+				// Navigate to postal code level where buildings are visible
+				await helpers.drillToLevel('postalCode')
+				// Wait for postal code UI instead of fixed timeout
+				await cesiumPage
+					.waitForSelector('text="Building Analysis"', {
+						timeout: TEST_TIMEOUTS.ELEMENT_STANDARD,
+					})
+					.catch(() => {})
 
-			await expect(tallBuildingsToggle).not.toBeChecked()
-		})
+				const tallBuildingsToggle = cesiumPage
+					.getByText('Tall Buildings', { exact: true })
+					.locator('..')
+					.locator('input[type="checkbox"]')
+
+				// Apply filter
+				await helpers.checkWithRetry(tallBuildingsToggle, {
+					elementName: 'Tall Buildings filter',
+					force: true,
+				})
+				// Brief wait for filter to apply
+				await cesiumPage.waitForTimeout(TEST_TIMEOUTS.WAIT_TOOLTIP)
+
+				// Filter should be applied (visual changes would occur in Cesium)
+				// We verify the toggle state is consistent
+				await expect(tallBuildingsToggle).toBeChecked()
+
+				// Remove filter
+				await helpers.uncheckWithRetry(tallBuildingsToggle, {
+					elementName: 'Tall Buildings filter',
+					force: true,
+				})
+				// Brief wait for filter to remove
+				await cesiumPage.waitForTimeout(TEST_TIMEOUTS.WAIT_TOOLTIP)
+
+				await expect(tallBuildingsToggle).not.toBeChecked()
+			}
+		)
 	})
 
 	cesiumTest.describe('Building Filter Performance', () => {
@@ -533,36 +541,40 @@ cesiumDescribe('Building Filters Accessibility', () => {
 			expect(errorCount).toBe(0)
 		})
 
-		cesiumTest('should handle filters during data loading', async ({ cesiumPage }) => {
-			// Intercept requests to simulate slow loading
-			cesiumPage.route('**/*.json', (route) => {
-				setTimeout(() => route.continue(), 1000)
-			})
+		cesiumTest(
+			'should handle filters during data loading',
+			{ tag: ['@requires-database'] },
+			async ({ cesiumPage }) => {
+				// Intercept requests to simulate slow loading
+				cesiumPage.route('**/*.json', (route) => {
+					setTimeout(() => route.continue(), 1000)
+				})
 
-			// Try applying filters during navigation/loading
-			await helpers.drillToLevel('postalCode')
+				// Try applying filters during navigation/loading
+				await helpers.drillToLevel('postalCode')
 
-			// Immediately apply filters
-			const tallBuildingsToggle = cesiumPage
-				.getByText('Tall Buildings', { exact: true })
-				.locator('..')
-				.locator('input[type="checkbox"]')
-			await helpers.checkWithRetry(tallBuildingsToggle, {
-				elementName: 'Tall Buildings filter',
-				force: true,
-			})
+				// Immediately apply filters
+				const tallBuildingsToggle = cesiumPage
+					.getByText('Tall Buildings', { exact: true })
+					.locator('..')
+					.locator('input[type="checkbox"]')
+				await helpers.checkWithRetry(tallBuildingsToggle, {
+					elementName: 'Tall Buildings filter',
+					force: true,
+				})
 
-			// Wait for loading to complete
-			await cesiumPage.waitForTimeout(TEST_TIMEOUTS.WAIT_LONG)
+				// Wait for loading to complete
+				await cesiumPage.waitForTimeout(TEST_TIMEOUTS.WAIT_LONG)
 
-			// Filter state should be consistent
-			await expect(tallBuildingsToggle).toBeChecked()
+				// Filter state should be consistent
+				await expect(tallBuildingsToggle).toBeChecked()
 
-			// No error states
-			const errorElements = cesiumPage.locator('[class*="error"], [class*="Error"]')
-			const errorCount = await errorElements.count()
-			expect(errorCount).toBe(0)
-		})
+				// No error states
+				const errorElements = cesiumPage.locator('[class*="error"], [class*="Error"]')
+				const errorCount = await errorElements.count()
+				expect(errorCount).toBe(0)
+			}
+		)
 	})
 
 	cesiumTest.describe('Building Filter Accessibility', () => {
@@ -830,48 +842,52 @@ cesiumDescribe('Building Filters Accessibility', () => {
 	})
 
 	cesiumTest.describe('Building Filter Integration', () => {
-		cesiumTest('should work with layer controls simultaneously', async ({ cesiumPage }) => {
-			// Navigate to context where both filters and layers are available
-			await helpers.drillToLevel('postalCode')
-			// Wait for postal code UI instead of fixed timeout
-			await cesiumPage
-				.waitForSelector('text="Building Analysis"', {
-					timeout: TEST_TIMEOUTS.ELEMENT_STANDARD,
+		cesiumTest(
+			'should work with layer controls simultaneously',
+			{ tag: ['@requires-database'] },
+			async ({ cesiumPage }) => {
+				// Navigate to context where both filters and layers are available
+				await helpers.drillToLevel('postalCode')
+				// Wait for postal code UI instead of fixed timeout
+				await cesiumPage
+					.waitForSelector('text="Building Analysis"', {
+						timeout: TEST_TIMEOUTS.ELEMENT_STANDARD,
+					})
+					.catch(() => {})
+
+				// Enable building filter
+				const tallBuildingsToggle = cesiumPage
+					.getByText('Tall Buildings', { exact: true })
+					.locator('..')
+					.locator('input[type="checkbox"]')
+				await helpers.checkWithRetry(tallBuildingsToggle, {
+					elementName: 'Tall Buildings filter',
+					force: true,
 				})
-				.catch(() => {})
 
-			// Enable building filter
-			const tallBuildingsToggle = cesiumPage
-				.getByText('Tall Buildings', { exact: true })
-				.locator('..')
-				.locator('input[type="checkbox"]')
-			await helpers.checkWithRetry(tallBuildingsToggle, {
-				elementName: 'Tall Buildings filter',
-				force: true,
-			})
+				// Enable layer toggle — NDVI is also a Vuetify v-switch.
+				const ndviToggle = cesiumPage
+					.getByText('NDVI')
+					.locator('..')
+					.locator('input[type="checkbox"]')
+				await helpers.checkWithRetry(ndviToggle, {
+					elementName: 'NDVI layer',
+					force: true,
+				})
 
-			// Enable layer toggle — NDVI is also a Vuetify v-switch.
-			const ndviToggle = cesiumPage
-				.getByText('NDVI')
-				.locator('..')
-				.locator('input[type="checkbox"]')
-			await helpers.checkWithRetry(ndviToggle, {
-				elementName: 'NDVI layer',
-				force: true,
-			})
+				// Both should be enabled simultaneously
+				await expect(tallBuildingsToggle).toBeChecked()
+				await expect(ndviToggle).toBeChecked()
 
-			// Both should be enabled simultaneously
-			await expect(tallBuildingsToggle).toBeChecked()
-			await expect(ndviToggle).toBeChecked()
-
-			// Both should remain functional
-			await helpers.uncheckWithRetry(tallBuildingsToggle, {
-				elementName: 'Tall Buildings filter',
-				force: true,
-			})
-			await expect(tallBuildingsToggle).not.toBeChecked()
-			await expect(ndviToggle).toBeChecked() // Should not affect layer toggle
-		})
+				// Both should remain functional
+				await helpers.uncheckWithRetry(tallBuildingsToggle, {
+					elementName: 'Tall Buildings filter',
+					force: true,
+				})
+				await expect(tallBuildingsToggle).not.toBeChecked()
+				await expect(ndviToggle).toBeChecked() // Should not affect layer toggle
+			}
+		)
 
 		cesiumTest(
 			'should hide filters in grid view and reset when returning',

--- a/tests/e2e/accessibility/expansion-panels.spec.ts
+++ b/tests/e2e/accessibility/expansion-panels.spec.ts
@@ -1,12 +1,15 @@
 /**
  * Sidebar Panels Accessibility Tests
  *
- * Tests conditional panel/section visibility and interactions for the analysis sidebar:
- * - Universal sections: Background Maps and Data Layers (Layers tab), Search tab
- * - View-specific: Grid Options (grid view), Climate Adaptation (grid + heat_index)
- * - Level-specific analysis tools: Heat Distribution, Building Analysis, Land Cover, etc.
- * - Properties section: Area Properties (postal code), Building Properties (building)
- * - NDVI toggle (visible in all views)
+ * Tests conditional panel/section visibility and interactions for the tabbed
+ * analysis sidebar (Search / Layers / Analysis / Details):
+ * - Universal: Background Maps and Data Layers (Layers tab), Search tab
+ * - View-specific (Analysis tab): Grid Options (grid view), Climate Adaptation
+ *   (grid + heat_index)
+ * - Level-specific (Analysis tab): Building Analysis etc.
+ * - Properties (Details tab): Area Properties (postal code), Building
+ *   Properties (building)
+ * - NDVI toggle (Layers tab, visible in all views)
  */
 
 import { expect } from '@playwright/test'
@@ -51,27 +54,43 @@ cesiumDescribe('Sidebar Panels Accessibility', () => {
 
 	cesiumTest.describe('View-Specific Panels', () => {
 		cesiumTest('should show Grid Options button only in Grid view', async ({ cesiumPage }) => {
+			// Grid Options renders in the Analysis tab (tabbed sidebar refactor);
+			// the view-mode toggle lives in the Layers tab, so switch back before
+			// navigating between views.
+			const analysisTab = cesiumPage.getByRole('tab', { name: 'Analysis' })
+			const layersTab = cesiumPage.getByRole('tab', { name: 'Layers' })
+
 			// Not visible in Capital Region view
+			await analysisTab.click()
 			await expect(cesiumPage.getByText('Grid Options')).toBeHidden()
 
 			// Switch to Grid view
+			await layersTab.click()
 			await helpers.navigateToView('gridView')
 
-			// Now visible as a button
+			// Now visible as a button in the Analysis tab
+			await analysisTab.click()
 			await expect(cesiumPage.getByText('Grid Options')).toBeVisible()
 		})
 
 		cesiumTest(
 			'should show Climate Adaptation only in Grid view with heat index',
 			async ({ cesiumPage }) => {
+				// Climate Adaptation renders in the Analysis tab (tabbed sidebar refactor)
+				const analysisTab = cesiumPage.getByRole('tab', { name: 'Analysis' })
+				const layersTab = cesiumPage.getByRole('tab', { name: 'Layers' })
+
 				// Not visible in Capital Region view
+				await analysisTab.click()
 				await expect(cesiumPage.getByText('Climate Adaptation')).toBeHidden()
 
 				// Switch to Grid view — Climate Adaptation is visible because
 				// statsIndex defaults to 'heat_index' and coolingOptimizer flag defaults to true
+				await layersTab.click()
 				await helpers.navigateToView('gridView')
 
 				// Climate Adaptation should now be visible as an expansion panel
+				await analysisTab.click()
 				await expect(cesiumPage.getByText('Climate Adaptation')).toBeVisible()
 			}
 		)
@@ -88,6 +107,10 @@ cesiumDescribe('Sidebar Panels Accessibility', () => {
 
 	cesiumTest.describe('Level-Specific Analysis Tools', () => {
 		cesiumTest('should show analysis tool buttons at postal code level', async ({ cesiumPage }) => {
+			// Analysis buttons render in the Analysis tab (tabbed sidebar refactor)
+			const analysisTab = cesiumPage.getByRole('tab', { name: 'Analysis' })
+			await analysisTab.click()
+
 			// Not visible at start level
 			await expect(cesiumPage.getByText('Building Analysis')).toBeHidden()
 
@@ -99,6 +122,10 @@ cesiumDescribe('Sidebar Panels Accessibility', () => {
 		})
 
 		cesiumTest('should show Area Properties at postal code level', async ({ cesiumPage }) => {
+			// Properties render in the Details tab (tabbed sidebar refactor)
+			const detailsTab = cesiumPage.getByRole('tab', { name: 'Details' })
+			await detailsTab.click()
+
 			// Properties section not visible at start level
 			await expect(cesiumPage.getByText('Area Properties')).toBeHidden()
 
@@ -115,6 +142,11 @@ cesiumDescribe('Sidebar Panels Accessibility', () => {
 		// where WebGL picking cannot be guaranteed.
 		cesiumTest('should show Building Properties at building level', async ({ cesiumPage }) => {
 			await helpers.drillToLevel('building', undefined, { method: 'store' })
+
+			// Properties render in the Details tab (tabbed sidebar refactor)
+			const detailsTab = cesiumPage.getByRole('tab', { name: 'Details' })
+			await detailsTab.click()
+
 			const buildingProps = cesiumPage.getByText('Building Properties')
 			await expect(buildingProps).toBeVisible()
 		})
@@ -145,8 +177,10 @@ cesiumDescribe('Sidebar Panels Accessibility', () => {
 
 	cesiumTest.describe('Accessibility Compliance', () => {
 		cesiumTest('should have proper navigation landmark', async ({ cesiumPage }) => {
-			// The sidebar should have role="navigation"
-			const sidebar = cesiumPage.locator('[role="navigation"]')
+			// The sidebar should have role="navigation". The page renders more
+			// than one navigation landmark (sidebar + analysis panel), so scope
+			// to the first to keep the locator strict-mode safe.
+			const sidebar = cesiumPage.locator('[role="navigation"]').first()
 			await expect(sidebar).toBeVisible()
 
 			// Should have an aria-label

--- a/tests/e2e/accessibility/expansion-panels.spec.ts
+++ b/tests/e2e/accessibility/expansion-panels.spec.ts
@@ -6,9 +6,10 @@
  * - Universal: Background Maps and Data Layers (Layers tab), Search tab
  * - View-specific (Analysis tab): Grid Options (grid view), Climate Adaptation
  *   (grid + heat_index)
- * - Level-specific (Analysis tab): Building Analysis etc.
+ * - Level-specific (Analysis tab): Building Analysis etc. — these drill to
+ *   postal-code/building level and are tagged @requires-database (#658)
  * - Properties (Details tab): Area Properties (postal code), Building
- *   Properties (building)
+ *   Properties (building) — also @requires-database
  * - NDVI toggle (Layers tab, visible in all views)
  */
 
@@ -106,50 +107,62 @@ cesiumDescribe('Sidebar Panels Accessibility', () => {
 	})
 
 	cesiumTest.describe('Level-Specific Analysis Tools', () => {
-		cesiumTest('should show analysis tool buttons at postal code level', async ({ cesiumPage }) => {
-			// Analysis buttons render in the Analysis tab (tabbed sidebar refactor)
-			const analysisTab = cesiumPage.getByRole('tab', { name: 'Analysis' })
-			await analysisTab.click()
+		cesiumTest(
+			'should show analysis tool buttons at postal code level',
+			{ tag: ['@requires-database'] },
+			async ({ cesiumPage }) => {
+				// Analysis buttons render in the Analysis tab (tabbed sidebar refactor)
+				const analysisTab = cesiumPage.getByRole('tab', { name: 'Analysis' })
+				await analysisTab.click()
 
-			// Not visible at start level
-			await expect(cesiumPage.getByText('Building Analysis')).toBeHidden()
+				// Not visible at start level
+				await expect(cesiumPage.getByText('Building Analysis')).toBeHidden()
 
-			// Navigate to postal code level
-			await helpers.drillToLevel('postalCode')
+				// Navigate to postal code level
+				await helpers.drillToLevel('postalCode')
 
-			// Building Analysis button should appear at postal code level
-			await expect(cesiumPage.getByText('Building Analysis')).toBeVisible()
-		})
+				// Building Analysis button should appear at postal code level
+				await expect(cesiumPage.getByText('Building Analysis')).toBeVisible()
+			}
+		)
 
-		cesiumTest('should show Area Properties at postal code level', async ({ cesiumPage }) => {
-			// Properties render in the Details tab (tabbed sidebar refactor)
-			const detailsTab = cesiumPage.getByRole('tab', { name: 'Details' })
-			await detailsTab.click()
+		cesiumTest(
+			'should show Area Properties at postal code level',
+			{ tag: ['@requires-database'] },
+			async ({ cesiumPage }) => {
+				// Properties render in the Details tab (tabbed sidebar refactor)
+				const detailsTab = cesiumPage.getByRole('tab', { name: 'Details' })
+				await detailsTab.click()
 
-			// Properties section not visible at start level
-			await expect(cesiumPage.getByText('Area Properties')).toBeHidden()
+				// Properties section not visible at start level
+				await expect(cesiumPage.getByText('Area Properties')).toBeHidden()
 
-			// Navigate to postal code level
-			await helpers.drillToLevel('postalCode')
+				// Navigate to postal code level
+				await helpers.drillToLevel('postalCode')
 
-			// Area Properties section heading should appear
-			const areaProps = cesiumPage.getByText('Area Properties')
-			await expect(areaProps).toBeVisible()
-		})
+				// Area Properties section heading should appear
+				const areaProps = cesiumPage.getByText('Area Properties')
+				await expect(areaProps).toBeVisible()
+			}
+		)
 
 		// Building-level navigation uses direct Pinia store manipulation because
 		// clicking a 3D building entity is unreliable in mocked/headless environments
 		// where WebGL picking cannot be guaranteed.
-		cesiumTest('should show Building Properties at building level', async ({ cesiumPage }) => {
-			await helpers.drillToLevel('building', undefined, { method: 'store' })
+		cesiumTest(
+			'should show Building Properties at building level',
+			{ tag: ['@requires-database'] },
+			async ({ cesiumPage }) => {
+				await helpers.drillToLevel('building', undefined, { method: 'store' })
 
-			// Properties render in the Details tab (tabbed sidebar refactor)
-			const detailsTab = cesiumPage.getByRole('tab', { name: 'Details' })
-			await detailsTab.click()
+				// Properties render in the Details tab (tabbed sidebar refactor)
+				const detailsTab = cesiumPage.getByRole('tab', { name: 'Details' })
+				await detailsTab.click()
 
-			const buildingProps = cesiumPage.getByText('Building Properties')
-			await expect(buildingProps).toBeVisible()
-		})
+				const buildingProps = cesiumPage.getByText('Building Properties')
+				await expect(buildingProps).toBeVisible()
+			}
+		)
 	})
 
 	cesiumTest.describe('Panel State Across View Switches', () => {

--- a/tests/e2e/accessibility/expansion-panels.spec.ts
+++ b/tests/e2e/accessibility/expansion-panels.spec.ts
@@ -2,7 +2,7 @@
  * Sidebar Panels Accessibility Tests
  *
  * Tests conditional panel/section visibility and interactions for the analysis sidebar:
- * - Universal sections: Background Maps, Search & Navigate, Map Controls
+ * - Universal sections: Background Maps and Data Layers (Layers tab), Search tab
  * - View-specific: Grid Options (grid view), Climate Adaptation (grid + heat_index)
  * - Level-specific analysis tools: Heat Distribution, Building Analysis, Land Cover, etc.
  * - Properties section: Area Properties (postal code), Building Properties (building)
@@ -28,20 +28,24 @@ cesiumDescribe('Sidebar Panels Accessibility', () => {
 			await expect(cesiumPage.getByText('Background Maps')).toBeVisible()
 		})
 
-		cesiumTest(
-			'should display Search & Navigate section in all contexts',
-			async ({ cesiumPage }) => {
-				// Search & Navigate is a permanent section with UnifiedSearch below
-				await expect(cesiumPage.getByText('Search & Navigate')).toBeVisible()
+		cesiumTest('should provide search via the Search tab in all contexts', async ({ cesiumPage }) => {
+			// The sidebar was refactored into tabs (Search / Layers / Analysis /
+			// Details); the old "Search & Navigate" section heading no longer
+			// exists. Search lives in the dedicated Search tab (#897).
+			const searchTab = cesiumPage.getByRole('tab', { name: 'Search' })
+			await expect(searchTab).toBeVisible()
+			await searchTab.click()
 
-				// Search input should be visible directly (no expansion needed)
-				const searchInput = cesiumPage.getByRole('textbox', { name: /search/i })
-				await expect(searchInput.first()).toBeVisible()
-			}
-		)
+			// Search input should be visible once the Search tab is active
+			const searchInput = cesiumPage.getByRole('textbox', { name: /search/i })
+			await expect(searchInput.first()).toBeVisible()
+		})
 
-		cesiumTest('should display Map Controls section in all contexts', async ({ cesiumPage }) => {
-			await expect(cesiumPage.getByText('Map Controls')).toBeVisible()
+		cesiumTest('should display map layer controls in all contexts', async ({ cesiumPage }) => {
+			// The old "Map Controls" heading was removed in the tabbed-sidebar
+			// refactor; MapControls renders inside the Layers tab under the
+			// "Data Layers" heading (#897).
+			await expect(cesiumPage.getByRole('heading', { name: 'Data Layers' })).toBeVisible()
 		})
 	})
 
@@ -118,23 +122,24 @@ cesiumDescribe('Sidebar Panels Accessibility', () => {
 
 	cesiumTest.describe('Panel State Across View Switches', () => {
 		cesiumTest('should maintain sidebar sections during view switches', async ({ cesiumPage }) => {
-			// Verify universal sections visible
+			// Verify universal sections visible (Search tab replaces the removed
+			// "Search & Navigate" heading — see Universal Sidebar Sections above)
 			await expect(cesiumPage.getByText('Background Maps')).toBeVisible()
-			await expect(cesiumPage.getByText('Search & Navigate')).toBeVisible()
+			await expect(cesiumPage.getByRole('tab', { name: 'Search' })).toBeVisible()
 
 			// Switch view
 			await helpers.navigateToView('gridView')
 
 			// Universal sections should remain visible
 			await expect(cesiumPage.getByText('Background Maps')).toBeVisible()
-			await expect(cesiumPage.getByText('Search & Navigate')).toBeVisible()
+			await expect(cesiumPage.getByRole('tab', { name: 'Search' })).toBeVisible()
 
 			// Switch back
 			await helpers.navigateToView('capitalRegionView')
 
 			// Still visible
 			await expect(cesiumPage.getByText('Background Maps')).toBeVisible()
-			await expect(cesiumPage.getByText('Search & Navigate')).toBeVisible()
+			await expect(cesiumPage.getByRole('tab', { name: 'Search' })).toBeVisible()
 		})
 	})
 

--- a/tests/e2e/accessibility/expansion-panels.spec.ts
+++ b/tests/e2e/accessibility/expansion-panels.spec.ts
@@ -11,14 +11,14 @@
 
 import { expect } from '@playwright/test'
 import { cesiumDescribe, cesiumTest } from '../../fixtures/cesium-fixture'
-import AccessibilityTestHelpers from '../helpers/test-helpers'
+import GridAwareTestHelpers from '../helpers/grid-aware-helpers'
 
 cesiumDescribe('Sidebar Panels Accessibility', () => {
 	cesiumTest.use({ tag: ['@accessibility', '@e2e'] })
-	let helpers: AccessibilityTestHelpers
+	let helpers: GridAwareTestHelpers
 
 	cesiumTest.beforeEach(async ({ cesiumPage }) => {
-		helpers = new AccessibilityTestHelpers(cesiumPage)
+		helpers = new GridAwareTestHelpers(cesiumPage)
 		// Cesium is already initialized by the fixture
 	})
 

--- a/tests/e2e/helpers/grid-aware-helpers.ts
+++ b/tests/e2e/helpers/grid-aware-helpers.ts
@@ -1,0 +1,100 @@
+/**
+ * Quiescence-aware accessibility test helpers (#897).
+ *
+ * Entering grid view mounts SosEco250mGrid, which loads an 8.9 MB GeoJSON
+ * file and creates ~6,700 Cesium entities. On CI runners (2 vCPU, software
+ * WebGL) that load saturates the browser main thread for tens of seconds,
+ * starving every subsequent Playwright page operation (locator resolution,
+ * actionability checks, boundingBox) and pushing the next navigateToView
+ * call through its whole retry ladder into failure. That is the root cause
+ * of the chronic "locator.click: Timeout 2000ms exceeded" failures on
+ * `.view-toggle-group button[value=...]` in the CI a11y jobs.
+ *
+ * GridAwareTestHelpers.navigateToView waits for the destination view to
+ * finish its data load before returning, so the caller's next interaction
+ * runs against a responsive page.
+ *
+ * Kept as a subclass (instead of editing AccessibilityTestHelpers) so specs
+ * can opt in individually; folding this into the base helper for all specs
+ * is tracked as a follow-up of #897.
+ */
+import type { PlaywrightPage } from '../../types/playwright'
+import AccessibilityTestHelpers, { TEST_TIMEOUTS } from './test-helpers'
+
+export { TEST_TIMEOUTS } from './test-helpers'
+
+type ViewModeId = 'capitalRegionView' | 'gridView'
+
+/**
+ * Wait for the app to settle after a view-mode switch.
+ *
+ * Strategy:
+ *   1. Grid view only: wait until the 250m_grid datasource exists and has
+ *      entities (observable via the VITE_E2E_TEST window.__viewer hook).
+ *   2. Wait for one trivially-true page evaluation, which can only resolve
+ *      once the main thread is free again.
+ *
+ * Both waits are non-fatal on timeout so they can never fail an otherwise
+ * passing interaction - the next interaction provides the real signal.
+ */
+export async function waitForViewSwitchQuiescence(
+	page: PlaywrightPage,
+	viewMode: ViewModeId
+): Promise<void> {
+	const timeout = process.env.CI ? 45000 : 10000
+
+	if (viewMode === 'gridView') {
+		try {
+			await page.waitForFunction(
+				() => {
+					// biome-ignore lint/suspicious/noExplicitAny: E2E-only window hook
+					const viewer = (window as any).__viewer
+					// Without the E2E viewer hook the load is not observable;
+					// fall through to the responsiveness probe below.
+					if (!viewer?.dataSources?._dataSources) return true
+					const sources = viewer.dataSources._dataSources as Array<{
+						name?: string
+						entities?: { values?: unknown[] }
+					}>
+					const grid = sources.find((ds) => ds.name?.startsWith('250m_grid'))
+					return !!grid && (grid.entities?.values?.length ?? 0) > 0
+				},
+				undefined,
+				{ timeout }
+			)
+		} catch {
+			console.warn(
+				'[waitForViewSwitchQuiescence] grid datasource did not finish loading in time; continuing'
+			)
+		}
+	}
+
+	try {
+		// Resolves on the first evaluation tick once the main thread is free.
+		await page.waitForFunction(() => true, undefined, { timeout })
+	} catch {
+		console.warn('[waitForViewSwitchQuiescence] main thread still busy; continuing')
+	}
+
+	await page.waitForTimeout(TEST_TIMEOUTS.WAIT_STABILITY)
+}
+
+/**
+ * Drop-in replacement for AccessibilityTestHelpers that waits for
+ * view-switch quiescence after every navigateToView call.
+ */
+export class GridAwareTestHelpers extends AccessibilityTestHelpers {
+	private readonly quiescencePage: PlaywrightPage
+
+	constructor(page: PlaywrightPage) {
+		super(page)
+		this.quiescencePage = page
+	}
+
+	override async navigateToView(viewMode: ViewModeId): Promise<void> {
+		await super.navigateToView(viewMode)
+		await waitForViewSwitchQuiescence(this.quiescencePage, viewMode)
+	}
+}
+
+export default GridAwareTestHelpers


### PR DESCRIPTION
Fixes #897

## Root cause (two independent failures)

**1. Grid-view main-thread wedge (desktop + tablet first failure, `building-filters.spec.ts`).**
Entering grid view mounts `SosEco250mGrid`, which loads an 8.9 MB GeoJSON and creates ~6,700 Cesium entities. On the CI runner (2 vCPU, SwiftShader software WebGL) that load saturates the browser main thread for tens of seconds. `navigateToView()` verified the view switch via the Pinia store and returned **while the wedge was still building**, so the next Playwright operation starved: the CI trace for run 27340631694 shows the gridView click recovering via the mouse fallback ("Successfully navigated to gridView" at 10:33:27), then every operation on the way back to capital region timing out for ~30 s — `locator.click: Timeout 2000ms exceeded` with the locator not even resolving, `waitFor(attached)` timeouts, `boundingBox: Timeout 8000ms exceeded` — until the helper's retry ladder was exhausted.

**2. Obsolete pre-tab-refactor selectors (mobile first failure, `expansion-panels.spec.ts`).**
The actual first mobile failure (artifact `accessibility-report-mobile`, run 27340631694) is `should display Search & Navigate section in all contexts` — the "Search & Navigate" and "Map Controls" headings no longer exist anywhere in `src/` (the sidebar became Search/Layers/Analysis/Details tabs). These tests fail identically in dev mode; they never reached the gridView click.

**Regression window.** The a11y matrix was last green at `bece822a` (2026-01-19) — when 10 of 11 a11y spec files were `describe.skip`-ed. #580/#581 (2026-01-20) rewrote the test helpers (first red run = `c36bfc25`), and #617 (2026-02-11) re-enabled 7 suites without a CI-green validation run. These specs have **never** passed in CI. The deck.gl spike (#879) is unrelated, as already established in #897.

## Changes

- **`tests/e2e/helpers/grid-aware-helpers.ts`** (new): `GridAwareTestHelpers extends AccessibilityTestHelpers`; after each successful `navigateToView` it waits until the `250m_grid` datasource has entities (via the `VITE_E2E_TEST` `window.__viewer` hook) and the main thread answers a trivial evaluation again. Non-fatal on timeout. Kept as an opt-in subclass; folding into the base helper + migrating the remaining specs is #902.
- **`building-filters.spec.ts`**: use `GridAwareTestHelpers`; drop the stale "SKIPPED per #470" header (the suite runs since #617); tag the four drill-based tests `@requires-database` (the CI a11y env has no backend — #658 convention).
- **`expansion-panels.spec.ts`**: use `GridAwareTestHelpers`; rewrite assertions for the tabbed sidebar (Search tab + textbox instead of "Search & Navigate"; "Data Layers" heading instead of "Map Controls"; Grid Options / Climate Adaptation / Building Analysis asserted in the **Analysis** tab, Area/Building Properties in the **Details** tab, switching back to Layers before `navigateToView` since the view toggle lives there); tag the three drill-based tests `@requires-database`; scope the navigation-landmark locator with `.first()` (two `role="navigation"` landmarks exist — strict-mode violation).
- **`playwright.config.ts`**: CI per-test timeout 50 s → 90 s. A grid round-trip now waits out the wedge instead of failing inside it; the timeout only bounds failing tests.
- **`scripts/test-e2e-ci.mjs` + `scripts/ci-parity.just` + `package.json` `test:e2e:ci`**: local CI-parity runner (production build with `VITE_E2E_TEST=true`, `bun run preview` on :4173, Playwright with `CI=true SKIP_REQUIRES_DATABASE=true`). Dev-mode runs cannot reproduce these failures — `MODE === 'development'` flips all feature flags on and the dev server proxies the data endpoints; `vite preview` proxies nothing but `/feature-flags`.

## Verification (local, CI-parity mode)

```
just -f scripts/ci-parity.just test-e2e-ci --skip-build tests/e2e/accessibility/building-filters.spec.ts --project=accessibility-tablet --project=accessibility-desktop --grep=non-grid.views --retries=0 --repeat-each=5
```
→ **10/10 passed** (5× tablet + 5× desktop; the previously chronically-failing test).

```
just -f scripts/ci-parity.just test-e2e-ci --skip-build tests/e2e/accessibility/expansion-panels.spec.ts --project=accessibility-mobile --retries=0
```
→ **9 passed**, 3 skipped (`@requires-database`). Pre-tagging run confirmed the only failures were the three backend-dependent drill tests.

Dev-mode (`just test-file …`) for the changed specs also passes.

## Notes for review

- `tests/fixtures/cesium-fixture.ts` is deliberately untouched (#869 is working on it).
- The a11y jobs run with `-x`, so once building-filters passes the job will proceed into specs that still carry pre-tab-refactor selectors and un-migrated helpers (`comprehensive-walkthrough`, `navigation-levels`, `layer-controls`, `view-modes`, `timeline-controls`). Those are tracked in #902 — if the a11y checks on this PR fail, expect the failure to have moved past the #897 signature into one of those specs.
- No release-please-managed files touched (the `package.json` change is a script entry only; version untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)