### PR TITLE
chore(ci): bring web-session install script up to spec

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,6 +39,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/path-bootstrap.sh\"",
+            "timeout": 10
+          },
+          {
+            "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/install_pkgs.sh\""
           }
         ]

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Tool version pins in scripts/install_pkgs.sh",
+      "managerFilePatterns": ["/^scripts/install_pkgs\\.sh$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+\\w+_VERSION=\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "{{{datasource}}}"
+    }
   ]
 }

--- a/scripts/install_pkgs.sh
+++ b/scripts/install_pkgs.sh
@@ -23,7 +23,8 @@ else
   echo "[install_pkgs] pre-commit already installed, skipping."
 fi
 
-# --- just 1.40.0 ---
+# --- just (latest stable) ---
+# renovate: datasource=github-releases depName=casey/just
 JUST_VERSION="1.40.0"
 if ! has just; then
   echo "[install_pkgs] Installing just ${JUST_VERSION}..."

--- a/scripts/path-bootstrap.sh
+++ b/scripts/path-bootstrap.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# scripts/path-bootstrap.sh
+#
+# SessionStart hook: prepend Homebrew and ~/.local/bin directories to PATH so
+# that agent subshells inherit the same `head`, `jq`, `gh`, `gitleaks`, `just`,
+# etc. that the parent interactive shell sees. Without this, agents spawned via
+# non-login shells end up with a `/usr/bin:/bin`-only PATH and report
+# `command not found: head` / `command not found: jq` despite the parent having
+# both — and tools that install_pkgs.sh drops in ~/.local/bin go unseen.
+#
+# This script is idempotent and safe in remote sandboxes:
+#   - Only writes to $CLAUDE_ENV_FILE when the harness sets it.
+#   - Only adds directories that actually exist on this machine.
+#   - Does not duplicate entries that are already on PATH.
+#
+# Closes laurigates/claude-plugins#1111
+set -euo pipefail
+
+# No env file → nothing to persist; the harness ignores plain stdout writes
+# to PATH because each tool call is a fresh subshell.
+if [ -z "${CLAUDE_ENV_FILE:-}" ]; then
+  exit 0
+fi
+
+# ~/.local/bin is where scripts/install_pkgs.sh drops gitleaks/just/pre-commit
+# in remote web sessions. Ensure it exists before the candidate check below so
+# the [ -d ] guard passes even when path-bootstrap runs before install_pkgs in
+# the SessionStart hook order — otherwise agent subshells never see those tools.
+mkdir -p "${HOME}/.local/bin" 2>/dev/null || true
+
+# Candidate directories, in priority order. /opt/homebrew is Apple Silicon;
+# /usr/local is Intel macOS / older installs / many Linux Homebrew layouts;
+# ~/.local/bin is the no-sudo install target used by install_pkgs.sh.
+candidates=(
+  "${HOME}/.local/bin"
+  /opt/homebrew/bin
+  /opt/homebrew/sbin
+  /usr/local/bin
+  /usr/local/sbin
+)
+
+prepend=""
+for dir in "${candidates[@]}"; do
+  # Skip dirs that don't exist on this machine (e.g. remote sandbox without
+  # Homebrew, or Intel-only host where /opt/homebrew is absent).
+  [ -d "$dir" ] || continue
+  # Skip dirs already on PATH to avoid duplication on session resume.
+  case ":${PATH:-}:" in
+    *":$dir:"*) continue ;;
+  esac
+  prepend="${prepend:+$prepend:}$dir"
+done
+
+if [ -n "$prepend" ]; then
+  printf 'PATH=%s:%s\n' "$prepend" "${PATH:-/usr/bin:/bin}" >> "$CLAUDE_ENV_FILE"
+fi
+
+exit 0


### PR DESCRIPTION
Brings the Claude Code web-session install setup up to the refreshed `configure-web-session` spec (laurigates/claude-plugins#1668).

## Changes

- **`scripts/install_pkgs.sh`** — added a Renovate annotation above the `just` pin so the version is auto-managed rather than hand-maintained:
  ```
  # renovate: datasource=github-releases depName=casey/just
  JUST_VERSION="1.40.0"
  ```
  Existing pin value (`1.40.0`) preserved. Structural baseline (remote guard, `~/.local/bin` install dir, `has()` helper, `pip install --user`, per-tool idempotency, temp-dir cleanup, summary loop) already matched the reference — no other changes.
- **`scripts/path-bootstrap.sh`** — new file (copied verbatim from the reference). Prepends `~/.local/bin` + Homebrew dirs to PATH via `$CLAUDE_ENV_FILE` so agent subshells inherit tools that `install_pkgs.sh` drops in `~/.local/bin`.
- **`.claude/settings.json`** — wired `path-bootstrap.sh` as the **first** SessionStart hook (`"timeout": 10`), before `install_pkgs.sh`, under the existing `""` matcher. Other keys preserved.
- **`renovate.json`** — added a `customManagers` entry so Renovate tracks the `<TOOL>_VERSION` pins in `scripts/install_pkgs.sh`. The existing `extends: ["config:recommended"]` is unchanged.

## Caveats

- This repo's `.pre-commit-config.yaml` has **no** `gitleaks` / `terraform` / `helm` hook, so only the `just` pin is present — no gitleaks block was added (it would be dead).
- The org `.github` `renovate.json` defines no shared preset to extend, so the existing local `config:recommended` was kept.

## Verification

- `bash -n` clean on both scripts.
- `jq .` valid on `.claude/settings.json` and `renovate.json`.
- `path-bootstrap.sh` confirmed first in the SessionStart hook list.
- Both scripts committed mode `100755`.
- pre-commit hooks passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)