### PR TITLE
chore(flags): add r4c-deckgl-renderer to flags.goff.yaml

### DIFF
--- a/flags.goff.yaml
+++ b/flags.goff.yaml
@@ -81,6 +81,16 @@ r4c-land-cover:
 # Graphics & Performance
 # ============================================================
 
+r4c-deckgl-renderer:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: disabled
+  targeting:
+    - query: domain eq "forumvirium.fi"
+      variation: enabled
+
 r4c-hdr-rendering:
   variations:
     enabled: true


### PR DESCRIPTION
`r4c-deckgl-renderer` is defined in the code registry (`src/constants/flagMetadata.ts`) and in the central GOFF relay ConfigMap, but was missing from this local-dev `flags.goff.yaml`. A docker-run relay seeded from this file would silently drop the flag. This adds it (matching the relay's `defaultRule: disabled` + `domain eq "forumvirium.fi"` targeting), bringing both sides to 32 keys.

Surfaced by the new feature-flag drift gate — ForumViriumHelsinki/infrastructure#2067. With this merged, that gate reports R4C clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)