### PR TITLE
refactor(viewer): skip Cesium init on /oauth2/* routes

### DIFF
--- a/src/pages/CesiumViewer.vue
+++ b/src/pages/CesiumViewer.vue
@@ -322,6 +322,14 @@ export default {
 		}
 
 		onMounted(async () => {
+			// #819: On /oauth2/* routes (OIDC proxy sign-in/sign-out pages), the
+			// SPA shell is served but the Cesium viewer must never boot — short-circuit
+			// before any viewer init or data loading starts.
+			if (window.location.pathname.startsWith('/oauth2/')) {
+				logger.debug('[CesiumViewer] On /oauth2/* route — skipping Cesium init (#819)')
+				return
+			}
+
 			// Check if we have URL state to restore before initializing
 			const urlState = getUrlState()
 			if (urlState) {


### PR DESCRIPTION
Closes #819

## What changed / why

The app has no vue-router, so `CesiumViewer.vue` initializes the Cesium viewer unconditionally on mount. On `/oauth2/*` routes (the OIDC proxy sign-in/sign-out pages), the SPA shell is served but the heavy 3D viewer and its data loaders should never boot.

This adds a minimal guard at the top of `onMounted` in `src/pages/CesiumViewer.vue`:

```js
if (window.location.pathname.startsWith("/oauth2/")) { return }
```

Placed before `loadExternalData()` and `initViewer()` so neither the viewer nor its data loaders start on oauth pages. No refactor of the loader chain.

## Local verification

- **lint** (`just lint`): PASS — `biome check src/`, checked 183 files, no fixes applied
- **typecheck** (`just typecheck`): PASS — `vue-tsc --noEmit`, no errors
- **build** (`just build`): PASS — `vite build` + precompress, built in 2.78s
- **unit** (`just test-unit`): PASS — 52 files, 942 passed / 4 skipped
- **e2e**: n/a — no local oauth route to drive. Manual check recommended on a deploy: loading `/oauth2/sign_out` must not boot Cesium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)