### PR TITLE
fix(viewer): Cesium worker DataCloneError — strip Vue reactivity at GeoJSON boundary

### DIFF
--- a/src/composables/useViewerInitialization.js
+++ b/src/composables/useViewerInitialization.js
@@ -178,11 +178,16 @@ export function useViewerInitialization() {
 
 		// Expose viewer to E2E test harness
 		if (isE2ETest) {
-			// `window` is augmented with __viewer/__cesium only in E2E mode; the global
-			// Window type has no such fields, so widen to access them here.
-			const testWindow = /** @type {Window & { __viewer?: any, __cesium?: any }} */ (window)
+			// `window` is augmented with __viewer/__cesium/__featurepicker only in E2E
+			// mode; the global Window type has no such fields, so widen to access them here.
+			const testWindow =
+				/** @type {Window & { __viewer?: any, __cesium?: any, __featurepicker?: any }} */ (window)
 			testWindow.__viewer = viewer.value
 			testWindow.__cesium = Cesium
+			// Expose the Featurepicker class so E2E tests can drive a real pick/navigate
+			// (e.g. the US-11 Cesium worker DataCloneError reproduction) without relying
+			// on canvas-coordinate clicks. Mirrors __viewer/__cesium (module-level refs).
+			testWindow.__featurepicker = Featurepicker
 			logger.debug('[useViewerInitialization] 🧪 Test mode enabled - viewer exposed to window')
 		}
 

--- a/src/services/datasource.js
+++ b/src/services/datasource.js
@@ -1,3 +1,4 @@
+import { toRaw } from 'vue'
 import { useGlobalStore } from '../stores/globalStore.js'
 import logger from '../utils/logger.js'
 import { getCesium } from './cesiumProvider.js'
@@ -302,6 +303,16 @@ export default class DataSource {
 			logger.warn(`[DATASOURCE CREATE] No data provided for "${name}", returning empty array`)
 			return []
 		}
+
+		// Strip Vue reactivity before handing the object to Cesium. This path loads
+		// polygons with `clampToGround: true`, which routes geometry through Cesium's
+		// TaskProcessor web workers. A reactive (Pinia/Vue) proxy array reaching
+		// `Worker.postMessage()` throws `DataCloneError: [object Array] could not be
+		// cloned` (Sentry REGIONS4CLIMATE-25, #925) because a proxy is not
+		// structured-cloneable. toRaw() returns the underlying plain object graph and
+		// is a no-op on data that was never made reactive. Cf. the markRaw() note in
+		// globalStore.setPickedEntity.
+		data = toRaw(data)
 
 		// Validate GeoJSON structure has required 'type' property
 		if (!data.type) {

--- a/src/services/datasource.js
+++ b/src/services/datasource.js
@@ -1,4 +1,4 @@
-import { toRaw } from 'vue'
+import { toRaw, unref } from 'vue'
 import { useGlobalStore } from '../stores/globalStore.js'
 import logger from '../utils/logger.js'
 import { getCesium } from './cesiumProvider.js'
@@ -312,7 +312,13 @@ export default class DataSource {
 		// structured-cloneable. toRaw() returns the underlying plain object graph and
 		// is a no-op on data that was never made reactive. Cf. the markRaw() note in
 		// globalStore.setPickedEntity.
-		data = toRaw(data)
+		//
+		// unref() first: a caller may pass a Vue ref() wrapping the GeoJSON (a
+		// common Vue 3 pattern). toRaw() on a RefImpl returns the RefImpl itself,
+		// so the `!data.type` check below would spuriously fail. unref() unwraps
+		// the ref (and is a no-op on non-ref values) so both reactive objects and
+		// refs are handled.
+		data = toRaw(unref(data))
 
 		// Validate GeoJSON structure has required 'type' property
 		if (!data.type) {

--- a/tests/unit/services/datasource.test.js
+++ b/tests/unit/services/datasource.test.js
@@ -1,5 +1,6 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { isReactive, reactive } from 'vue'
 import DataSource from '@/services/datasource.js'
 
 // Mock fetch globally
@@ -21,7 +22,15 @@ vi.mock('@/services/cesiumProvider.js', () => ({
 				this.a = a
 			}
 			static BLACK = 'BLACK'
+			static WHITE = { withAlpha: () => 'WHITE_ALPHA' }
 		},
+		defined: (v) => v !== undefined && v !== null,
+		ConstantProperty: class ConstantProperty {
+			constructor(value) {
+				this.value = value
+			}
+		},
+		ArcType: { GEODESIC: 'GEODESIC' },
 	}),
 }))
 
@@ -196,6 +205,79 @@ describe(
 			expect(geoJsonLoad.mock.calls[0][0]).toEqual(geojson)
 			expect(dataSourcesAdd).toHaveBeenCalledTimes(1)
 			expect(result).toBe(entities)
+		})
+	}
+)
+
+describe(
+	'DataSource Service - addDataSourceWithPolygonFix reactivity stripping',
+	{ tags: ['@unit', '@datasource'] },
+	() => {
+		let dataSource
+
+		beforeEach(() => {
+			setActivePinia(createPinia())
+			vi.clearAllMocks()
+			geoJsonLoad.mockReset()
+			dataSourcesAdd.mockReset()
+			vi.spyOn(console, 'warn').mockImplementation(() => {})
+			vi.spyOn(console, 'error').mockImplementation(() => {})
+			vi.spyOn(console, 'log').mockImplementation(() => {})
+
+			// clampToGround:true load resolves to a datasource with no entities,
+			// so the polygon-fix loop (defined/ConstantProperty/ArcType) never runs.
+			geoJsonLoad.mockResolvedValue({ name: '', show: undefined, entities: { values: [] } })
+
+			dataSource = new DataSource()
+		})
+
+		afterEach(() => {
+			vi.restoreAllMocks()
+		})
+
+		it('hands Cesium a non-reactive plain object when given reactive GeoJSON (DataCloneError #925)', async () => {
+			// A Vue reactive proxy reaching Cesium's geometry worker via postMessage()
+			// throws `DataCloneError: [object Array] could not be cloned`. toRaw() must
+			// de-proxy at the boundary before the data is handed to Cesium.
+			const reactiveGeojson = reactive({
+				type: 'FeatureCollection',
+				features: [
+					{
+						type: 'Feature',
+						properties: { id: 1 },
+						geometry: { type: 'Polygon', coordinates: [[[24.9, 60.1]]] },
+					},
+				],
+			})
+			expect(isReactive(reactiveGeojson)).toBe(true)
+
+			await dataSource.addDataSourceWithPolygonFix(reactiveGeojson, 'Trees')
+
+			expect(geoJsonLoad).toHaveBeenCalledTimes(1)
+			const handed = geoJsonLoad.mock.calls[0][0]
+			expect(isReactive(handed)).toBe(false)
+			expect(handed).toEqual({
+				type: 'FeatureCollection',
+				features: [
+					{
+						type: 'Feature',
+						properties: { id: 1 },
+						geometry: { type: 'Polygon', coordinates: [[[24.9, 60.1]]] },
+					},
+				],
+			})
+		})
+
+		it('passes plain (non-reactive) data through unchanged', async () => {
+			const plain = {
+				type: 'FeatureCollection',
+				features: [{ type: 'Feature', properties: { id: 2 } }],
+			}
+
+			await dataSource.addDataSourceWithPolygonFix(plain, 'Trees')
+
+			expect(geoJsonLoad).toHaveBeenCalledTimes(1)
+			expect(geoJsonLoad.mock.calls[0][0]).toBe(plain)
 		})
 	}
 )

--- a/tests/unit/services/datasource.test.js
+++ b/tests/unit/services/datasource.test.js
@@ -1,6 +1,6 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { isReactive, reactive } from 'vue'
+import { isReactive, reactive, ref } from 'vue'
 import DataSource from '@/services/datasource.js'
 
 // Mock fetch globally
@@ -278,6 +278,38 @@ describe(
 
 			expect(geoJsonLoad).toHaveBeenCalledTimes(1)
 			expect(geoJsonLoad.mock.calls[0][0]).toBe(plain)
+		})
+
+		it('unwraps a Vue ref containing GeoJSON before stripping reactivity', async () => {
+			// A caller may pass a ref() wrapping the GeoJSON (common Vue 3 pattern).
+			// unref() must unwrap it before toRaw(); otherwise toRaw(ref) returns the
+			// RefImpl, the `!data.type` validation fails, and the load is rejected.
+			const reactiveGeojson = ref({
+				type: 'FeatureCollection',
+				features: [
+					{
+						type: 'Feature',
+						properties: { id: 3 },
+						geometry: { type: 'Polygon', coordinates: [[[24.9, 60.1]]] },
+					},
+				],
+			})
+
+			await dataSource.addDataSourceWithPolygonFix(reactiveGeojson, 'Trees')
+
+			expect(geoJsonLoad).toHaveBeenCalledTimes(1)
+			const handed = geoJsonLoad.mock.calls[0][0]
+			expect(isReactive(handed)).toBe(false)
+			expect(handed).toEqual({
+				type: 'FeatureCollection',
+				features: [
+					{
+						type: 'Feature',
+						properties: { id: 3 },
+						geometry: { type: 'Polygon', coordinates: [[[24.9, 60.1]]] },
+					},
+				],
+			})
 		})
 	}
 )


### PR DESCRIPTION
## What

Two paired changes addressing the Cesium worker `DataCloneError` (Sentry [REGIONS4CLIMATE-25](https://forum-virium-helsinki.sentry.io/issues/REGIONS4CLIMATE-25)).

### 1. The fix — `fix(viewer)`

`DataCloneError: Failed to execute 'postMessage' on 'Worker': [object Array] could not be cloned.` is thrown from Cesium's own geometry `TaskProcessor` worker. Cesium structured-clones its worker payloads, and a **Vue/Pinia reactive proxy array is not structured-cloneable** — so when reactive GeoJSON reaches the `clampToGround: true` load path (which routes polygon geometry through that worker), the clone fails.

`DataSource.addDataSourceWithPolygonFix()` is the shared choke point for that path (`tree`, `urbanheat`, `hsybuilding`, `viewportBuildingLoader`, `sensor`, `coldarea`, `vegetation`, `othernature`, `espooSurvey`, `buildingLoader`). The fix de-proxies the GeoJSON with `toRaw()` at that boundary before handing it to Cesium. `toRaw()` returns the underlying plain object graph and is a **no-op on data that was never made reactive**, so healthy paths are unchanged. This mirrors the existing `markRaw()` guards in `globalStore.setPickedEntity` / `propsStore`.

Added a unit test (`tests/unit/services/datasource.test.js`) asserting reactive GeoJSON is handed to Cesium as a non-reactive plain object, and that plain data passes through untouched.

### 2. Test enablement — `test(viewer)` (taskwarrior #94)

Exposes the `Featurepicker` class as `window.__featurepicker` in E2E mode (gated on `VITE_E2E_TEST`, alongside the existing `__viewer` / `__cesium` globals) so an E2E spec can drive a real pick/navigate without canvas-coordinate clicks — unblocking a faithful US-11 `DataCloneError` reproduction.

## Note on root cause

Per #925, the captured Sentry event is a click on the Cesium **error-panel button**, so the `DataCloneError` is likely *secondary* to an earlier render/data failure (9 session replays attached, not reviewable from here). This PR removes the reactive-proxy class of trigger at the Cesium boundary — the concrete, code-only half of the acceptance criteria. The session-replay root-cause review remains tracked on #925.

## Testing

- `bun run lint` — clean.
- `tests/unit/services/datasource.test.js` — 7/7 pass (validated with tags registered; see below).

> The repo's pinned `vitest@^4.1.9` now enforces tag registration that `vitest.config.js` does not yet provide, so the unit suite currently errors at collection (`The Vitest config doesn't define any "tags"`) for **every** tagged file, not just this one — a pre-existing, environment-wide issue orthogonal to this PR.

Closes #925