### PR TITLE
perf(nginx): serve precompressed brotli (.br) for static assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,26 @@ COPY . .
 RUN --mount=type=cache,target=/app/node_modules/.vite \
     NODE_ENV=production bun run build
 
+# Compile ngx_brotli as a dynamic module against the SAME pinned nginx:1.31
+# base, so the resulting .so is ABI-compatible with the runtime binary. Built
+# with `--with-compat` (the only configure flag required for a portable
+# dynamic module), so we don't need to mirror the stock image's full configure
+# args. Keeping this on the Debian-based official image preserves the apt-get
+# dbmate install below and the Renovate-managed `nginx:1.31` pin (issue #876).
+FROM nginx:1.31 AS brotli-builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential ca-certificates git wget libpcre2-dev zlib1g-dev libbrotli-dev \
+    && NGINX_VERSION="$(nginx -v 2>&1 | sed 's|.*nginx/||')" \
+    && wget -qO /tmp/nginx.tar.gz "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" \
+    && tar -xf /tmp/nginx.tar.gz -C /tmp \
+    && git clone --depth 1 --recurse-submodules --shallow-submodules \
+        https://github.com/google/ngx_brotli.git /tmp/ngx_brotli \
+    && cd "/tmp/nginx-${NGINX_VERSION}" \
+    && ./configure --with-compat --add-dynamic-module=/tmp/ngx_brotli \
+    && make -j"$(nproc)" modules \
+    && mkdir -p /modules \
+    && cp objs/ngx_http_brotli_static_module.so /modules/
+
 FROM nginx:1.31
 
 # Set default values for nginx environment variables
@@ -43,6 +63,15 @@ RUN apt-get update && apt-get install -y \
     && chmod +x /usr/local/bin/dbmate \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Load the brotli static module compiled above. `load_module` must live in the
+# main context, before `events`/`http`; the official image's nginx.conf has no
+# modules-enabled include, so prepend the directive. `modules/` resolves under
+# the prefix (/etc/nginx/modules -> /usr/lib/nginx/modules). Only the static
+# module is shipped — we serve precompressed `.br` siblings (brotli_static),
+# not on-the-fly compression, so the filter module is intentionally omitted.
+COPY --from=brotli-builder /modules/ngx_http_brotli_static_module.so /etc/nginx/modules/
+RUN sed -i '1i load_module modules/ngx_http_brotli_static_module.so;' /etc/nginx/nginx.conf
 
 # Copy built frontend
 COPY --link --from=build /app/dist/ /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/app/node_modules/.vite \
 # dbmate install below and the Renovate-managed `nginx:1.31` pin (issue #876).
 FROM nginx:1.31 AS brotli-builder
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        build-essential ca-certificates git wget libpcre2-dev zlib1g-dev libbrotli-dev \
+        build-essential ca-certificates git wget libpcre2-dev zlib1g-dev \
     && NGINX_VERSION="$(nginx -v 2>&1 | sed 's|.*nginx/||')" \
     && wget -qO /tmp/nginx.tar.gz "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" \
     && tar -xf /tmp/nginx.tar.gz -C /tmp \

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -213,6 +213,16 @@ server {
     # below for anything without a .gz (notably proxied pygeoapi JSON).
     gzip_static on;
 
+    # Serve build-time precompressed brotli siblings (.br, written by
+    # scripts/precompress.mjs at quality 11) when present. Brotli-11 shaves a
+    # further ~28-43% off the largest static JSON payloads over gzip-9 (WO-6:
+    # r4c_stats_grid_index.json 1.86 MB -> 1.34 MB, hsy_po.json 0.54 MB ->
+    # 0.31 MB). A client advertising `Accept-Encoding: br` gets the .br; one
+    # without falls through to gzip_static (.gz) then dynamic gzip below. The
+    # brotli static module is compiled into the image (see Dockerfile); only
+    # static serving is enabled (no on-the-fly `brotli on;`).
+    brotli_static on;
+
     # On-the-fly gzip for dynamic/proxied responses that have no precompressed
     # sibling — primarily the uncompressed multi-MB GeoJSON arriving from
     # pygeoapi (WO-2: origin sends no Content-Encoding). Level 6 is the sane

--- a/scripts/precompress.mjs
+++ b/scripts/precompress.mjs
@@ -2,10 +2,14 @@
 /**
  * Build-time static precompression.
  *
- * Walks the build output (`dist/`) and writes a level-9 gzip sibling
- * (`<file>.gz`) for every compressible asset above a size threshold. nginx
- * serves these directly via `gzip_static on;` — no per-request CPU and a far
- * better ratio than nginx's default on-the-fly gzip level 1.
+ * Walks the build output (`dist/`) and writes, for every compressible asset
+ * above a size threshold, both a level-9 gzip sibling (`<file>.gz`) and a
+ * quality-11 brotli sibling (`<file>.br`). nginx serves these directly via
+ * `gzip_static on;` / `brotli_static on;` — no per-request CPU and a far
+ * better ratio than nginx's default on-the-fly gzip level 1. A client
+ * advertising `Accept-Encoding: br` gets the smaller `.br`; gzip-only clients
+ * fall back to the `.gz`. Brotli-11 shaves a further ~28-43% off the largest
+ * static JSON payloads over gzip-9 (WO-6).
  *
  * Why a script (not a bundle-scoped vite plugin): the heaviest compressible
  * payload — `assets/data/r4c_stats_grid_index.json` (8.9 MB, WO-6) — is a
@@ -16,11 +20,10 @@
  * Run with `bun scripts/precompress.mjs` (the build image is `oven/bun`, which
  * has no `node` binary). bun implements `node:zlib` / `node:fs`.
  *
- * Brotli (`.br`) is intentionally NOT emitted here: stock `nginx:1.31` has no
- * brotli module, so `.br` files would ship dead weight. Adding `brotli_static`
- * is a tracked follow-up that also adds `.br` generation here.
+ * The runtime image (Dockerfile) compiles `ngx_brotli` as a dynamic module so
+ * nginx can serve these `.br` siblings via `brotli_static on;` (issue #876).
  */
-import { gzipSync, constants } from 'node:zlib';
+import { gzipSync, brotliCompressSync, constants } from 'node:zlib';
 import { readdirSync, readFileSync, writeFileSync, statSync } from 'node:fs';
 import { join, extname } from 'node:path';
 
@@ -42,9 +45,20 @@ const COMPRESSIBLE = new Set([
 // Mirror nginx `gzip_min_length 1000` — tiny files don't benefit.
 const MIN_BYTES = 1024;
 
+/** @param {Buffer} buf */
+function brotli(buf) {
+	return brotliCompressSync(buf, {
+		params: {
+			[constants.BROTLI_PARAM_QUALITY]: constants.BROTLI_MAX_QUALITY, // 11
+			[constants.BROTLI_PARAM_SIZE_HINT]: buf.length,
+		},
+	});
+}
+
 let count = 0;
 let rawTotal = 0;
 let gzTotal = 0;
+let brTotal = 0;
 
 /** @param {string} dir */
 function walk(dir) {
@@ -63,13 +77,21 @@ function walk(dir) {
 
 		const buf = readFileSync(full);
 		const gz = gzipSync(buf, { level: constants.Z_BEST_COMPRESSION });
-		// Skip if compression doesn't actually help (e.g. already-dense data).
-		if (gz.length >= size) continue;
+		const br = brotli(buf);
+		// Skip if neither codec actually helps (e.g. already-dense data).
+		if (gz.length >= size && br.length >= size) continue;
 
-		writeFileSync(`${full}.gz`, gz);
 		count += 1;
 		rawTotal += size;
-		gzTotal += gz.length;
+		// Emit each sibling only when it beats the raw payload.
+		if (gz.length < size) {
+			writeFileSync(`${full}.gz`, gz);
+			gzTotal += gz.length;
+		}
+		if (br.length < size) {
+			writeFileSync(`${full}.br`, br);
+			brTotal += br.length;
+		}
 	}
 }
 
@@ -82,8 +104,10 @@ try {
 
 walk(DIST);
 
-const pct = rawTotal > 0 ? ((1 - gzTotal / rawTotal) * 100).toFixed(1) : '0.0';
+const gzPct = rawTotal > 0 ? ((1 - gzTotal / rawTotal) * 100).toFixed(1) : '0.0';
+const brPct = rawTotal > 0 ? ((1 - brTotal / rawTotal) * 100).toFixed(1) : '0.0';
 console.log(
-	`precompress: gzip-9 wrote ${count} .gz files — ` +
-		`${(rawTotal / 1e6).toFixed(2)} MB → ${(gzTotal / 1e6).toFixed(2)} MB (-${pct}%)`
+	`precompress: ${count} assets, ${(rawTotal / 1e6).toFixed(2)} MB raw — ` +
+		`gzip-9 → ${(gzTotal / 1e6).toFixed(2)} MB (-${gzPct}%), ` +
+		`brotli-11 → ${(brTotal / 1e6).toFixed(2)} MB (-${brPct}%)`
 );

--- a/scripts/precompress.mjs
+++ b/scripts/precompress.mjs
@@ -83,14 +83,21 @@ function walk(dir) {
 
 		count += 1;
 		rawTotal += size;
-		// Emit each sibling only when it beats the raw payload.
+		// Emit each sibling only when it beats the raw payload. When a codec
+		// doesn't help, nginx serves the uncompressed file for that encoding, so
+		// accumulate the raw `size` (not 0) to keep the printed totals/ratios
+		// honest.
 		if (gz.length < size) {
 			writeFileSync(`${full}.gz`, gz);
 			gzTotal += gz.length;
+		} else {
+			gzTotal += size;
 		}
 		if (br.length < size) {
 			writeFileSync(`${full}.br`, br);
 			brTotal += br.length;
+		} else {
+			brTotal += size;
 		}
 	}
 }


### PR DESCRIPTION
Closes #876

Unblocks the brotli follow-up deferred when gzip precompression + `gzip_static` landed: stock `nginx:1.31` ships no brotli module.

## Changes

### Brotli-capable image (Dockerfile)
Compile `ngx_brotli` as a **dynamic module** in a dedicated `brotli-builder` stage against the **same pinned `nginx:1.31` base**, built with `--with-compat` (the one configure flag required for a portable dynamic module — no need to mirror the stock image's full configure args). Only the static module is shipped.

Chosen over Alpine brotli images (`fholzer/nginx-brotli` etc.) because:
- Staying on the **Debian-based official image** preserves the existing `apt-get` install of `postgresql-client` + `dbmate` (Alpine would force an `apk`/musl rewrite).
- Keeps the **Renovate-managed `nginx:1.31` pin** intact — the builder derives its nginx source version from `nginx -v` of the same base, so the tag bump flows through automatically.
- Lowest maintenance burden: no third-party image to track, no version-skew risk between module and runtime binary.

The shipped `ngx_http_brotli_static_module.so` is **statically linked** (verified via `ldd`), so the runtime image needs no brotli runtime libs. `load_module` is prepended to `nginx.conf` (the official image has no modules-enabled include). Kyverno constraints unchanged — no new writable paths, runtime user/listener untouched.

### nginx config (`nginx/default.conf.template`)
`brotli_static on;` alongside `gzip_static on;`. A client advertising `Accept-Encoding: br` gets the `.br`; others fall through to `gzip_static` (`.gz`) then dynamic gzip. No on-the-fly `brotli on;` (precompressed serving only, per the issue).

### Build (`scripts/precompress.mjs`)
Also emit a **quality-11 `.br`** sibling next to each `.gz`, over the same compressible asset set. Each sibling is written only when it beats the raw payload.

## Verification (local)
- `ngx_brotli` compiles against nginx 1.31.2; static module statically linked.
- `nginx -t` passes with the module loaded.
- Live container: `GET /assets/app.js` with `Accept-Encoding: br` → `Content-Encoding: br` (serves the `.br`); with `Accept-Encoding: gzip` → `Content-Encoding: gzip` (correct fallback).
- `bun run build` emits **312 `.br`** files — brotli-11 **-82.5%** vs gzip-9 -76.8% overall; `hsy_po.json` 547 KB gz → **310 KB br**, matching the issue's WO-6 projection.

> Note: the full `docker build` could not complete locally due to a **pre-existing** failure in the unchanged frontend `build` stage (`Cannot find package 'esbuild'` from vite/rolldown under `--frozen-lockfile`) — independent of this PR. The runtime stage (module compile + load + `brotli_static` serving) was validated in isolation as described above; CI build will exercise the full image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)