### PR TITLE
refactor(loading): replace stale-cleanup timer with per-tile AbortSignal tracking

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -329,8 +329,6 @@ onMounted(async () => {
 				logger.error(`Failed to check layer cache for ${layer}:`, error)
 			})
 		})
-
-		loadingStore.startStaleCleanupTimer()
 	} catch (error) {
 		logger.warn('Failed to initialize caching services:', error)
 	}
@@ -338,7 +336,6 @@ onMounted(async () => {
 
 onBeforeUnmount(async () => {
 	stopLevelUrlWatcher()
-	loadingStore.stopStaleCleanupTimer()
 	serviceHealthStore.teardown()
 
 	if (featureFlagStore.isEnabled('backgroundPreload')) {

--- a/src/services/unifiedLoader.js
+++ b/src/services/unifiedLoader.js
@@ -201,6 +201,17 @@ class UnifiedLoader {
 			cacheOnly = false,
 		} = options
 
+		// A single AbortController owns this layer's whole lifecycle (cache check,
+		// fetch + retries, processing). Registering it in activeRequests for the
+		// entire call — not just the fetch phase — means cancelLoading(layerId)
+		// can abort at any point and the loading-state lifecycle is tracked
+		// deterministically: every layerId that starts loading here is settled
+		// (completed / errored / aborted) before activeRequests.delete in finally.
+		// This is what makes the loadingStore stale-sweep path unreachable rather
+		// than merely time-gated (see #816, #680).
+		const controller = new AbortController()
+		this.activeRequests.set(layerId, controller)
+
 		try {
 			// Start loading tracking
 			this.loadingStore.startLayerLoading(layerId, { url, type, priority })
@@ -232,7 +243,7 @@ class UnifiedLoader {
 					retries,
 				})
 			} else {
-				data = await this.loadStandard(layerId, url, type, retries)
+				data = await this.loadStandard(layerId, url, type, retries, controller.signal)
 			}
 
 			// Cache the data if enabled
@@ -257,6 +268,11 @@ class UnifiedLoader {
 			this.loadingStore.setLayerError(layerId, error.message)
 			logger.error(`Failed to load layer ${layerId}:`, error?.message || error)
 			throw error
+		} finally {
+			// The lifecycle is over (resolved, rejected, or aborted) — drop the
+			// controller so the map reflects only genuinely in-flight layers.
+			// Idempotent with cancelLoading()'s own delete.
+			this.activeRequests.delete(layerId)
 		}
 	}
 
@@ -294,59 +310,49 @@ class UnifiedLoader {
 	 * @param {string} url - Data source URL
 	 * @param {string} type - Data type ('json', 'geojson', 'text', 'blob')
 	 * @param {number} retries - Maximum retry attempts
+	 * @param {AbortSignal} [signal] - Abort signal owned by loadLayer's lifecycle controller
 	 * @returns {Promise<*>} Parsed data
 	 * @throws {Error} If fetch fails after all retries
 	 * @private
 	 */
-	async loadStandard(layerId, url, type, retries) {
-		const controller = new AbortController()
-		this.activeRequests.set(layerId, controller)
+	async loadStandard(layerId, url, type, retries, signal) {
+		// The AbortController lifecycle is owned by loadLayer (registered in
+		// activeRequests for the whole call); here we just honor its signal.
+		const response = await this.fetchWithRetry(url, { signal }, retries)
 
-		try {
-			const response = await this.fetchWithRetry(
-				url,
-				{
-					signal: controller.signal,
-				},
-				retries
-			)
-
-			// Network byte count (Content-Length; absent on chunked/gzip-without-length
-			// responses, in which case it reads 0).
-			if (PERF_STATS_ENABLED) {
-				const contentLength = Number(response.headers.get('content-length'))
-				perfStats.recordNetworkBytes(Number.isFinite(contentLength) ? contentLength : 0)
-			}
-
-			// `response.json()/.text()/.blob()` stream the body from the network
-			// before parsing, so this span measures body download + parse time,
-			// not pure CPU-bound deserialization. On slow links it is dominated by
-			// transfer time. Kept as one combined "body read" metric on purpose:
-			// awaiting `.text()` first to isolate `JSON.parse` would double-buffer
-			// large payloads and drop blob handling.
-			const deserializeStart = PERF_STATS_ENABLED ? performance.now() : 0
-			let data
-			switch (type) {
-				case 'json':
-				case 'geojson':
-					data = await response.json()
-					break
-				case 'text':
-					data = await response.text()
-					break
-				case 'blob':
-					data = await response.blob()
-					break
-				default:
-					data = await response.json()
-			}
-			if (PERF_STATS_ENABLED) perfStats.recordDeserialize(performance.now() - deserializeStart)
-
-			this.loadingStore.updateLayerProgress(layerId, 100, 100)
-			return data
-		} finally {
-			this.activeRequests.delete(layerId)
+		// Network byte count (Content-Length; absent on chunked/gzip-without-length
+		// responses, in which case it reads 0).
+		if (PERF_STATS_ENABLED) {
+			const contentLength = Number(response.headers.get('content-length'))
+			perfStats.recordNetworkBytes(Number.isFinite(contentLength) ? contentLength : 0)
 		}
+
+		// `response.json()/.text()/.blob()` stream the body from the network
+		// before parsing, so this span measures body download + parse time,
+		// not pure CPU-bound deserialization. On slow links it is dominated by
+		// transfer time. Kept as one combined "body read" metric on purpose:
+		// awaiting `.text()` first to isolate `JSON.parse` would double-buffer
+		// large payloads and drop blob handling.
+		const deserializeStart = PERF_STATS_ENABLED ? performance.now() : 0
+		let data
+		switch (type) {
+			case 'json':
+			case 'geojson':
+				data = await response.json()
+				break
+			case 'text':
+				data = await response.text()
+				break
+			case 'blob':
+				data = await response.blob()
+				break
+			default:
+				data = await response.json()
+		}
+		if (PERF_STATS_ENABLED) perfStats.recordDeserialize(performance.now() - deserializeStart)
+
+		this.loadingStore.updateLayerProgress(layerId, 100, 100)
+		return data
 	}
 
 	/**

--- a/src/services/viewportBuildingLoader.js
+++ b/src/services/viewportBuildingLoader.js
@@ -126,6 +126,16 @@ export default class ViewportBuildingLoader {
 		this.visibleTiles = new Set()
 		/** @type {Set<string>} Tiles currently being loaded */
 		this.loadingTiles = new Set()
+		/**
+		 * In-flight tile fetches keyed by tileKey → unifiedLoader layerId.
+		 * Lets us deterministically abort a tile's building fetch (freeing the
+		 * loadingStore layer state and the host concurrency slot immediately)
+		 * when the tile is abandoned — grid switch, view-mode change, shutdown —
+		 * instead of letting it run to completion and rely on a stale-cleanup
+		 * timer (see #816).
+		 * @type {Map<string, string>}
+		 */
+		this.inFlightTileLayerIds = new Map()
 
 		// Camera event tracking
 		this.debounceTimeout = null
@@ -648,8 +658,15 @@ export default class ViewportBuildingLoader {
 				heatDataPromise = this.urbanheatService.getHeatData(currentPostalCode)
 			}
 
+			const layerId = `viewport_buildings_${viewPrefix}_${tileKey}`
+			// Record the layerId while the fetch is in flight so it can be aborted
+			// deterministically if the tile is abandoned. Captured from the same
+			// viewPrefix used to issue the request, so an abort always targets the
+			// real layerId even if the view mode toggles mid-load.
+			this.inFlightTileLayerIds.set(tileKey, layerId)
+
 			const loadingConfig = {
-				layerId: `viewport_buildings_${viewPrefix}_${tileKey}`,
+				layerId,
 				url: url,
 				type: 'geojson',
 				options: {
@@ -699,6 +716,10 @@ export default class ViewportBuildingLoader {
 		} catch (error) {
 			logger.error(`[ViewportBuildingLoader] ❌ Error loading tile ${tileKey}:`, error)
 			throw error
+		} finally {
+			// Settled (resolved, errored, or aborted) — the layerId is no longer
+			// in flight, so a later abort would target nothing.
+			this.inFlightTileLayerIds.delete(tileKey)
 		}
 	}
 
@@ -1205,14 +1226,36 @@ export default class ViewportBuildingLoader {
 	}
 
 	/**
+	 * Abort every in-flight tile building fetch.
+	 * Each abort flips the tile's loadingStore layer state to settled and frees
+	 * its host concurrency slot immediately, so no abandoned tile lingers in
+	 * `layerLoading: true` waiting on a stale-cleanup timer (see #816).
+	 *
+	 * @private
+	 * @returns {void}
+	 */
+	abortInFlightTileLoads() {
+		if (this.inFlightTileLayerIds.size === 0) return
+		const aborted = this.inFlightTileLayerIds.size
+		for (const layerId of this.inFlightTileLayerIds.values()) {
+			this.unifiedLoader.cancelLoading(layerId)
+		}
+		this.inFlightTileLayerIds.clear()
+		logger.debug(`[ViewportBuildingLoader] Aborted ${aborted} in-flight tile load(s)`)
+	}
+
+	/**
 	 * Cancel all pending tile loads in the queue.
-	 * Called when grid view is enabled to stop further building loading.
+	 * Called when grid view is enabled to stop further building loading. Aborts
+	 * in-flight tile fetches too — under grid view their buildings are hidden, so
+	 * letting them run only holds concurrency slots and loading state.
 	 *
 	 * @returns {void}
 	 */
 	cancelPendingLoads() {
 		const cancelled = this.loadingQueue.length
 		this.loadingQueue = []
+		this.abortInFlightTileLoads()
 		if (cancelled > 0) {
 			logger.debug(`[ViewportBuildingLoader] Cancelled ${cancelled} pending tile loads`)
 		}
@@ -1226,6 +1269,10 @@ export default class ViewportBuildingLoader {
 	 */
 	async clearAllTiles() {
 		logger.debug(`[ViewportBuildingLoader] Clearing all ${this.loadedTiles.size} loaded tiles`)
+
+		// Abort in-flight fetches before dropping their tracking — the data they
+		// would return is about to be discarded (datasource removal / view switch).
+		this.abortInFlightTileLoads()
 
 		// Remove all viewport datasources
 		await this.datasourceService.removeDataSourcesByNamePrefix('Buildings Viewport')

--- a/src/stores/loadingStore.js
+++ b/src/stores/loadingStore.js
@@ -41,14 +41,6 @@ export const useLoadingStore = defineStore('loading', {
 		// Global loading state
 		isLoading: false,
 
-		// Stale loading cleanup timer ID (for automatic cleanup)
-		/** @type {ReturnType<typeof setInterval>|null} */
-		_staleCleanupTimer: null,
-
-		// beforeunload handler reference (registered lazily when the timer starts)
-		/** @type {(() => void)|null} */
-		_staleCleanupUnloadHandler: null,
-
 		// Individual layer loading states
 		layerLoading: {
 			trees: false,
@@ -273,9 +265,14 @@ export const useLoadingStore = defineStore('loading', {
 
 		/**
 		 * Clear loading states that have genuinely been loading longer than the timeout.
-		 * This prevents the loading indicator from getting stuck due to:
-		 * - Network timeouts not properly completing layer loading
-		 * - Race conditions in navigation where layer loading was interrupted
+		 *
+		 * Defensive, manual safety net only. As of #816 in-flight layers are settled
+		 * deterministically — viewport tiles via per-tile AbortSignal tracking in
+		 * unifiedLoader.activeRequests (resolve / error / abort), predefined layers
+		 * via their own try/catch — so nothing fires this on a timer any more. It is
+		 * retained as an explicitly-callable recovery hook should a future caller need
+		 * to force-clear a stuck indicator; the automatic interval that produced the
+		 * #680 warning flood has been removed.
 		 *
 		 * The staleness check is purely time-based and applies equally to predefined
 		 * layers and dynamic layer IDs (e.g., viewport tile IDs). A layer being dynamic
@@ -335,48 +332,6 @@ export const useLoadingStore = defineStore('loading', {
 			}
 
 			return clearedCount
-		},
-
-		/**
-		 * Start automatic stale loading cleanup.
-		 * Runs clearStaleLoading periodically to prevent stuck loading indicators.
-		 * In E2E test mode, uses more aggressive cleanup (every 3s with 5s timeout).
-		 */
-		startStaleCleanupTimer() {
-			if (this._staleCleanupTimer) return // Already running
-
-			const isE2ETest =
-				typeof import.meta !== 'undefined' && import.meta.env?.VITE_E2E_TEST === 'true'
-			const interval = isE2ETest ? 3000 : 10000 // 3s in tests, 10s in production
-			const timeout = isE2ETest ? 5000 : 30000 // 5s in tests, 30s in production
-
-			this._staleCleanupTimer = setInterval(() => {
-				this.clearStaleLoading(timeout)
-			}, interval)
-
-			if (typeof window !== 'undefined' && !this._staleCleanupUnloadHandler) {
-				this._staleCleanupUnloadHandler = () => this.stopStaleCleanupTimer()
-				window.addEventListener('beforeunload', this._staleCleanupUnloadHandler, { once: true })
-			}
-
-			logger.debug(
-				`[loadingStore] Started stale cleanup timer (${interval}ms interval, ${timeout}ms timeout)`
-			)
-		},
-
-		/**
-		 * Stop automatic stale loading cleanup. Idempotent — safe to call multiple times.
-		 */
-		stopStaleCleanupTimer() {
-			if (this._staleCleanupTimer) {
-				clearInterval(this._staleCleanupTimer)
-				this._staleCleanupTimer = null
-				logger.debug('[loadingStore] Stopped stale cleanup timer')
-			}
-			if (typeof window !== 'undefined' && this._staleCleanupUnloadHandler) {
-				window.removeEventListener('beforeunload', this._staleCleanupUnloadHandler)
-				this._staleCleanupUnloadHandler = null
-			}
 		},
 
 		// Retry loading a layer that failed

--- a/tests/e2e/loading/no-stale-warnings.spec.ts
+++ b/tests/e2e/loading/no-stale-warnings.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * US-09 AC1 regression spec (#816, refs #680).
+ *
+ * Before #816 the loadingStore ran a periodic `clearStaleLoading` timer as a
+ * safety net for stuck loading indicators. On a cold load, viewport building
+ * tiles queue behind CONCURRENT_TILE_LOADS and the gateway rate limit, so they
+ * legitimately stay in-flight; the timer then logged a flood of
+ * "[loadingStore] Clearing stale loading state for viewport_buildings_*"
+ * warnings (the #680 symptom).
+ *
+ * #816 replaced the timer with deterministic per-tile AbortSignal tracking
+ * (unifiedLoader.activeRequests owns each layer's whole lifecycle; the viewport
+ * loader aborts abandoned tiles), so the stale-cleanup path is unreachable and
+ * the warning must never appear. This spec fails loudly if the timer — or any
+ * other periodic stale sweep — is reintroduced.
+ *
+ * @tag @e2e
+ */
+
+import { expect, test } from '../../fixtures/test-fixture'
+import { dismissModalIfPresent, TEST_TIMEOUTS } from '../../helpers/test-helpers'
+import { setupCesiumForCI, waitForAppReady } from '../helpers/cesium-helper'
+
+// Substring emitted by loadingStore.clearStaleLoading() when it clears a layer.
+const STALE_WARNING_NEEDLE = 'Clearing stale loading state'
+
+test(
+	'cold load emits no stale-loading cleanup warnings',
+	{ tag: ['@e2e'] },
+	async ({ page }) => {
+		const staleWarnings: string[] = []
+
+		// Attach the listener BEFORE navigation so the cold-load window is covered.
+		page.on('console', (msg) => {
+			const text = msg.text()
+			if (text.includes(STALE_WARNING_NEEDLE)) {
+				staleWarnings.push(text)
+			}
+		})
+
+		await setupCesiumForCI(page)
+		await page.goto('/')
+		await page.waitForLoadState('domcontentloaded')
+		await dismissModalIfPresent(page, 'Explore Map')
+		await waitForAppReady(page, TEST_TIMEOUTS.CESIUM_READY).catch(() => {
+			// App-ready is best-effort here; the assertion is about the absence of
+			// warnings during the load window, not about a specific ready state.
+		})
+
+		// Idle past the window where the removed timer would have fired. In E2E
+		// mode the old timer used a 3s interval with a 5s staleness threshold, so
+		// ~8s comfortably spans at least one would-be sweep of any tile still
+		// in-flight from the cold load.
+		await page.waitForTimeout(8000)
+
+		expect(
+			staleWarnings,
+			`Expected zero stale-loading cleanup warnings, got:\n${staleWarnings.join('\n')}`
+		).toEqual([])
+	}
+)

--- a/tests/unit/services/unifiedLoaderLifecycle.test.js
+++ b/tests/unit/services/unifiedLoaderLifecycle.test.js
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for unifiedLoader.loadLayer's per-layer lifecycle tracking (#816):
+ * a single AbortController owns each layer's whole call, registered in
+ * activeRequests, so cancelLoading() deterministically aborts an in-flight load
+ * and the loading state is settled (errored) — no time-based stale sweep needed.
+ *
+ * Tags: @unit
+ */
+
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { __resetForTests as resetBreaker } from '../../../src/services/hostCircuitBreaker.js'
+import { __resetForTests as resetLimiter } from '../../../src/services/hostConcurrencyLimiter.js'
+import unifiedLoader from '../../../src/services/unifiedLoader.js'
+import { useLoadingStore } from '../../../src/stores/loadingStore.js'
+
+const URL = 'https://pygeoapi.dataportal.fi/collections/x/items?tile=1'
+
+describe('unifiedLoader.loadLayer — per-layer lifecycle & abort (#816)', () => {
+	let loadingStore
+
+	beforeEach(() => {
+		setActivePinia(createPinia())
+		loadingStore = useLoadingStore()
+		// Force the loader's lazy store getter to resolve to this fresh store.
+		unifiedLoader._loadingStore = null
+		unifiedLoader._loadingStoreFallback = false
+		resetBreaker()
+		resetLimiter()
+		global.fetch = vi.fn()
+	})
+
+	afterEach(() => {
+		resetBreaker()
+		resetLimiter()
+		vi.restoreAllMocks()
+	})
+
+	it('registers a controller for the whole call and clears it after a successful load', async () => {
+		const layerId = 'viewport_buildings_hsy_2490_6010'
+		global.fetch.mockResolvedValue({
+			ok: true,
+			status: 200,
+			headers: { get: () => null },
+			json: async () => ({ type: 'FeatureCollection', features: [] }),
+		})
+
+		await unifiedLoader.loadLayer({ layerId, url: URL, type: 'geojson', options: { cache: false } })
+
+		expect(unifiedLoader.activeRequests.has(layerId)).toBe(false)
+		expect(loadingStore.layerLoading[layerId]).toBe(false)
+	})
+
+	it('cancelLoading aborts an in-flight load, settling the layer and clearing the controller', async () => {
+		const layerId = 'viewport_buildings_hsy_2491_6010'
+		// Hung upstream: resolves only when its signal aborts (mirrors real fetch).
+		global.fetch.mockImplementation(
+			(_url, opts) =>
+				new Promise((_resolve, reject) => {
+					opts.signal?.addEventListener('abort', () =>
+						reject(new DOMException('Aborted', 'AbortError'))
+					)
+				})
+		)
+
+		const promise = unifiedLoader.loadLayer({
+			layerId,
+			url: URL,
+			type: 'geojson',
+			options: { cache: false, retries: 0 },
+		})
+
+		// Let startLayerLoading + controller registration run before asserting.
+		await vi.waitFor(() => {
+			expect(unifiedLoader.activeRequests.has(layerId)).toBe(true)
+			expect(loadingStore.layerLoading[layerId]).toBe(true)
+		})
+
+		unifiedLoader.cancelLoading(layerId)
+
+		await expect(promise).rejects.toThrow()
+		expect(unifiedLoader.activeRequests.has(layerId)).toBe(false)
+		// Deterministically settled — not waiting on any stale-cleanup timer.
+		expect(loadingStore.layerLoading[layerId]).toBe(false)
+	})
+})

--- a/tests/unit/services/viewportBuildingLoader.test.js
+++ b/tests/unit/services/viewportBuildingLoader.test.js
@@ -9,7 +9,7 @@
  */
 
 import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import ViewportBuildingLoader from '@/services/viewportBuildingLoader.js'
 import { useToggleStore } from '@/stores/toggleStore.js'
 
@@ -442,6 +442,44 @@ describe('ViewportBuildingLoader - Unit Tests', () => {
 		})
 	})
 
+	describe('in-flight tile abort wiring (#816)', () => {
+		it('aborts every tracked in-flight tile via unifiedLoader.cancelLoading and clears the map', () => {
+			const cancelLoading = vi.fn()
+			loader.unifiedLoader = { cancelLoading }
+			loader.inFlightTileLayerIds.set('2490_6010', 'viewport_buildings_hsy_2490_6010')
+			loader.inFlightTileLayerIds.set('2491_6010', 'viewport_buildings_hsy_2491_6010')
+
+			loader.abortInFlightTileLoads()
+
+			expect(cancelLoading).toHaveBeenCalledTimes(2)
+			expect(cancelLoading).toHaveBeenCalledWith('viewport_buildings_hsy_2490_6010')
+			expect(cancelLoading).toHaveBeenCalledWith('viewport_buildings_hsy_2491_6010')
+			expect(loader.inFlightTileLayerIds.size).toBe(0)
+		})
+
+		it('is a no-op when nothing is in flight', () => {
+			const cancelLoading = vi.fn()
+			loader.unifiedLoader = { cancelLoading }
+
+			loader.abortInFlightTileLoads()
+
+			expect(cancelLoading).not.toHaveBeenCalled()
+		})
+
+		it('cancelPendingLoads aborts in-flight tile fetches too, not just the queue', () => {
+			const cancelLoading = vi.fn()
+			loader.unifiedLoader = { cancelLoading }
+			loader.loadingQueue = ['2492_6010', '2493_6010']
+			loader.inFlightTileLayerIds.set('2490_6010', 'viewport_buildings_hsy_2490_6010')
+
+			loader.cancelPendingLoads()
+
+			expect(loader.loadingQueue).toEqual([])
+			expect(cancelLoading).toHaveBeenCalledWith('viewport_buildings_hsy_2490_6010')
+			expect(loader.inFlightTileLayerIds.size).toBe(0)
+		})
+	})
+
 	describe('constructor', () => {
 		it('should initialize with correct default state', () => {
 			const loader = new ViewportBuildingLoader()
@@ -454,6 +492,8 @@ describe('ViewportBuildingLoader - Unit Tests', () => {
 			expect(loader.visibleTiles.size).toBe(0)
 			expect(loader.loadingTiles).toBeInstanceOf(Set)
 			expect(loader.loadingTiles.size).toBe(0)
+			expect(loader.inFlightTileLayerIds).toBeInstanceOf(Map)
+			expect(loader.inFlightTileLayerIds.size).toBe(0)
 			expect(loader.loadingQueue).toEqual([])
 			expect(loader.activeLoads).toBe(0)
 			expect(loader.debounceTimeout).toBeNull()


### PR DESCRIPTION
Closes #816

## What

Replace the loadingStore's periodic `clearStaleLoading()` timer with deterministic per-tile `AbortSignal` lifecycle tracking, so the stale-cleanup path becomes **unreachable** rather than merely time-gated (the #680 follow-up deferred from PR #812).

## Why

On a cold load, viewport building tiles legitimately stay in-flight while queued behind `CONCURRENT_TILE_LOADS` and the gateway rate limit. The 30s (5s in E2E) stale-cleanup timer would eventually flip genuinely-loading tiles and emit a flood of `Clearing stale loading state for viewport_buildings_*` warnings. PR #812 gated the sweep but left the timer as a safety net; this PR removes the need for it.

## How

- **`unifiedLoader`** — a single `AbortController` now owns each layer's whole lifecycle (cache check, fetch + retries, processing). It is registered in `activeRequests` for the entire `loadLayer` call and dropped in a `finally`, so `cancelLoading(layerId)` can abort at any phase and every layer that starts loading is settled (completed / errored / aborted) before its controller is removed. `loadStandard` now honors the passed signal instead of owning its own.
- **`viewportBuildingLoader`** — tracks each in-flight tile's `layerId` and deterministically aborts abandoned tiles via `unifiedLoader.cancelLoading` on grid switch (`cancelPendingLoads`), view-mode change / `clearAllTiles`, and `shutdown`. Each abort flips the tile's loadingStore state to settled and frees its host-concurrency slot immediately instead of letting the request run to completion.
- **`loadingStore` / `App.vue`** — removes the automatic stale-cleanup interval timer (`startStaleCleanupTimer` / `stopStaleCleanupTimer` + state + `beforeunload` hook) and its App.vue wiring. `clearStaleLoading()` is retained as an explicitly-callable defensive recovery hook, now unreachable on a timer.

Preserves the HSY-outage invariants: per-attempt `FETCH_TIMEOUT_MS`, the per-host circuit breaker, and the concurrency limiter are untouched.

## Acceptance criteria

- [x] Loading state cleared via per-tile abort/resolve tracking; cleanup timer removed
- [x] `tests/e2e/loading/no-stale-warnings.spec.ts` added (US-09 AC1) and green locally
- [x] No regression in the stale-timeout safety behaviour — in-flight layers now settle structurally

## Testing

- `bun run lint` — clean
- `bun run typecheck` (vue-tsc) — clean
- Full unit suite: 56 files, 995 passed / 4 skipped (includes new `viewportBuildingLoader` abort-wiring tests and `unifiedLoaderLifecycle` activeRequests/abort tests)
- `tests/e2e/loading/no-stale-warnings.spec.ts` — passes on chromium locally (no DB required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wdo32p4aXsFmRUs22YqJfK