### PR TITLE
test(a11y): migrate remaining accessibility specs to grid-aware helpers and tabbed-sidebar selectors

### DIFF
--- a/tests/e2e/accessibility/building-filters.spec.ts
+++ b/tests/e2e/accessibility/building-filters.spec.ts
@@ -238,16 +238,18 @@ cesiumDescribe('Building Filters Accessibility', () => {
 				// In Helsinki view, the label should change to "Only social & healthcare buildings"
 
 				// Verify that the filter toggle exists and can be identified.
-				// Use toBeAttached() not toBeVisible() — `.switch-container` is
-				// responsive-CSS-hidden on mobile viewports (analogous to
-				// `.timeline-compact` `d-none d-lg-flex` pattern documented in
-				// .claude/rules/testing.md "Testing Cesium Interactions"). This
-				// test only verifies presence; the visible-label check below
-				// reads sibling text and tolerates either label.
-				const _buildingTypeToggle = cesiumPage.locator('input[type="checkbox"]').first()
-				const filterContainer = cesiumPage.locator('.switch-container').first()
+				// The legacy `.switch-container` markup (src/components/Filters.vue /
+				// Layers.vue) is unmounted; the live filters render in
+				// BuildingFiltersControl.vue as `.control-item` rows with a v-switch
+				// and a `.control-label`. Scope to the building-type toggle by its
+				// label (matching the passing tests in this file) — mobile is skipped
+				// by the top-level beforeEach, so the row is mounted and visible here.
+				const buildingTypeToggle = cesiumPage
+					.getByText(/Public Buildings|Social & Healthcare/)
+					.locator('..')
+					.locator('input[type="checkbox"]')
 
-				await expect(filterContainer).toBeAttached()
+				await expect(buildingTypeToggle).toBeVisible()
 
 				// The actual label text depends on the view state
 				// We verify the toggle is functional regardless of label
@@ -580,9 +582,12 @@ cesiumDescribe('Building Filters Accessibility', () => {
 	cesiumTest.describe('Building Filter Accessibility', () => {
 		cesiumTest('should have consistent styling for all filter toggles', async ({ cesiumPage }) => {
 			// Mobile skip is handled by the top-level beforeEach hook.
-			// Check that all visible filters have consistent structure
+			// Check that all visible filters have consistent structure. The live
+			// filter rows render as `.control-item` (BuildingFiltersControl.vue),
+			// each with a v-switch (`input[type="checkbox"]`, visually opacity:0) and
+			// a `.control-label` — not the legacy `.switch-container`/`.switch`/`.label`.
 			const filterToggles = cesiumPage
-				.locator('.switch-container')
+				.locator('.control-item')
 				.filter({ has: cesiumPage.locator('input[type="checkbox"]') })
 			const count = await filterToggles.count()
 
@@ -591,14 +596,12 @@ cesiumDescribe('Building Filters Accessibility', () => {
 			for (let i = 0; i < count; i++) {
 				const toggle = filterToggles.nth(i)
 
-				// Each should have a switch and label
-				const switchElement = toggle.locator('.switch')
-				const label = toggle.locator('.label')
+				// Each should have a switch input and a visible label
+				const switchElement = toggle.locator('input[type="checkbox"]')
+				const label = toggle.locator('.control-label')
 
-				if (await switchElement.isVisible()) {
-					await expect(switchElement).toBeVisible()
-					await expect(label).toBeVisible()
-				}
+				await expect(switchElement).toBeAttached()
+				await expect(label).toBeVisible()
 			}
 		})
 

--- a/tests/e2e/accessibility/building-filters.spec.ts
+++ b/tests/e2e/accessibility/building-filters.spec.ts
@@ -245,8 +245,7 @@ cesiumDescribe('Building Filters Accessibility', () => {
 				// label (matching the passing tests in this file) — mobile is skipped
 				// by the top-level beforeEach, so the row is mounted and visible here.
 				const buildingTypeToggle = cesiumPage
-					.getByText(/Public Buildings|Social & Healthcare/)
-					.locator('..')
+					.locator('.control-item', { hasText: /Public Buildings|Social & Healthcare/ })
 					.locator('input[type="checkbox"]')
 
 				await expect(buildingTypeToggle).toBeVisible()

--- a/tests/e2e/accessibility/comprehensive-walkthrough.spec.ts
+++ b/tests/e2e/accessibility/comprehensive-walkthrough.spec.ts
@@ -11,14 +11,14 @@
 
 import { expect } from '@playwright/test'
 import { cesiumDescribe, cesiumTest } from '../../fixtures/cesium-fixture'
-import AccessibilityTestHelpers, { TEST_TIMEOUTS } from '../helpers/test-helpers'
+import GridAwareTestHelpers, { TEST_TIMEOUTS } from '../helpers/grid-aware-helpers'
 
 cesiumDescribe('Comprehensive Walkthrough Accessibility', () => {
 	cesiumTest.use({ tag: ['@accessibility', '@e2e', '@comprehensive'] })
-	let helpers: AccessibilityTestHelpers
+	let helpers: GridAwareTestHelpers
 
 	cesiumTest.beforeEach(async ({ cesiumPage }) => {
-		helpers = new AccessibilityTestHelpers(cesiumPage)
+		helpers = new GridAwareTestHelpers(cesiumPage)
 		// Cesium is already initialized by the fixture
 	})
 
@@ -547,7 +547,7 @@ cesiumDescribe('Comprehensive Walkthrough Accessibility', () => {
 
 				// Sidebar sections
 				'Background Maps',
-				'Search & Navigate',
+				'Search', // Search tab (replaced the removed "Search & Navigate" heading, #897)
 
 				// Level-specific features (test at appropriate levels)
 				'Building Analysis', // postal code level
@@ -562,7 +562,9 @@ cesiumDescribe('Comprehensive Walkthrough Accessibility', () => {
 			await expect(cesiumPage.getByText('Public Buildings', { exact: true })).toBeVisible()
 			await expect(cesiumPage.getByText('Tall Buildings', { exact: true })).toBeVisible()
 			await expect(cesiumPage.getByText('Background Maps')).toBeVisible()
-			await expect(cesiumPage.getByText('Search & Navigate')).toBeVisible()
+			// The old "Search & Navigate" heading was replaced by the Search tab in
+			// the tabbed-sidebar refactor (#897).
+			await expect(cesiumPage.getByRole('tab', { name: 'Search' })).toBeVisible()
 
 			// Test features at postal code level
 			await helpers.drillToLevel('postalCode')

--- a/tests/e2e/accessibility/layer-controls.spec.ts
+++ b/tests/e2e/accessibility/layer-controls.spec.ts
@@ -20,16 +20,16 @@
 import { expect } from '@playwright/test'
 import { VIEWPORTS } from '../../config/constants'
 import { cesiumDescribe, cesiumTest } from '../../fixtures/cesium-fixture'
-import AccessibilityTestHelpers, { TEST_TIMEOUTS } from '../helpers/test-helpers'
+import GridAwareTestHelpers, { TEST_TIMEOUTS } from '../helpers/grid-aware-helpers'
 
 // Drawer rendering fixed by 'eager' prop - view navigation fixes implemented
 // Re-enabled to verify navigateToView helper improvements
 cesiumDescribe('Layer Controls Accessibility', () => {
 	cesiumTest.use({ tag: ['@accessibility', '@e2e'] })
-	let helpers: AccessibilityTestHelpers
+	let helpers: GridAwareTestHelpers
 
 	cesiumTest.beforeEach(async ({ cesiumPage }) => {
-		helpers = new AccessibilityTestHelpers(cesiumPage)
+		helpers = new GridAwareTestHelpers(cesiumPage)
 		// Cesium is already initialized by the fixture
 	})
 
@@ -545,8 +545,13 @@ cesiumDescribe('Layer Controls Accessibility', () => {
 				})
 				.catch(() => {})
 
-			// Check that all visible toggles have consistent structure
-			const toggles = cesiumPage.locator('.switch-container')
+			// Check that all visible toggles have consistent structure. The live
+			// layer rows render as `.control-item` (MapControls.vue), each with a
+			// v-switch (`input[type="checkbox"]`, visually opacity:0) and a
+			// `.control-label` — not the legacy `.switch-container`/`.switch`/`.label`.
+			const toggles = cesiumPage
+				.locator('.control-item')
+				.filter({ has: cesiumPage.locator('input[type="checkbox"]') })
 			const count = await toggles.count()
 
 			expect(count).toBeGreaterThan(2) // Should have multiple layer toggles
@@ -554,14 +559,12 @@ cesiumDescribe('Layer Controls Accessibility', () => {
 			for (let i = 0; i < count; i++) {
 				const toggle = toggles.nth(i)
 
-				// Each should have a switch and label
-				const switchElement = toggle.locator('.switch')
-				const label = toggle.locator('.label')
+				// Each should have a switch input and a visible label
+				const switchElement = toggle.locator('input[type="checkbox"]')
+				const label = toggle.locator('.control-label')
 
-				if (await switchElement.isVisible()) {
-					await expect(switchElement).toBeVisible()
-					await expect(label).toBeVisible()
-				}
+				await expect(switchElement).toBeAttached()
+				await expect(label).toBeVisible()
 			}
 		})
 

--- a/tests/e2e/accessibility/navigation-levels.spec.ts
+++ b/tests/e2e/accessibility/navigation-levels.spec.ts
@@ -11,14 +11,14 @@
 
 import { expect } from '@playwright/test'
 import { cesiumDescribe, cesiumTest } from '../../fixtures/cesium-fixture'
-import AccessibilityTestHelpers, { TEST_TIMEOUTS } from '../helpers/test-helpers'
+import GridAwareTestHelpers, { TEST_TIMEOUTS } from '../helpers/grid-aware-helpers'
 
 cesiumDescribe('Navigation Levels Accessibility', () => {
 	cesiumTest.use({ tag: ['@accessibility', '@e2e', '@navigation'] })
-	let helpers: AccessibilityTestHelpers
+	let helpers: GridAwareTestHelpers
 
 	cesiumTest.beforeEach(async ({ cesiumPage }) => {
-		helpers = new AccessibilityTestHelpers(cesiumPage)
+		helpers = new GridAwareTestHelpers(cesiumPage)
 		// Cesium is already initialized by the fixture
 	})
 
@@ -52,9 +52,11 @@ cesiumDescribe('Navigation Levels Accessibility', () => {
 		})
 
 		cesiumTest('should show basic panels at start level', async ({ cesiumPage }) => {
-			// Universal panels should be visible
+			// Universal panels should be visible. The sidebar was refactored into
+			// tabs (Search / Layers / Analysis / Details); the old "Search & Navigate"
+			// section heading no longer exists — search lives in the Search tab (#897).
 			await expect(cesiumPage.getByText('Background Maps')).toBeVisible()
-			await expect(cesiumPage.getByText('Search & Navigate')).toBeVisible()
+			await expect(cesiumPage.getByRole('tab', { name: 'Search' })).toBeVisible()
 
 			// Level-specific panels should not be visible
 			await expect(cesiumPage.getByText('Heat Distribution')).not.toBeVisible()
@@ -171,14 +173,12 @@ cesiumDescribe('Navigation Levels Accessibility', () => {
 					})
 					.catch(() => {})
 
-				// Verify view mode is maintained via Pinia store state (v-btn-toggle doesn't use radio inputs)
-				await cesiumPage.waitForFunction(
-					() => {
-						const pinia = (window as any).__PINIA__
-						return pinia?.state?.value?.global?.currentView === 'grid'
-					},
-					{ timeout: TEST_TIMEOUTS.ELEMENT_STANDARD }
-				)
+				// Verify view mode is maintained via Pinia store state (v-btn-toggle doesn't use radio inputs).
+				// The live globalStore is exposed as window.globalStore; the field is `view`
+				// with values 'capitalRegion' / 'grid' (see src/main.js, #781).
+				await cesiumPage.waitForFunction(() => (window as any).globalStore?.view === 'grid', {
+					timeout: TEST_TIMEOUTS.ELEMENT_STANDARD,
+				})
 
 				// Grid-specific features should be visible
 				await expect(cesiumPage.getByText('Grid Options')).toBeVisible()
@@ -463,11 +463,11 @@ cesiumDescribe('Navigation Levels Accessibility', () => {
 					})
 					.catch(() => {})
 
-				// Trees toggle should now be available (unless in grid view)
-				// Check view mode via Pinia store state (v-btn-toggle doesn't use radio inputs)
+				// Trees toggle should now be available (unless in grid view).
+				// Check view mode via the live globalStore (window.globalStore.view); the
+				// store values are 'capitalRegion' / 'grid' (see src/main.js, #781).
 				const currentView = await cesiumPage.evaluate(() => {
-					const pinia = (window as any).__PINIA__
-					return pinia?.state?.value?.global?.currentView || 'capitalRegion'
+					return (window as any).globalStore?.view || 'capitalRegion'
 				})
 
 				if (currentView === 'capitalRegion') {

--- a/tests/e2e/accessibility/timeline-controls.spec.ts
+++ b/tests/e2e/accessibility/timeline-controls.spec.ts
@@ -10,14 +10,14 @@
 
 import { expect } from '@playwright/test'
 import { cesiumDescribe, cesiumTest } from '../../fixtures/cesium-fixture'
-import AccessibilityTestHelpers, { TEST_TIMEOUTS } from '../helpers/test-helpers'
+import GridAwareTestHelpers, { TEST_TIMEOUTS } from '../helpers/grid-aware-helpers'
 
 cesiumDescribe('Timeline Controls Accessibility', () => {
 	cesiumTest.use({ tag: ['@accessibility', '@e2e'] })
-	let helpers: AccessibilityTestHelpers
+	let helpers: GridAwareTestHelpers
 
 	cesiumTest.beforeEach(async ({ cesiumPage }) => {
-		helpers = new AccessibilityTestHelpers(cesiumPage)
+		helpers = new GridAwareTestHelpers(cesiumPage)
 		// Cesium is already initialized by the fixture
 	})
 

--- a/tests/e2e/accessibility/view-modes.spec.ts
+++ b/tests/e2e/accessibility/view-modes.spec.ts
@@ -13,7 +13,7 @@
 
 import { expect, type Locator } from '@playwright/test'
 import { cesiumDescribe, cesiumTest } from '../../fixtures/cesium-fixture'
-import AccessibilityTestHelpers, { TEST_TIMEOUTS } from '../helpers/test-helpers'
+import GridAwareTestHelpers, { TEST_TIMEOUTS } from '../helpers/grid-aware-helpers'
 
 /**
  * Helper to get view mode button locators for v-btn-toggle component
@@ -35,10 +35,10 @@ async function isViewModeButtonSelected(button: Locator): Promise<boolean> {
 
 cesiumDescribe('View Modes Accessibility', () => {
 	cesiumTest.use({ tag: ['@accessibility', '@e2e'] })
-	let helpers: AccessibilityTestHelpers
+	let helpers: GridAwareTestHelpers
 
 	cesiumTest.beforeEach(async ({ cesiumPage }) => {
-		helpers = new AccessibilityTestHelpers(cesiumPage)
+		helpers = new GridAwareTestHelpers(cesiumPage)
 		// Cesium is already initialized by the fixture
 	})
 

--- a/tests/e2e/helpers/test-helpers.ts
+++ b/tests/e2e/helpers/test-helpers.ts
@@ -2070,9 +2070,12 @@ export class AccessibilityTestHelpers {
 			await expect(this.page.getByText('Building Properties')).toBeVisible()
 		}
 
-		// Universal panels should always be visible
+		// Universal panels should always be visible. The sidebar was refactored
+		// into tabs (Search / Layers / Analysis / Details); the old "Search &
+		// Navigate" section heading no longer exists — search lives in the
+		// dedicated Search tab (#897).
 		await expect(this.page.getByText('Background Maps')).toBeVisible()
-		await expect(this.page.getByText('Search & Navigate')).toBeVisible()
+		await expect(this.page.getByRole('tab', { name: 'Search' })).toBeVisible()
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Completes the migration of the accessibility E2E suite to the grid-aware helper and the tabbed-sidebar selectors, the path to a fully-green a11y/E2E CI matrix.

Migrates the five remaining specs that still routed view switches through the base `AccessibilityTestHelpers` to **`GridAwareTestHelpers`** (which waits for grid-view quiescence after every `navigateToView` — the 6,700-entity `SosEco250mGrid` load saturates the CI runner main thread and times out the next interaction):

- `layer-controls.spec.ts` (22 nav calls)
- `view-modes.spec.ts` (15)
- `comprehensive-walkthrough.spec.ts` (8)
- `navigation-levels.spec.ts` (7)
- `timeline-controls.spec.ts` (2)

(`building-filters` and `expansion-panels` were already migrated in #903.)

## Tabbed-sidebar selector updates

The sidebar was refactored into tabs (Search / Layers / Analysis / Details). Obsolete pre-refactor selectors fixed:

- **`Search & Navigate`** heading no longer exists → assert the Search tab via `getByRole('tab', { name: 'Search' })` in `navigation-levels`, `comprehensive-walkthrough`, and the shared `verifyPanelVisibility` helper in `test-helpers.ts`.
- **`.switch-container` / `.switch` / `.label`** are legacy classes from the unmounted `Filters.vue` / `Layers.vue`. Rewritten to the live `.control-item` / `.control-label` / `v-switch` (`input[type=checkbox]`) markup rendered by `BuildingFiltersControl.vue` and `DataLayersControl.vue` (`building-filters` ×2, `layer-controls` ×1).
- **`window.__PINIA__.state.value.global.currentView`** (never exposed) → `window.globalStore.view` in `navigation-levels` (the #781 dead-ref family).

## Verification

- `bun run lint` — clean
- `bun run typecheck` (`vue-tsc`) — no errors
- `biome check` on all touched test files — clean (pre-commit hooks passed)
- Full E2E not run locally: most specs are `@requires-database` and need a backend; **CI is the real gate** (production bundle via `bun run preview`, no backend — see #902).

## Issues

Closes #902.

Also addresses:
- **#127** (dead Vuetify v3 class sweep): the `.v-btn--selected` fallback was already removed in #804 and `verifyViewModeSelection` already uses `.v-btn--active`; a repo-wide sweep found **no remaining `.v-btn--selected` occurrences** in `tests/` or `src/`.
- **#130** (`.switch-container` mobile assertion): `building-filters` already skips the mobile viewport via its top-level `beforeEach`; the deeper fix is rewriting the dead `.switch-container` rows to live markup (done here), since the class is absent on **all** viewports, not just mobile.

## Notes for reviewer

Three `window.__PINIA__` fallback reads remain inside non-fatal (`.catch`-wrapped) paths in `test-helpers.ts` (`drillToLevel` lines ~1684/1811/1945). They are caught and only affect a rarely-hit fallback path; left untouched to keep this diff scoped to the migration. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wdo32p4aXsFmRUs22YqJfK