### PR TITLE
fix(nginx): stop envsubst corrupting config via GOFF_API_KEY in a comment

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -314,8 +314,16 @@ server {
     # the websocket via the `apiKey` query parameter ONLY (the Authorization
     # header is rejected on this endpoint — verified against relay v1.50.1),
     # so the rewrite injects the key server-side; it never ships in the JS
-    # bundle. Empty ${GOFF_API_KEY} yields a 401 and the app degrades to
-    # fallback defaults, same as an unreachable relay.
+    # bundle. An empty/invalid GOFF_API_KEY yields a 401 and the app degrades
+    # to fallback defaults, same as an unreachable relay.
+    #
+    # NB: never write the GOFF_API_KEY variable in shell brace form inside a
+    # comment. This template is run through `envsubst` at container start,
+    # which substitutes the variable everywhere — comments included. A key
+    # value carrying a stray newline then splits the comment, and its trailing
+    # words parse as an nginx directive (`[emerg] unknown directive`), which
+    # crashes the container. Reference it by bare name in prose only.
+    # (Infra incident 2026-06-29.)
     location /feature-flags/ws/ {
         set $goff_host "gofeatureflag-relay-proxy.feature-flags.svc.cluster.local";
         rewrite ^/feature-flags/(.*)$ /$1?apiKey=${GOFF_API_KEY} break;


### PR DESCRIPTION
## What

Reword the `nginx/default.conf.template` comment so it no longer references `GOFF_API_KEY` in shell brace form, and add a guard note. The legitimate substitution in the `rewrite` directive (line ~321) is unchanged.

## Why

**Incident (2026-06-29):** `r4c.dataportal.fi` returned `upstream connect error or disconnect/reset before headers. reset reason: remote connection failure ... Connection refused` for users carrying the `r4c_ui=new` cookie (the next/beta frontend).

Root cause: the beta pod crash-looped (93 restarts) on:

```
nginx: [emerg] unknown directive "yields" in /etc/nginx/conf.d/default.conf:310
```

The nginx image runs `envsubst` over the **entire** template at container start — including comments. The comment line

```
# bundle. Empty ${GOFF_API_KEY} yields a 401 and the app degrades to
```

had its `${GOFF_API_KEY}` substituted. The GSM secret `r4c_cesium_viewer_goff_client_id` value carried a **trailing newline** (36-char UUID + `\n` = 37 bytes), so the substitution split the comment, leaving `yields a 401 ...` on its own line with no leading `#` → nginx parsed `yields` as a directive → crash → no Service endpoints → Envoy "connection refused".

A `#` comment terminates at a newline, so it is the unique crash vector; the line-321 `rewrite` tolerates the newline because nginx directives terminate at `;`, not a newline.

## Fix

- **This PR (durable):** the template no longer embeds `${GOFF_API_KEY}` in a comment, so a malformed key value cannot corrupt the config. Guard note added to prevent reintroduction.
- **Already done (operational restore):** the stray trailing newline was stripped from the GSM secret and the beta deployment restarted — service is restored.

## Verification

- nginx now starts clean on the restored pod (workers up, `200` to probes, no `[emerg]`).
- Beta Service has a live ready endpoint again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)