### PR TITLE
feat(deps): enable Renovate lockFileMaintenance for bun.lock

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "config:recommended"
   ],
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

Completes the remaining actionable item in #912 (Renovate for Bun / deprecate Dependabot).

Enables `lockFileMaintenance` in `renovate.json` so Renovate periodically performs a full `bun.lock` refresh, keeping the lockfile clean and optimized as the issue requested.

## Status of #912's checklist

- [x] **Deprecate Dependabot** — already done: `.github/dependabot.yml` was removed in #921 (merged 2026-06-21). Renovate runs centrally from the infrastructure repo.
- [x] **Enable `lockFileMaintenance`** — this PR.
- [N/A] **`postUpdateOptions` for bun** — not applicable. There is **no valid bun value** for `postUpdateOptions` (allowed values are npm/pnpm/yarn/bundler/go/nuget only; an invented value fails Renovate's `allowedValues` validation and breaks the whole config). Renovate already **natively** regenerates and commits `bun.lock` when it patches `package.json`, so no option is needed to get a synchronized lockfile on update/pin PRs.

## Validation

```
npx renovate@latest renovate-config-validator renovate.json
INFO: Config validated successfully against 1 file(s)
```

(The bundled/older validator flags the pre-existing `managerFilePatterns` custom-manager field — that's a stale-version artifact, not introduced here; current Renovate accepts it.)

## Note

The issue comment observes the same Bun/Dependabot overlap affects other FVH bun/TypeScript repos and suggests codifying this in claude-plugins — that cross-repo follow-up is out of scope for this repo PR.

Refs #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)